### PR TITLE
Trivial correction.

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -112,7 +112,7 @@ The Windows build also supports CUDA. The latest (development) version of Eigen 
 
 DyNet can leverage Intel's MKL library to speed up computation on the CPU. As an example, we've seen 3x speedup in seq2seq training when using MKL. To use MKL, include the following cmake option: 
 
-    -DMKL
+    -DMKL=TRUE
 
 If cmake is unable to find MKL automatically, try setting `MKL_ROOT`, such as
 

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -376,7 +376,7 @@ void Concatenate::forward_dev_impl(const MyDevice & dev, const vector<const Tens
   unsigned curr_row = 0;
   src_row_indices.resize(xs.size());
   Eigen::DSizes<ptrdiff_t, 3> indices(0,0,0);
-  Eigen::DSizes<ptrdiff_t, 3> sizes(0,fx.d.cols(),fx.d.bd);
+  Eigen::DSizes<ptrdiff_t, 3> sizes(0,static_cast<ptrdiff_t>(fx.d.cols()),static_cast<ptrdiff_t>(fx.d.bd));
   for (unsigned i = 0; i < xs.size(); ++i) {
     indices[0] = src_row_indices[i] = curr_row;
     const unsigned row_size = xs[i]->d.rows();
@@ -399,8 +399,9 @@ void Concatenate::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   assert(i < src_row_indices.size());
-  Eigen::DSizes<ptrdiff_t, 3> indices(src_row_indices[i],0,0);
-  Eigen::DSizes<ptrdiff_t, 3> sizes(dEdxi.d.rows(),fx.d.cols(),fx.d.bd);
+  Eigen::DSizes<ptrdiff_t, 3> indices(static_cast<ptrdiff_t>(src_row_indices[i]),0,0);
+  Eigen::DSizes<ptrdiff_t, 3> sizes(static_cast<ptrdiff_t>(dEdxi.d.rows()), static_cast<ptrdiff_t>(fx.d.cols()),
+                                    static_cast<ptrdiff_t>(fx.d.bd));
   if(dEdxi.d.bd == dEdf.d.bd) {
     dEdxi.tb<2>().device(*dev.edevice) += dEdf.tb<2>().slice(indices, sizes);
   } else {
@@ -1428,8 +1429,9 @@ DYNET_NODE_INST_DEV_IMPL(PickNegLogSoftmax)
 // slice of matrix from index start (inclusive) to index end (exclusive)
 template<class MyDevice>
 void PickRange::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  Eigen::DSizes<ptrdiff_t, 3> indices(start,0,0);
-  Eigen::DSizes<ptrdiff_t, 3> sizes(end-start,fx.d.cols(),fx.d.bd);
+  Eigen::DSizes<ptrdiff_t, 3> indices(static_cast<ptrdiff_t>(start),0,0);
+  Eigen::DSizes<ptrdiff_t, 3> sizes(static_cast<ptrdiff_t>(end)- static_cast<ptrdiff_t>(start), 
+                                    static_cast<ptrdiff_t>(fx.d.cols()), static_cast<ptrdiff_t>(fx.d.bd));
   fx.tb<2>().device(*dev.edevice) = xs[0]->tb<2>().slice(indices, sizes);
 }
 
@@ -1441,8 +1443,9 @@ void PickRange::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  Eigen::DSizes<ptrdiff_t, 3> indices(start,0,0);
-  Eigen::DSizes<ptrdiff_t, 3> sizes(end-start,fx.d.cols(),fx.d.bd);
+  Eigen::DSizes<ptrdiff_t, 3> indices(static_cast<ptrdiff_t>(start),0,0);
+  Eigen::DSizes<ptrdiff_t, 3> sizes(static_cast<ptrdiff_t>(end) - static_cast<ptrdiff_t>(start), 
+                                    static_cast<ptrdiff_t>(fx.d.cols()) ,static_cast<ptrdiff_t>(fx.d.bd));
   dEdxi.tb<2>().slice(indices, sizes).device(*dev.edevice) += dEdf.tb<2>();
 }
 DYNET_NODE_INST_DEV_IMPL(PickRange)


### PR DESCRIPTION
1. Compiling Error at MSVC 14.0 (MSVS 2015 update3) for Error  C2397.
    Because a inexplicitly narrow cast from unsigned to int. G++ is ok while MSVS report error.
    I use `static_cast<ptfdiff_t>` to explicitly cast, but I don't know whether this is the best solution. (can the `DSizes<ptrdiff_t, 3>` to be `DSizes<unsigned, 3>` ?)
2. Using MKL using -DMKL=TRUE for CMake comandline or error reporting.