### PR TITLE
added more param inits, init expressions for cfsm

### DIFF
--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -233,6 +233,15 @@ void ClassFactoredSoftmaxBuilder::serialize(Archive& ar, const unsigned int) {
   ar & p_rc2ws;
   ar & p_rcwbiases;
 }
+
+
+void ClassFactoredSoftmaxBuilder::initialize_expressions() {
+  for (unsigned c = 0; c < p_rc2ws.size(); ++c) {
+    Expression temp = get_rc2w(c);
+    Expression temp2 = get_rc2wbias(c);
+  }
+}
+
 DYNET_SERIALIZE_IMPL(ClassFactoredSoftmaxBuilder)
 
 } // namespace dynet

--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -237,8 +237,9 @@ void ClassFactoredSoftmaxBuilder::serialize(Archive& ar, const unsigned int) {
 
 void ClassFactoredSoftmaxBuilder::initialize_expressions() {
   for (unsigned c = 0; c < p_rc2ws.size(); ++c) {
-    Expression temp = get_rc2w(c);
-    Expression temp2 = get_rc2wbias(c);
+    //get_rc2w(_bias) creates the expression at c if the expression does not already exist.
+    get_rc2w(c);
+    get_rc2wbias(c);
   }
 }
 

--- a/dynet/cfsm-builder.h
+++ b/dynet/cfsm-builder.h
@@ -67,6 +67,7 @@ class ClassFactoredSoftmaxBuilder : public SoftmaxBuilder {
   expr::Expression neg_log_softmax(const expr::Expression& rep, unsigned wordidx);
   unsigned sample(const expr::Expression& rep);
   expr::Expression full_log_distribution(const expr::Expression& rep);
+  void initialize_expressions();
 
  private:
   ClassFactoredSoftmaxBuilder();

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -199,6 +199,18 @@ void ParameterInitGlorot::initialize_params(Tensor & values) const {
   TensorTools::RandomizeUniform(values, -my_scale, my_scale);
 }
 
+void ParameterInitFromVector::initialize_params(Tensor & values) const {
+  TensorTools::SetElements(values, vec);
+}
+
+void ParameterInitFromFile::initialize_params(Tensor & values) const {
+  ifstream is(filename);
+  istream_iterator<float> start(is), end;
+  vector<float> param_vector(start, end);
+  TensorTools::SetElements(values, param_vector);
+}
+
+
 Parameter::Parameter() {
   mp = nullptr;
   index = 0;
@@ -305,6 +317,17 @@ Parameter Model::add_parameters(const Dim& d, float scale) {
   updated_params.push_back(r.index);
   return r;
 }
+
+Parameter Model::add_parameters(const Dim& d, ParameterInit & init) {
+  ParameterStorage* p = new ParameterStorage(d, init);
+  Parameter r(this, params.size());
+  //cerr << "Adding parameters with dim " << d << endl;
+  all_params.push_back(p);
+  params.push_back(p);
+  updated_params.push_back(r.index);
+  return r;
+}
+
 
 LookupParameter Model::add_lookup_parameters(unsigned n, const Dim& d) {
   LookupParameterStorage* p = new LookupParameterStorage(n,d);

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -209,6 +209,22 @@ private:
   float cnst;
 };
 
+struct ParameterInitFromFile : public ParameterInit {
+  ParameterInitFromFile(std::string f) : filename(f) {}
+  virtual void initialize_params(Tensor & values) const override;
+private:
+  std::string filename;
+};
+
+struct ParameterInitFromVector : public ParameterInit {
+  ParameterInitFromVector(std::vector<float> v) : vec(v) {}
+  virtual void initialize_params(Tensor & values) const override;
+private:
+  std::vector<float> vec;
+};
+
+
+
 // this is a collection of parameters
 // if you need a matrix of parameters, or a lookup table - ask an instance of this class
 // this knows how to serialize itself


### PR DESCRIPTION
I added initfromvector and file for parameter initializations, as well as implementing add_parameter(dim, parameterinit) as that appeared to be unimplemented.  I also added a initialize_expressions to the cfsm_builder, as you need to pre-initialize all expressions when using it with model rollback.