### PR TITLE
Removing multiprocess examples from Windows build and simplifying windows build instructions to reflect latest Eigen version

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -170,7 +170,7 @@ installed Eigen and Boost (for example, at c:\\libs\\Eigen and c:\\libs\\boost_1
 This will generate dynet.sln and a bunch of \*.vcxproj files (one for
 the DYNET library, and one per example). You should be able to just open
 dynet.sln and build all. **Note: multi-process functionality is
-currently not supported in Windows, so the example rnnlm-mp will not be included 
+currently not supported in Windows, so the multi-process examples (*-mp) will not be included 
 in the generated solution**
 
 The Windows build also supports CUDA with the latest version of Eigen (as of Oct 28, 2016), with the following code change: 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -170,9 +170,8 @@ installed Eigen and Boost (for example, at c:\\libs\\Eigen and c:\\libs\\boost_1
 This will generate dynet.sln and a bunch of \*.vcxproj files (one for
 the DYNET library, and one per example). You should be able to just open
 dynet.sln and build all. **Note: multi-process functionality is
-currently not supported in Windows, so you will not be able to build
-rnnlm-mp. Go to build->Configuration Manager and uncheck the box next to
-this project**
+currently not supported in Windows, so the example rnnlm-mp will not be included 
+in the generated solution**
 
 The Windows build also supports CUDA. The latest (development) version of Eigen has some code that causes problems with the CUDA compiler. These issue change as Eigen is developed. Currently, the following three changes are needed in Eigen when compiling with CUDA support:
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -173,9 +173,7 @@ dynet.sln and build all. **Note: multi-process functionality is
 currently not supported in Windows, so the example rnnlm-mp will not be included 
 in the generated solution**
 
-The Windows build also supports CUDA. The latest (development) version of Eigen has some code that causes problems with the CUDA compiler. These issue change as Eigen is developed. Currently, the following three changes are needed in Eigen when compiling with CUDA support:
+The Windows build also supports CUDA with the latest version of Eigen (as of Oct 28, 2016), with the following code change: 
 
-- block.h: add `#ifndef __CUDACC__` / `#endif` around `EIGEN_INHERIT_ASSIGNMENT_OPERATORS(Block)`
-- ref.h: add `#ifndef __CUDACC__ / #endif` around `EIGEN_INHERIT_ASSIGNMENT_OPERATORS(RefBase)`
 - TensorDeviceCuda.h: Change `sleep(1)` to `Sleep(1000)`
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,11 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
+if (NOT MSVC)
+   set(RNNLM_MP "rnnlm-mp")
+endif()
+
 # segrnn-sup
-foreach(TARGET mlc tok-embed poisson-regression tag-bilstm embed-cl encdec xor xor-xent xor-batch xor-batch-lookup rnnlm rnnlm-aevb rnnlm-cfsm rnnlm-batch nlm textcat rnnlm-mp read-write)
+foreach(TARGET mlc tok-embed poisson-regression tag-bilstm embed-cl encdec xor xor-xent xor-batch xor-batch-lookup rnnlm rnnlm-aevb rnnlm-cfsm rnnlm-batch nlm textcat ${RNNLM_MP} read-write)
   ADD_EXECUTABLE(${TARGET} ${TARGET}.cc)
   if (WITH_CUDA_BACKEND)
     target_link_libraries(${TARGET} gdynet ${LIBS})


### PR DESCRIPTION
I think it's more convenient to have xor-mp and rnnlm-mp removed from the Windows build altogether, so after running cmake the user just builds the entire solution. Updated cmake file to do this, and updated instructions to clarify.

Also, some of the windows-specific Eigen code changes are no longer needed, they were fixed in the latest version of Eigen, so I removed these from the windows section of the install. There is now just one line they have to change in Eigen, and hopefully eventually we can remove that too.