### PR TITLE
Change "assert(false)" to "throw exception(...)" so it always fails, and also compiles properly with NDEBUG set

### DIFF
--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -271,12 +271,12 @@ void SocherTreeLSTMBuilder::copy(const RNNBuilder & rnn) {
   }
 }
 
-Expression TreeLSTMBuilder::add_input_impl(int prev, const Expression& x) { assert (false); }
-Expression TreeLSTMBuilder::back() const { assert(false); }
-std::vector<Expression> TreeLSTMBuilder::final_h() const { assert(false); }
-std::vector<Expression> TreeLSTMBuilder::final_s() const { assert(false); }
-unsigned TreeLSTMBuilder::num_h0_components() const { assert (false); }
-void TreeLSTMBuilder::copy(const RNNBuilder&) { assert(false); }
+Expression TreeLSTMBuilder::add_input_impl(int prev, const Expression& x) { throw std::runtime_error("add_input_impl() not a valid function for TreeLSTMBuilder"); }
+Expression TreeLSTMBuilder::back() const { throw std::runtime_error("back() not a valid function for TreeLSTMBuilder"); }
+std::vector<Expression> TreeLSTMBuilder::final_h() const { throw std::runtime_error("final_h() not a valid function for TreeLSTMBuilder"); }
+std::vector<Expression> TreeLSTMBuilder::final_s() const { throw std::runtime_error("final_s() not a valid function for TreeLSTMBuilder"); }
+unsigned TreeLSTMBuilder::num_h0_components() const { throw std::runtime_error("num_h0_components() not a valid function for TreeLSTMBuilder"); }
+void TreeLSTMBuilder::copy(const RNNBuilder&) { throw std::runtime_error("copy() not a valid function for TreeLSTMBuilder"); }
 
 UnidirectionalTreeLSTMBuilder::UnidirectionalTreeLSTMBuilder(unsigned layers,
                          unsigned input_dim,
@@ -359,4 +359,4 @@ Expression BidirectionalTreeLSTMBuilder::add_input(int id, vector<int> children,
   return embedding;
 }
 
-Expression BidirectionalTreeLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new) { assert (false); }
+Expression BidirectionalTreeLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new) { throw std::runtime_error("set_h() not a valid function for BidirectionalTreeLSTMBuilder"); }

--- a/dynet/treelstm.h
+++ b/dynet/treelstm.h
@@ -19,9 +19,9 @@ public:
   virtual unsigned num_h0_components() const override;
   virtual void copy(const RNNBuilder & params) override;
   virtual Expression add_input(int id, std::vector<int> children, const Expression& x) = 0;
-  std::vector<Expression> get_h(RNNPointer i) const override { assert (false); }
-  std::vector<Expression> get_s(RNNPointer i) const override { assert (false); }
-  Expression set_s_impl(int prev, const std::vector<Expression>& s_new) override { assert (false); }
+  std::vector<Expression> get_h(RNNPointer i) const override { throw std::runtime_error("get_h() not a valid function for TreeLSTMBuilder"); }
+  std::vector<Expression> get_s(RNNPointer i) const override { throw std::runtime_error("get_s() not a valid function for TreeLSTMBuilder"); }
+  Expression set_s_impl(int prev, const std::vector<Expression>& s_new) override { throw std::runtime_error("set_s_impl() not a valid function for TreeLSTMBuilder"); }
  protected:
   virtual void new_graph_impl(ComputationGraph& cg) override = 0;
   virtual void start_new_sequence_impl(const std::vector<Expression>& h0) override = 0;


### PR DESCRIPTION
assert is replaced with nothing when compiling release (NDEBUG) code, breaking the compile (in MSVC at least) because the function doesn't return anything. Also, we really want this function to fail whether in debug or non-debug mode, so I think it's better to have assert(false) replaced by throw exception() instead. I don't know the proper exception for this situation.

@armatthews: Perhaps the number of invalid functions means the class hierarchy should be redesigned? It's a bit strange to have TreeLSTMBuilder be a RNNBuilder but have a bunch of functions that are not valid. Perhaps it could be:

class SomethingBuilder 
class RNNBuilder : SomethingBuilder
class TreeLSTM: SomethingBuilder

Where the SomethingBuilder is just the subset of functions that are valid for treeLSTM also.

I don't fully understand why the functions aren't valid, so my opinion here might be way off.