### PR TITLE
Adding MKL_NUM_THREADS to MKL documentation.

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -137,6 +137,31 @@ If cmake is unable to find MKL automatically, try setting `MKL_ROOT`, such as
 
 If either MKL or MKL_ROOT are set, CMake will look for MKL.
 
+By default, MKL will use all CPU cores. You can control how many cores MKL uses by setting the environment
+variable `MKL_NUM_THREADS` to the desired number. The following is the total time to process 250 training 
+examples running the example encdec (on a 6 core Intel Xeon E5-1650):
+
+::
+
+    encdec.exe --dynet-seed 1 --dynet-mem 1000 train-hsm.txt dev-hsm.txt
+ 
+::
+
+    +-----------------+------------+---------+
+    | MKL_NUM_THREADS | Cores Used | Time(s) |
+    +-----------------+------------+---------+
+    | <Without MKL>   |     1      |  28.6   |
+    |       1         |     1      |  13.3   |
+    |       2         |     2      |   9.5   |
+    |       3         |     3      |   8.1   |
+    |       4         |     4      |   7.8   |
+    |       6         |     6      |   8.2   |
+    +-----------------+------------+---------+
+
+As you can see, for this particular example, using MKL roughly doubles the speed of computation while 
+still using only one core. Increasing the number of cores to 2 or 3 is quite beneficial, but beyond that
+there are diminishing returns or even slowdown.
+
 Non-standard Boost location
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
And adding a table showing that even just 1 thread is useful, and max benefit can be around 2-3 threads, at least for this test.

In talking with people, it's clear that this option needs to be highlighted so that people do not accidentally use all of their cores when they will only get benefit from using a few cores. Also wanted to show the benefit even from just using one core. The table may be overkill, let me know if you think it should be shortened or otherwise edited.