### PR TITLE
Fixed slicing in Python interface

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -622,11 +622,16 @@ cdef class Expression: #{{{
         return "expression %s/%s" % (<int>self.vindex, self.cg_version)
 
     # __getitem__ and __getslice__ in one for python 3 compatibility
-    def __getitem__(self, object index):
-         if isinstance(index, int):
-             return pick(self, index)            
-         
-         return pickrange(self, index[0], index[1])
+    def __getitem__(self, index):
+        assert isinstance(index, (int, slice))
+        if isinstance(index, int):
+            return pick(self, index)
+        else:
+            if index.start is None or index.stop is None:
+                raise ValueError("Default start and stop indices not yet supported.")
+            if index.step is not None:
+                raise ValueError("Step sizes not yet supported.")
+            return pickrange(self, index.start, index.stop)
 
     cpdef scalar_value(self, recalculate=False):
         if self.cg_version != _cg._cg_version: raise RuntimeError("Stale Expression (created before renewing the Computation Graph).")

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -624,14 +624,41 @@ cdef class Expression: #{{{
     # __getitem__ and __getslice__ in one for python 3 compatibility
     def __getitem__(self, index):
         assert isinstance(index, (int, slice))
+        cdef int rows = self.c().dim().rows()
+        cdef int i, j
         if isinstance(index, int):
-            return pick(self, index)
+            i = index
+            if i > rows - 1:
+                raise IndexError("Index too large: %d > %d" % (i, rows - 1))
+            if i < -rows:
+                raise IndexError("Index too small: %d < %d" % (i, -rows))
+            if i < 0:
+                i += rows
+            return pick(self, i)
         else:
-            if index.start is None or index.stop is None:
-                raise ValueError("Default start and stop indices not yet supported.")
+            i = 0
+            j = rows
+            if index.start is not None:
+                i = index.start
+                if i > rows - 1:
+                    raise IndexError("Start index too large: %d > %d" % (i, rows - 1))
+                if i < -rows:
+                    raise IndexError("Start index too small: %d < %d" % (i, -rows))
+                if i < 0:
+                    i += rows
+            if index.stop is not None:
+                j = index.stop
+                if j > rows - 1:
+                    raise IndexError("Stop index too large: %d > %d" % (j, rows - 1))
+                if j < -rows:
+                    raise IndexError("Stop index too small: %d < %d" % (j, -rows))
+                if j < 0:
+                    j += rows
+            if i >= j:
+                raise ValueError("Improper slice: start index must come strictly before stop index")
             if index.step is not None:
                 raise ValueError("Step sizes not yet supported.")
-            return pickrange(self, index.start, index.stop)
+            return pickrange(self, i, j)
 
     cpdef scalar_value(self, recalculate=False):
         if self.cg_version != _cg._cg_version: raise RuntimeError("Stale Expression (created before renewing the Computation Graph).")


### PR DESCRIPTION
**Issue:**

In the `Expression` class, the most recent version of `__getitem__` (introduced in [this commit](https://github.com/clab/dynet/commit/4efe677c0c77d979e73cdd0ae31d2c6874be070e#diff-7267f041aa255db05426440b37393c8dR600)) accepted either an integer index (calling `pick` on that index) or a sequence of indices (calling `pickrange` on the first two indices). While selecting a single element from a matrix or higher-dimensional tensor using a sequence of indices would be a useful future addition, the semantics of `pickrange` are those of slicing rather than element selection.

**Fix:**

The `__getitem__` method was modified to accept either an integer index as before or a `slice` object. Slice features that are currently unsupported give rise to exceptions with informative error messages.

**Previous behavior:**

```
>>> import dynet as dy
>>> v = dy.inputVector([0,1,2,3])
```
Single indices worked correctly:
```
>>> v[0].value()
0.0
>>> v[3].value()
3.0
```
Slices were not accepted:
```
>>> v[0:3].value()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_dynet.pyx", line 629, in _dynet.Expression.__getitem__ (_dynet.cpp:17694)
TypeError: 'slice' object has no attribute '__getitem__'
```
Index sequences were accepted with unexpected behavior:
```
>>> v[0,3].value()
[0.0, 1.0, 2.0]
>>> v[0,3,4].value()
[0.0, 1.0, 2.0]
>>> v[0,3,4,"test"].value()
[0.0, 1.0, 2.0]
```

**New behavior:**

```
>>> import dynet as dy
>>> v = dy.inputVector([0,1,2,3])
```
Single indices are accepted correctly:
```
>>> v[0].value()
0.0
>>> v[3].value()
3.0
```
Index sequences are no longer accepted:
```
>>> v[0,3].value()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_dynet.pyx", line 626, in _dynet.Expression.__getitem__ (_dynet.cpp:17660)
    assert isinstance(index, (int, slice))
AssertionError
```
Simple slices are accepted:
```
>>> v[0:3].value()
[0.0, 1.0, 2.0]
```
Informative error messages are given when attempting to use default endpoints or step sizes:
```
>>> v[:].value()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_dynet.pyx", line 631, in _dynet.Expression.__getitem__ (_dynet.cpp:17764)
    raise ValueError("Default start and stop indices not yet supported.")
ValueError: Default start and stop indices not yet supported.

>>> v[0:].value()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_dynet.pyx", line 631, in _dynet.Expression.__getitem__ (_dynet.cpp:17764)
    raise ValueError("Default start and stop indices not yet supported.")
ValueError: Default start and stop indices not yet supported.

>>> v[:3].value()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_dynet.pyx", line 631, in _dynet.Expression.__getitem__ (_dynet.cpp:17764)
    raise ValueError("Default start and stop indices not yet supported.")
ValueError: Default start and stop indices not yet supported.

>>> v[0:3:2].value()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "_dynet.pyx", line 633, in _dynet.Expression.__getitem__ (_dynet.cpp:17800)
    raise ValueError("Step sizes not yet supported.")
ValueError: Step sizes not yet supported.
```