### PR TITLE
Add ipython notebooks to the docs

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -19,8 +19,9 @@ import subprocess
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
-
+# sys.path.insert(0, os.path.abspath('../../examples/tutorials'))
+if not os.path.islink('tutorials_notebooks'):
+    os.symlink('../../examples/tutorials', 'tutorials_notebooks')
 # Run doxygen if on Readthedocs :
 on_rtd = os.environ.get('READTHEDOCS') == 'True'
 if on_rtd:
@@ -35,11 +36,15 @@ if on_rtd:
     # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
     # ones.
 extensions = [
-    'sphinx.ext.mathjax', 'breathe'
+    'sphinx.ext.mathjax', 'breathe', 'nbsphinx'
 ]
+
 
 breathe_projects = {"dynet": "../doxygen/xml/"}
 breathe_default_project = "dynet"
+
+# Don't execute notebooks because it requires installing Dynet
+nbsphinx_execute = 'never'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -78,7 +83,7 @@ release = '1.0'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ['_build', '**.ipynb_checkpoints']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/doc/source/cpp_basic_tutorial.rst
+++ b/doc/source/cpp_basic_tutorial.rst
@@ -1,0 +1,84 @@
+Basic Tutorial
+~~~~~~~~~~~~~~
+
+An illustration of how models are trained (for a simple logistic
+regression model) is below:
+
+ First, we set up the structure of the model.
+
+Create a model, and an SGD trainer to update its parameters.
+
+.. code:: cpp
+
+    Model mod;
+    SimpleSGDTrainer sgd(mod);
+
+Create a "computation graph," which will define the flow of information.
+
+.. code:: cpp
+
+    ComputationGraph cg;
+
+Initialize a 1x3 parameter vector, and add the parameters to be part of the computation graph.
+
+.. code:: cpp
+
+    Expression W = parameter(cg, mod.add_parameters({1, 3}));
+
+Create variables defining the input and output of the regression, and load them into the computation graph. Note that we don't need to set concrete values yet.
+
+.. code:: cpp
+
+    vector<dynet::real> x_values(3);
+    Expression x = input(cg, {3}, &x_values);
+    dynet::real y_value;
+    Expression y = input(cg, &y_value);
+
+Next, set up the structure to multiply the input by the weight vector,  then run the output of this through a logistic sigmoid function logistic regression).
+
+.. code:: cpp
+
+    Expression y_pred = logistic(W*x);
+
+Finally, we create a function to calculate the loss. The model will be optimized to minimize the value of the final function in the computation graph.
+
+.. code:: cpp
+
+    Expression l = binary_log_loss(y_pred, y);
+
+We are now done setting up the graph, and we can print out its structure:
+
+.. code:: cpp
+
+    cg.print_graphviz();
+
+Now, we perform a parameter update for a single example. Set the input/output to the values specified by the training data:
+
+.. code:: cpp
+
+    x_values = {0.5, 0.3, 0.7};
+    y_value = 1.0;
+
+"forward" propagates values forward through the computation graph, and returns the loss.
+
+.. code:: cpp
+
+    dynet::real loss = as_scalar(cg.forward(l));
+
+"backward" performs back-propagation, and accumulates the gradients of the parameters within the "Model" data structure.
+
+.. code:: cpp
+
+    cg.backward(l);
+
+"sgd.update" updates parameters of the model that was passed to its constructor. Here 1.0 is the scaling factor that allows us to control the size of the update.
+
+.. code:: cpp
+
+    sgd.update(1.0);
+
+Note that this very simple example that doesn't cover things like memory
+initialization, reading/writing models, recurrent/LSTM networks, or
+adding biases to functions. The best way to get an idea of how to use
+DyNet for real is to look in the ``example`` directory, particularly
+starting with the simplest ``xor`` example.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -19,7 +19,7 @@ DyNet can be installed according to the instructions below:
 And get the basic information to create programs and use models:
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 3
 
    tutorial
    commandline

--- a/doc/source/python_saving_tutorial.rst
+++ b/doc/source/python_saving_tutorial.rst
@@ -1,15 +1,8 @@
 .. role:: python(code)
    :language: python
 
-Python Tutorial
-===============
-
-Guided examples in Python can be found in the jupyter tutorials_.
-
-.. _tutorials: https://github.com/clab/dynet/tree/master/examples/tutorials
-
 Saving Models
--------------
+~~~~~~~~~~~~~
 
 In order to save model parameters, the user instead tells the model, at save time, which are the components it is
 interested in saving. They then need to specify the same components, in the same order, at load time.

--- a/doc/source/requirements.txt
+++ b/doc/source/requirements.txt
@@ -1,1 +1,4 @@
+sphinx>=1.4
 breathe
+nbsphinx
+ipykernel

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -24,3 +24,8 @@ Guided examples in Python can be found below :
    tutorials_notebooks/API.ipynb
    tutorials_notebooks/RNNs.ipynb
    python_saving_tutorial
+
+A more comprehensive tutorial can be found here_ (EMNLP 2016 tutorial).
+
+
+.. _here: https://github.com/clab/dynet_tutorial_examples

--- a/doc/source/tutorial.rst
+++ b/doc/source/tutorial.rst
@@ -1,91 +1,26 @@
 DyNet Tutorial
 ==============
 
-An illustration of how models are trained (for a simple logistic
-regression model) is below:
+C++ Tutorial
+------------
 
- First, we set up the structure of the model.
+See the tutorials for the C++ version of Dynet
 
-Create a model, and an SGD trainer to update its parameters.
+.. toctree::
+   :maxdepth: 2
 
-.. code:: cpp
+   cpp_basic_tutorial
 
-    Model mod;
-    SimpleSGDTrainer sgd(mod);
-
-Create a "computation graph," which will define the flow of information.
-
-.. code:: cpp
-
-    ComputationGraph cg;
-
-Initialize a 1x3 parameter vector, and add the parameters to be part of the computation graph.
-
-.. code:: cpp
-
-    Expression W = parameter(cg, mod.add_parameters({1, 3}));
-
-Create variables defining the input and output of the regression, and load them into the computation graph. Note that we don't need to set concrete values yet.
-
-.. code:: cpp
-
-    vector<dynet::real> x_values(3);
-    Expression x = input(cg, {3}, &x_values);
-    dynet::real y_value;
-    Expression y = input(cg, &y_value);
-
-Next, set up the structure to multiply the input by the weight vector,  then run the output of this through a logistic sigmoid function logistic regression).
-
-.. code:: cpp
-
-    Expression y_pred = logistic(W*x);
-
-Finally, we create a function to calculate the loss. The model will be optimized to minimize the value of the final function in the computation graph.
-
-.. code:: cpp
-
-    Expression l = binary_log_loss(y_pred, y);
-
-We are now done setting up the graph, and we can print out its structure:
-
-.. code:: cpp
-
-    cg.print_graphviz();
-
-Now, we perform a parameter update for a single example. Set the input/output to the values specified by the training data:
-
-.. code:: cpp
-
-    x_values = {0.5, 0.3, 0.7};
-    y_value = 1.0;
-
-"forward" propagates values forward through the computation graph, and returns the loss.
-
-.. code:: cpp
-
-    dynet::real loss = as_scalar(cg.forward(l));
-
-"backward" performs back-propagation, and accumulates the gradients of the parameters within the "Model" data structure.
-
-.. code:: cpp
-
-    cg.backward(l);
-
-"sgd.update" updates parameters of the model that was passed to its constructor. Here 1.0 is the scaling factor that allows us to control the size of the update.
-
-.. code:: cpp
-
-    sgd.update(1.0);
-
-Note that this very simple example that doesn't cover things like memory
-initialization, reading/writing models, recurrent/LSTM networks, or
-adding biases to functions. The best way to get an idea of how to use
-DyNet for real is to look in the ``example`` directory, particularly
-starting with the simplest ``xor`` example.
-
-Python Tutorials
+Python Tutorial
 ---------------
 
-Guided examples in Python can be found in the jupyter tutorials_.
+Guided examples in Python can be found below :
 
-.. _tutorials: https://github.com/clab/dynet/tree/master/examples/tutorials
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+
+   tutorials_notebooks/tutorial-1-xor.ipynb
+   tutorials_notebooks/API.ipynb
+   tutorials_notebooks/RNNs.ipynb
+   python_saving_tutorial

--- a/examples/tutorials/API.ipynb
+++ b/examples/tutorials/API.ipynb
@@ -4,9 +4,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Expression building\n",
+    "## API tutorial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Expression building\n",
     "\n",
-    "### (note: may have old API in some cases)"
+    "(note: may have old API in some cases)"
    ]
   },
   {
@@ -169,7 +176,7 @@
     "collapsed": true
    },
    "source": [
-    "## Recipe"
+    "### Recipe"
    ]
   },
   {
@@ -274,7 +281,7 @@
     "collapsed": true
    },
    "source": [
-    "# Recipe (using classes)"
+    "### Recipe (using classes)"
    ]
   },
   {
@@ -371,7 +378,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## or, alternatively, have the training outside of the network class"
+    "### or, alternatively, have the training outside of the network class"
    ]
   },
   {
@@ -458,7 +465,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/tutorials/RNNs.ipynb
+++ b/examples/tutorials/RNNs.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## RNNs tutorial"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
@@ -17,7 +24,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## An LSTM/RNN overview:\n",
+    "### An LSTM/RNN overview:\n",
     "\n",
     "An (1-layer) RNN can be thought of as a sequence of cells, $h_1,...,h_k$, where $h_i$ indicates the time dimenstion. \n",
     "\n",
@@ -46,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## The LSTM (RNN) Interface\n",
+    "### The LSTM (RNN) Interface\n",
     "\n",
     "RNN / LSTM / GRU follow the same interface. We have a \"builder\" which is in charge of creating definining the parameters for the sequence."
    ]
@@ -289,7 +296,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Extra options in the RNN/LSTM interface\n",
+    "### Extra options in the RNN/LSTM interface\n",
     "\n",
     "**Stack LSTM** The RNN's are shaped as a stack: we can remove the top and continue from the previous state.\n",
     "This is done either by remembering the previous state and continuing it with a new `.add_input()`, or using\n",
@@ -374,7 +381,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Aside: memory efficient transduction\n",
+    "### Aside: memory efficient transduction\n",
     "The `RNNState` interface is convenient, and allows for incremental input construction.\n",
     "However, sometimes we know the sequence of inputs in advance, and care only about the sequence of\n",
     "output expressions. In this case, we can use the `add_inputs(xs)` method, where `xs` is a list of Expression."
@@ -445,7 +452,7 @@
     "collapsed": true
    },
    "source": [
-    "## Charecter-level LSTM\n",
+    "### Charecter-level LSTM\n",
     "\n",
     "Now that we know the basics of RNNs, let's build a character-level LSTM language-model.\n",
     "We have a sequence LSTM that, at each step, gets as input a character, and needs to predict the next character."
@@ -775,15 +782,6 @@
    },
    "outputs": [],
    "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -802,7 +800,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,

--- a/examples/tutorials/tutorial-1-xor.ipynb
+++ b/examples/tutorials/tutorial-1-xor.ipynb
@@ -1,23 +1,10 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false
-   },
-   "outputs": [],
-   "source": [
-    "# we assume that we have the dynet module in your path.\n",
-    "# OUTDATED: we also assume that LD_LIBRARY_PATH includes a pointer to where libcnn_shared.so is.\n",
-    "from dynet import *"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Working with the python dyNET package\n",
+    "## Working with the python dyNET package\n",
     "\n",
     "The dyNET package is intended for neural-network processing on the CPU, and is particularly suited for NLP applications. It is a python-wrapper for the dyNET C++ package written by Chris Dyer.\n",
     "\n",
@@ -33,7 +20,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Package Fundamentals\n",
+    "### Package Fundamentals\n",
     "\n",
     "The main piece of dyNET is the `ComputationGraph`, which is what essentially defines a neural network.\n",
     "The `ComputationGraph` is composed of expressions, which relate to the inputs and outputs of the network,\n",
@@ -48,7 +35,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Static Networks\n",
+    "### Static Networks\n",
     "\n",
     "The life-cycle of a dyNET program is:\n",
     "1. Create a `Model`, and populate it with `Parameters`.\n",
@@ -68,6 +55,19 @@
     "We want the output to be either 0 or 1, so we take the output layer to be the logistic-sigmoid function, $\\sigma(x)$, that takes values between $-\\infty$ and $+\\infty$ and returns numbers in $[0,1]$.\n",
     "\n",
     "We will begin by defining the model and the computation graph.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# we assume that we have the dynet module in your path.\n",
+    "# OUTDATED: we also assume that LD_LIBRARY_PATH includes a pointer to where libcnn_shared.so is.\n",
+    "from dynet import *"
    ]
   },
   {
@@ -211,7 +211,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Training\n",
+    "### Training\n",
     "We now want to set the parameter weights such that the loss is minimized. \n",
     "\n",
     "For this, we will use a trainer object. A trainer is constructed with respect to the parameters of a given model."
@@ -547,7 +547,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## To summarize\n",
+    "### To summarize\n",
     "Here is a complete program:"
    ]
   },
@@ -702,7 +702,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Dynamic Networks\n",
+    "### Dynamic Networks\n",
     "\n",
     "Dynamic networks are very similar to static ones, but instead of creating the network once and then calling \"set\" in each training example to change the inputs, we just create a new network for each training example.\n",
     "\n",
@@ -869,7 +869,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Notable changes : 

- Tutorials reorganized in docs, c++ and python are separated
- ipython notebooks from examples/tutorials are included in the python docs (if it doesn't break readthedocs   *fingers crossed*
- The ipython notebooks have been slightly modified to fit in the doc hierarchy. Most headers are downsized from 1 level in markdown

N.B. : this PR is redundant with #211 