### PR TITLE
Fixed off-by-one error in slice stop index bounds checking

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -656,10 +656,10 @@ cdef class Expression: #{{{
                     i += rows
             if index.stop is not None:
                 j = index.stop
-                if j > rows - 1:
-                    raise IndexError("Stop index too large: %d > %d" % (j, rows - 1))
-                if j < -rows:
-                    raise IndexError("Stop index too small: %d < %d" % (j, -rows))
+                if j > rows:
+                    raise IndexError("Stop index too large: %d > %d" % (j, rows))
+                if j < -rows + 1:
+                    raise IndexError("Stop index too small: %d < %d" % (j, -rows + 1))
                 if j < 0:
                     j += rows
             if i >= j:


### PR DESCRIPTION
For a vector with `rows` rows, the valid range of stop indices is `[-rows + 1, rows]`, which is one higher than the valid range of start indices, `[-rows, rows - 1]`. This commit fixes an off-by-one bug in the current implementation, which does bounds checking according to the same range used for start indices and incorrectly rejects explicit stop indices equal to `rows`.

Compare the old behavior with the new behavior below:

Old behavior:
```
>>> import dynet as dy
>>> import itertools
>>> l = [0, 1, 2]
>>> v = dy.inputVector(l)
>>> for i, j in itertools.product(range(-len(l), len(l) + 1), repeat=2):
...     if l[i:j]:
...         try:
...             print((i, j, l[i:j], v[i:j].npvalue()))
...         except Exception as e:
...             print((i, j, l[i:j], e))
... 
(-3, -2, [0], array([ 0.]))
(-3, -1, [0, 1], array([ 0.,  1.]))
(-3, 1, [0], array([ 0.]))
(-3, 2, [0, 1], array([ 0.,  1.]))
(-3, 3, [0, 1, 2], IndexError('Stop index too large: 3 > 2',))
(-2, -1, [1], array([ 1.]))
(-2, 2, [1], array([ 1.]))
(-2, 3, [1, 2], IndexError('Stop index too large: 3 > 2',))
(-1, 3, [2], IndexError('Stop index too large: 3 > 2',))
(0, -2, [0], array([ 0.]))
(0, -1, [0, 1], array([ 0.,  1.]))
(0, 1, [0], array([ 0.]))
(0, 2, [0, 1], array([ 0.,  1.]))
(0, 3, [0, 1, 2], IndexError('Stop index too large: 3 > 2',))
(1, -1, [1], array([ 1.]))
(1, 2, [1], array([ 1.]))
(1, 3, [1, 2], IndexError('Stop index too large: 3 > 2',))
(2, 3, [2], IndexError('Stop index too large: 3 > 2',))
```

New behavior:
```
>>> import dynet as dy
>>> import itertools
>>> l = [0, 1, 2]
>>> v = dy.inputVector(l)
>>> for i, j in itertools.product(range(-len(l), len(l) + 1), repeat=2):
...     if l[i:j]:
...         try:
...             print((i, j, l[i:j], v[i:j].npvalue()))
...         except Exception as e:
...             print((i, j, l[i:j], e))
... 
(-3, -2, [0], array([ 0.]))
(-3, -1, [0, 1], array([ 0.,  1.]))
(-3, 1, [0], array([ 0.]))
(-3, 2, [0, 1], array([ 0.,  1.]))
(-3, 3, [0, 1, 2], array([ 0.,  1.,  2.]))
(-2, -1, [1], array([ 1.]))
(-2, 2, [1], array([ 1.]))
(-2, 3, [1, 2], array([ 1.,  2.]))
(-1, 3, [2], array([ 2.]))
(0, -2, [0], array([ 0.]))
(0, -1, [0, 1], array([ 0.,  1.]))
(0, 1, [0], array([ 0.]))
(0, 2, [0, 1], array([ 0.,  1.]))
(0, 3, [0, 1, 2], array([ 0.,  1.,  2.]))
(1, -1, [1], array([ 1.]))
(1, 2, [1], array([ 1.]))
(1, 3, [1, 2], array([ 1.,  2.]))
(2, 3, [2], array([ 2.]))
```