### PR TITLE
Fix typo in RNN tutorial

### DIFF
--- a/examples/python/tutorials/RNNs.ipynb
+++ b/examples/python/tutorials/RNNs.ipynb
@@ -452,7 +452,7 @@
     "collapsed": true
    },
    "source": [
-    "### Charecter-level LSTM\n",
+    "### Character-level LSTM\n",
     "\n",
     "Now that we know the basics of RNNs, let's build a character-level LSTM language-model.\n",
     "We have a sequence LSTM that, at each step, gets as input a character, and needs to predict the next character."


### PR DESCRIPTION
"Charecter" -> "Character"