### PR TITLE
fix windows compiling error by modifying the unsupported initializer_list

### DIFF
--- a/dynet/nodes-conv.cc
+++ b/dynet/nodes-conv.cc
@@ -409,7 +409,7 @@ DYNET_NODE_INST_DEV_IMPL(KMaxPooling)
 template<class MyDevice>
 void SumDimension::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   assert(xs.size() == 1);
-  Eigen::array<int, 1> reduction_axis({(int)dimension});
+  Eigen::array<int, 1> reduction_axis = {(int)dimension};
   fx.t<1>().device(*dev.edevice) = xs[0]->t<2>().sum(reduction_axis);
 }
 
@@ -421,8 +421,8 @@ void SumDimension::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   // TODO: limit to 3-dimensional tensor is arbitrary
-  Eigen::array<int, 4> bcast({1,1,1,1}); bcast[dimension] = dEdxi.d[dimension];
-  Eigen::array<int, 4> morph({(int)dEdxi.d[0],(int)dEdxi.d[1],(int)dEdxi.d[2],(int)dEdxi.d.bd}); morph[dimension] = 1;
+  Eigen::array<int, 4> bcast = {1,1,1,1}; bcast[dimension] = dEdxi.d[dimension];
+  Eigen::array<int, 4> morph = {(int)dEdxi.d[0],(int)dEdxi.d[1],(int)dEdxi.d[2],(int)dEdxi.d.bd}; morph[dimension] = 1;
   dEdxi.tb<3>().device(*dev.edevice) += dEdf.tb<3>().reshape(morph).broadcast(bcast);
 }
 DYNET_NODE_INST_DEV_IMPL(SumDimension)

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1952,7 +1952,7 @@ void Sum::backward_dev_impl(const MyDevice & dev,
   if(dEdxi.d.bd == fx.d.bd) {
     dEdxi.tvec().device(*dev.edevice) += dEdf.tvec();
   } else {
-    Eigen::array<int, 1> red_axis({1});
+    Eigen::array<int, 1> red_axis = {1};
     dEdxi.tvec().device(*dev.edevice) += dEdf.tbvec().sum(red_axis);
   }
 }


### PR DESCRIPTION
syntax like `Eigen::array<int, 1> x({1});` is not supported on VS15 (MSVC19.0.) and cause compile error on windows. change to `Eigen::array<int, 1> x = {1};`