### PR TITLE
Updating install docs to be consistent with build

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -66,7 +66,7 @@ To see that things have built properly, you can run
 
 ::
 
-    ./examples/xor
+    ./examples/train_xor
 
 which will train a multilayer perceptron to predict the xor function.
 


### PR DESCRIPTION
Minor change to show the correct executable.

For new users it may be obvious, but I hit the problem that I still had 'examples/xor' from a previous build, and so when I tried to run it I got a segfault.