### PR TITLE
Bugfix in vanillalstm serialization

### DIFF
--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -441,6 +441,7 @@ void VanillaLSTMBuilder::serialize(Archive& ar, const unsigned int) {
   ar & params;
   ar & layers;
   ar & dropout_rate;
+  ar & hid;
 }
 DYNET_SERIALIZE_IMPL(VanillaLSTMBuilder);
 


### PR DESCRIPTION
vanillalstm didn't save `hid` which causes errors when loading a saved model. 

Couldn't test so putting it as a pull request.