### PR TITLE
Fixing MKL build for OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,13 @@ function(find_mkl)
             PATHS ${MKL_ROOT} ${MKL_ROOT}/include)
   find_library(MKL_CORE_LIB NAMES mkl_intel_lp64 mkl_intel_thread mkl_core
                PATHS ${MKL_ROOT} ${MKL_ROOT}/lib/${MKL_ARCH}
+                     ${MKL_ROOT}/lib #OSX
                DOC "MKL core library path")
 
   find_library(MKL_COMPILER_LIB NAMES iomp5 libiomp5md
                PATHS ${MKL_ROOT} ${MKL_ROOT}/../compiler/lib/${MKL_ARCH}              #Windows
                      ${MKL_ROOT}/../compilers_and_libraries/linux/lib/${MKL_ARCH}_lin #Linux
+                     ${MKL_ROOT}/../compilers_and_libraries/mac/lib                   #OSX
                DOC "MKL compiler lib (for threaded MKL)")
 
   if(MKL_INCLUDE_DIR AND MKL_CORE_LIB AND MKL_COMPILER_LIB)

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -139,6 +139,8 @@ If CMake is unable to find MKL automatically, try setting `MKL_ROOT`, such as
 
     -DMKL_ROOT="/path/to/MKL"
 
+One common install location is ``/opt/intel/mkl/``.
+
 If either `MKL` or `MKL_ROOT` are set, CMake will look for MKL.
 
 By default, MKL will use all CPU cores. You can control how many cores MKL uses by setting the environment


### PR DESCRIPTION
On OSX the intel installer arranges the MKL directory slightly differently. These changes account for that (tested on OSX 10.12 Sierra) and I also added a note about where to find the library usually.