### PR TITLE
Homebrew on macOS can install the dev version of Eigen

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -16,7 +16,7 @@ For example on **Ubuntu Linux**:
 
     sudo apt-get install libboost-all-dev cmake mercurial
 
-Or on **Mac OSX**, first make sure the Apple Command Line Tools are installed, then
+Or on **macOS**, first make sure the Apple Command Line Tools are installed, then
 get Boost, CMake, and Mercurial with either homebrew or macports:
 
 ::
@@ -28,8 +28,14 @@ get Boost, CMake, and Mercurial with either homebrew or macports:
 To compile DyNet you also need the `development version of the Eigen
 library <https://bitbucket.org/eigen/eigen>`__. **If you use any of the
 released versions, you may get assertion failures or compile errors.**
-If you don't have Eigen installed already, you can get it easily using
-the following command:
+If you are use Homebrew on macOS, you can install the development version
+as follows:
+
+::
+
+    brew install --HEAD eigen
+
+Otherwise, you can get and install Eigen using the following commands:
 
 ::
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -28,14 +28,8 @@ get Boost, CMake, and Mercurial with either homebrew or macports:
 To compile DyNet you also need the `development version of the Eigen
 library <https://bitbucket.org/eigen/eigen>`__. **If you use any of the
 released versions, you may get assertion failures or compile errors.**
-If you are use Homebrew on macOS, you can install the development version
-as follows:
-
-::
-
-    brew install --HEAD eigen
-
-Otherwise, you can get and install Eigen using the following commands:
+If you don't have Eigen installed already, you can get it easily using
+the following command:
 
 ::
 
@@ -46,8 +40,14 @@ Otherwise, you can get and install Eigen using the following commands:
     make install # sudo permissions might be necessary on Linux.
     cd ../..
     
-The `-r NUM` specified a revision number that is known to work.
-Adventurous users can remove it and use the very latest version, at the risk of the code breaking / not compiling.
+The `-r NUM` specified a revision number that is known to work.  Adventurous
+users can remove it and use the very latest version, at the risk of the code
+breaking / not compiling. On macOS, you can install the latest development
+of Eigen using Homebrew:
+
+::
+
+    brew install --HEAD eigen
 
 Building
 --------


### PR DESCRIPTION
Thanks for DyNet. This is a small modification to the documentation to point out that on Homebrew/macOS you can install the development version of Eigen with Homebrew as well.

This has the benefit that Eigen is manageable through Homebrew (and it makes /usr/local less messy ;)).