### PR TITLE
To make the DeviceMemPoolSizes constructor more robust

### DIFF
--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -7,6 +7,7 @@
 #include "dynet/cuda.h"
 #include "dynet/dynet.h"
 #include "dynet/expr.h"
+#include "dynet/except.h"
 
 using namespace std;
 
@@ -37,8 +38,7 @@ DeviceMempoolSizes::DeviceMempoolSizes(const std::string & descriptor) {
     used[1] = stoi(strs[1]);
     used[2] = stoi(strs[2]);
   } else {
-    cerr<<"The format of --dynet-mem is invalid"<<endl;
-    abort();
+    throw invalid_argument_format("the format of --dynet-mem is invalid");
   }
 }
 

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -36,6 +36,9 @@ DeviceMempoolSizes::DeviceMempoolSizes(const std::string & descriptor) {
     used[0] = stoi(strs[0]);
     used[1] = stoi(strs[1]);
     used[2] = stoi(strs[2]);
+  } else {
+    cerr<<"The format of --dynet-mem is invalid"<<endl;
+    abort();
   }
 }
 

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -38,7 +38,8 @@ DeviceMempoolSizes::DeviceMempoolSizes(const std::string & descriptor) {
     used[1] = stoi(strs[1]);
     used[2] = stoi(strs[2]);
   } else {
-    throw invalid_argument_format("the format of --dynet-mem is invalid");
+    ostringstream s; s<<"the format of --dynet-mem is invalid:"<<descriptor;
+    throw std::invalid_argument(s.str());
   }
 }
 

--- a/dynet/except.h
+++ b/dynet/except.h
@@ -25,6 +25,11 @@ class cuda_exception : public std::runtime_error {
   cuda_exception(const std::string& what_arg) : runtime_error(what_arg) {}
 };
 
+// this is throw when the initial argument is in an invalid format
+class invalid_argument_format : public std::invalid_argument {
+  public:
+    invalid_argument_format(const std::string& what_arg):invalid_argument(what_arg){}
+};
 } // namespace dynet
 
 #endif

--- a/dynet/except.h
+++ b/dynet/except.h
@@ -24,12 +24,6 @@ class cuda_exception : public std::runtime_error {
  public:
   cuda_exception(const std::string& what_arg) : runtime_error(what_arg) {}
 };
-
-// this is throw when the initial argument is in an invalid format
-class invalid_argument_format : public std::invalid_argument {
-  public:
-    invalid_argument_format(const std::string& what_arg):invalid_argument(what_arg){}
-};
 } // namespace dynet
 
 #endif


### PR DESCRIPTION
Add `cerr<<The format of --dynet-mem is invalid` and `abort()` to avoid program encoutering some unexpected problems when the --dynet-mem's length  is not 1 or 3.