### PR TITLE
Corrected path to examples as part of Python DyNet module installation

### DIFF
--- a/doc/source/python.rst
+++ b/doc/source/python.rst
@@ -146,7 +146,7 @@ Now, check that everything works:
 .. code:: bash
 
     cd $PATH_TO_DYNET
-    cd pyexamples
+    cd examples/python
     python xor.py
     python rnnlm.py rnnlm.py
 


### PR DESCRIPTION
Corrected path to examples as part of Python DyNet module installation.