### PR TITLE
Removes regex header (boost regex is used instead)

### DIFF
--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -13,7 +13,6 @@
 
 #include <iostream>
 #include <fstream>
-#include <regex>
 #include <sstream>
 
 #include <boost/algorithm/string/join.hpp>


### PR DESCRIPTION
This PR removes the (standard) `regex` header in `train_rnnlm.cc`, because the regex header from Boost is used (and later included) to avoid conflicts.