### PR TITLE
Immediate computation (imperative style) (only C++ now)

### DIFF
--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -85,8 +85,10 @@ void Node::backward(const std::vector<const Tensor*>& xs,
   }
 }
 
-ComputationGraph::ComputationGraph() :
+ComputationGraph::ComputationGraph(bool ic, bool cv) :
   ee(new SimpleExecutionEngine(*this)) {
+  immediate_compute = ic;
+  check_validity = cv;
   ++n_hgs;
   if (n_hgs > 1) {
     cerr << "Memory allocator assumes only a single ComputationGraph at a time.\n";
@@ -277,6 +279,14 @@ void ComputationGraph::set_dim_for_new_node(const VariableIndex& i) {
     ++ai;
   }
   node->dim = node->dim_forward(xds);
+  if (immediate_compute) {
+    const Tensor& value = incremental_forward(i);
+    if (check_validity)
+    {
+      bool valid = value.is_valid();
+      assert(valid);
+    }
+  }
 }
 
 const Tensor& ComputationGraph::incremental_forward(const expr::Expression& last) { return ee->incremental_forward(last.i); }

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -281,10 +281,11 @@ void ComputationGraph::set_dim_for_new_node(const VariableIndex& i) {
   node->dim = node->dim_forward(xds);
   if (immediate_compute) {
     const Tensor& value = incremental_forward(i);
-    if (check_validity) {
-      bool valid = value.is_valid();
-      assert(valid);
-    }
+    if (check_validity) 
+      if (!value.is_valid()) {
+        cerr << "NaN or Inf detected\n";
+        throw std::runtime_error("NaN or Inf detected");
+      }
   }
 }
 

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -85,11 +85,11 @@ void Node::backward(const std::vector<const Tensor*>& xs,
   }
 }
 
-ComputationGraph::ComputationGraph(bool ic, bool cv) :
+ComputationGraph::ComputationGraph():
   ee(new SimpleExecutionEngine(*this)) {
-  immediate_compute = ic;
-  check_validity = cv;
   ++n_hgs;
+  immediate_compute = false;
+  check_validity = false;
   if (n_hgs > 1) {
     cerr << "Memory allocator assumes only a single ComputationGraph at a time.\n";
     throw std::runtime_error("Attempted to create >1 CG");
@@ -297,6 +297,14 @@ const Tensor& ComputationGraph::get_value(const expr::Expression& e) { return th
 void ComputationGraph::invalidate() { ee->invalidate(); }
 void ComputationGraph::backward(const expr::Expression& last) { ee->backward(last.i); }
 void ComputationGraph::backward(VariableIndex i) { ee->backward(i); }
+
+void ComputationGraph::set_immediate_compute(bool ic) {
+  immediate_compute = ic;
+}
+
+void ComputationGraph::set_check_validity(bool cv) {
+  check_validity = cv;
+}
 
 void ComputationGraph::print_graphviz() const {
   cerr << "digraph G {\n  rankdir=LR;\n  nodesep=.05;\n";

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -281,8 +281,7 @@ void ComputationGraph::set_dim_for_new_node(const VariableIndex& i) {
   node->dim = node->dim_forward(xds);
   if (immediate_compute) {
     const Tensor& value = incremental_forward(i);
-    if (check_validity)
-    {
+    if (check_validity) {
       bool valid = value.is_valid();
       assert(valid);
     }

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -58,7 +58,7 @@ inline void swap(VariableIndex& i1, VariableIndex& i2) {
 }
 
 struct ComputationGraph {
-  ComputationGraph(bool=false, bool=false);
+  ComputationGraph();
   ~ComputationGraph();
 
   // INPUTS
@@ -123,6 +123,10 @@ struct ComputationGraph {
   void backward(const expr::Expression& last);
   // computes backward gradients from node i (assuming it already been evaluated).
   void backward(VariableIndex i);
+  // set immediate_compute variable
+  void set_immediate_compute(bool ic);
+  // set check_validity variable
+  void set_check_validity(bool cv);
 
   // debugging
   void print_graphviz() const;
@@ -132,9 +136,11 @@ struct ComputationGraph {
   std::vector<VariableIndex> parameter_nodes; // nodes that contain parameters that can be updated (subset of nodes)
 
   ExecutionEngine* ee;  // handles the execution
-  bool immediate_compute;
-  bool check_validity;
  private:
+  // flag of whether to compute immediately for each expression, i.e., an imperative execution style to help debug.
+  bool immediate_compute;
+  // flag of checking Inf/NaN of each layer. Only performing checking when immediate_compute is also set to true.
+  bool check_validity;
   void set_dim_for_new_node(const VariableIndex& i);
 
   std::vector<CGCheckpoint> checkpoints;

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -58,7 +58,7 @@ inline void swap(VariableIndex& i1, VariableIndex& i2) {
 }
 
 struct ComputationGraph {
-  ComputationGraph();
+  ComputationGraph(bool=false, bool=false);
   ~ComputationGraph();
 
   // INPUTS
@@ -132,6 +132,8 @@ struct ComputationGraph {
   std::vector<VariableIndex> parameter_nodes; // nodes that contain parameters that can be updated (subset of nodes)
 
   ExecutionEngine* ee;  // handles the execution
+  bool immediate_compute;
+  bool check_validity;
  private:
   void set_dim_for_new_node(const VariableIndex& i);
 

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE( log_softmax_colbatch_gradient ) {
 // Expression log_softmax(const Expression& x, const std::vector<unsigned>& restriction);
 BOOST_AUTO_TEST_CASE( restricted_log_softmax_gradient ) {
   vector<unsigned> restriction = {0,1};
-  dynet::ComputationGraph cg(true, false);
+  dynet::ComputationGraph cg;
   Expression x3 = parameter(cg, param3);
   Expression y = exp( log_softmax(x3, restriction) );
   Expression z = input(cg, {1,3}, first_one_vals) * y;

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -554,7 +554,7 @@ BOOST_AUTO_TEST_CASE( log_softmax_colbatch_gradient ) {
 // Expression log_softmax(const Expression& x, const std::vector<unsigned>& restriction);
 BOOST_AUTO_TEST_CASE( restricted_log_softmax_gradient ) {
   vector<unsigned> restriction = {0,1};
-  dynet::ComputationGraph cg;
+  dynet::ComputationGraph cg(true, false);
   Expression x3 = parameter(cg, param3);
   Expression y = exp( log_softmax(x3, restriction) );
   Expression z = input(cg, {1,3}, first_one_vals) * y;


### PR DESCRIPTION
Added immediate computation mode and INF/NaN checking to make it easy to debug. Two boolean variables in ComputationGraph are used to activate them. Immediate computation is performed if immediate_compute is set to True. Inf or Nan is checked if check_validity is set to True in immediate computation mode. 