### PR TITLE
Retro-compatible serialization

### DIFF
--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -321,11 +321,18 @@ void LSTMBuilder::disable_dropout() {
 }
 
 template<class Archive>
-void LSTMBuilder::serialize(Archive& ar, const unsigned int) {
+void LSTMBuilder::serialize(Archive& ar, const unsigned int version ) {
   ar & boost::serialization::base_object<RNNBuilder>(*this);
   ar & params;
   ar & layers;
   ar & dropout_rate;
+  // Backward compatibility
+  if (version > 0) {
+    ar & dropout_rate_h;
+    ar & dropout_rate_c;
+    ar & input_dim;
+    ar & hid;
+  }
 }
 
 DYNET_SERIALIZE_IMPL(LSTMBuilder);
@@ -578,3 +585,4 @@ void VanillaLSTMBuilder::serialize(Archive& ar, const unsigned int) {
 DYNET_SERIALIZE_IMPL(VanillaLSTMBuilder);
 
 } // namespace dynet
+

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -82,6 +82,20 @@ void LSTMBuilder::new_graph_impl(ComputationGraph& cg) {
 // layout: 0..layers = c
 //         layers+1..2*layers = h
 void LSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
+  // Check input dim and hidden dim
+  if (input_dim != params[0][X2I].dim()[1]) {
+    cerr << "Warning : LSTMBuilder input dimension " << input_dim
+         << " doesn't match with parameter dimension " << params[0][X2I].dim()[1]
+         << ". Setting input_dim to " << params[0][X2I].dim()[1] << endl;
+    input_dim = params[0][X2I].dim()[1];
+  }
+  if (hid != params[0][X2I].dim()[0]) {
+    cerr << "Warning : LSTMBuilder hidden dimension " << hid
+         << " doesn't match with parameter dimension " << params[0][X2I].dim()[0]
+         << ". Setting hid to " << params[0][X2I].dim()[0] << endl;
+    hid = params[0][X2I].dim()[0];
+  }
+
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
@@ -312,15 +326,6 @@ void LSTMBuilder::serialize(Archive& ar, const unsigned int) {
   ar & params;
   ar & layers;
   ar & dropout_rate;
-  // FOR COMPATIBILITY
-  if (dropout_rate_h > 0.f)
-    ar & dropout_rate_h;
-  if (dropout_rate_c > 0.f)
-    ar & dropout_rate_c;
-  if (hid > 0)
-    ar & hid;
-  if (input_dim > 0)
-    ar & input_dim;
 }
 
 DYNET_SERIALIZE_IMPL(LSTMBuilder);

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -299,4 +299,8 @@ private:
 
 } // namespace dynet
 
+
+// Class version
+BOOST_CLASS_VERSION(dynet::LSTMBuilder, 1);
+
 #endif

--- a/python_tests/test_no_update.py
+++ b/python_tests/test_no_update.py
@@ -91,4 +91,10 @@ print p2.as_array() # below 0.99, updates did occur
 print lp1.as_array() # below 0.99, update did occur
 print lp2.as_array() # 0.99
 
+# Test saving and loading
 
+m = dy.Model()
+b = dy.BiRNNBuilder(2, 10, 10, m, dy.LSTMBuilder)
+m.save("bilstm.model", [b])
+m2 = dy.Model()
+m2.load("bilstm.model")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,6 +9,7 @@ add_definitions (-DBOOST_TEST_DYN_LINK)
 set(test_dynet_SRCS
     test-nodes.cc
     test-trainers.cc
+    test-io.cc
 )
 
 add_executable (test-dynet test-dynet.cc ${test_dynet_SRCS})

--- a/tests/test-io.cc
+++ b/tests/test-io.cc
@@ -1,0 +1,106 @@
+#include <dynet/dynet.h>
+#include <dynet/expr.h>
+#include <dynet/rnn.h>
+#include <dynet/lstm.h>
+#include <dynet/gru.h>
+#include <boost/test/unit_test.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <iostream>
+#include <fstream>
+
+#include <stdexcept>
+
+using namespace dynet;
+using namespace dynet::expr;
+using namespace std;
+
+struct IOTest {
+    IOTest() {
+        // initialize if necessary
+        if (default_device == nullptr) {
+            for (auto x : {"IOTest", "--dynet-mem", "512"}) {
+                av.push_back(strdup(x));
+            }
+            char **argv = &av[0];
+            int argc = av.size();
+            dynet::initialize(argc, argv);
+        }
+        filename = "io.dump";
+    }
+    ~IOTest() {
+        for (auto x : av) free(x);
+    }
+
+    std::vector<char*> av;
+    std::string filename;
+};
+
+// define the test suite
+BOOST_FIXTURE_TEST_SUITE(io_test, IOTest);
+
+BOOST_AUTO_TEST_CASE( simple_rnn_io ) {
+    dynet::Model mod1;
+    dynet::SimpleRNNBuilder rnn1(1, 10, 10, mod1);
+    std::ofstream out(filename);
+    boost::archive::text_oarchive oa(out);
+    oa << mod1 << rnn1;
+    out.close();
+
+    dynet::Model mod2;
+    dynet::SimpleRNNBuilder rnn2;
+
+    ifstream in(filename);
+    boost::archive::text_iarchive ia(in);
+    ia >> mod2 >> rnn2;
+    in.close();
+}
+
+BOOST_AUTO_TEST_CASE( vanilla_lstm_io ) {
+    dynet::Model mod1;
+    dynet::VanillaLSTMBuilder rnn1(1, 10, 10, mod1);
+    std::ofstream out(filename);
+    boost::archive::text_oarchive oa(out);
+    oa << mod1 << rnn1;
+    out.close();
+
+    dynet::Model mod2;
+    dynet::VanillaLSTMBuilder rnn2;
+
+    BOOST_CHECK(rnn2.input_dim == 0);
+    BOOST_CHECK(rnn2.hid == 0);
+
+    ifstream in(filename);
+    boost::archive::text_iarchive ia(in);
+    ia >> mod2 >> rnn2;
+    in.close();
+
+    BOOST_CHECK(rnn2.input_dim == 10);
+    BOOST_CHECK(rnn2.hid == 10);
+}
+
+BOOST_AUTO_TEST_CASE( lstm_io ) {
+    dynet::Model mod1;
+    dynet::LSTMBuilder rnn1(1, 10, 10, mod1);
+    std::ofstream out(filename);
+    boost::archive::text_oarchive oa(out);
+    oa << mod1 << rnn1;
+    out.close();
+
+    dynet::Model mod2;
+    dynet::LSTMBuilder rnn2;
+
+    BOOST_CHECK(rnn2.input_dim == 0);
+    BOOST_CHECK(rnn2.hid == 0);
+
+    ifstream in(filename);
+    boost::archive::text_iarchive ia(in);
+    ia >> mod2 >> rnn2;
+    in.close();
+
+    BOOST_CHECK(rnn2.input_dim == 10);
+    BOOST_CHECK(rnn2.hid == 10);
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
LSTMBuilder is returned to its previous version. This has 2 effects : 

- It is now impossible to save different dropout values for `x`, `h`, `c`. If anyone knows a clean, retrocompatible way to do this, let me know

- Since `input_dim` and `hid` are needed, I added a sanity check in `start_new_sequence` so that if these variables are not set, they are retrieved directly from the parameters (and fire a warning)

Addresses #274 