### PR TITLE
Better initializers

### DIFF
--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -65,7 +65,7 @@ ParameterStorage::ParameterStorage(const Dim& d, float scale) : dim(d) {
   default_device->allocate_tensor(DeviceMempool::PS, values);
   default_device->allocate_tensor(DeviceMempool::PS, g);
   TensorTools::Zero(g);
-  if(scale == 0.0f) {
+  if (scale == 0.0f) {
     ParameterInitGlorot init;
     init.initialize_params(values);
   } else {
@@ -96,7 +96,7 @@ void ParameterStorage::copy(const ParameterStorage & param) {
 }
 
 void ParameterStorage::clear() {
-  if(g.v != nullptr)
+  if (g.v != nullptr)
     TensorTools::Zero(g);
 }
 
@@ -133,18 +133,18 @@ LookupParameterStorage::LookupParameterStorage(unsigned n, const Dim& d, const P
 }
 
 void LookupParameterStorage::initialize_lookups() {
-  int num = all_dim[all_dim.nd-1];
+  int num = all_dim[all_dim.nd - 1];
   dim = all_dim; dim.nd--;
   int dim_size = dim.size();
-  if(values.size() == 0) {
+  if (values.size() == 0) {
     values.resize(num);
-    for(int i = 0; i < num; ++i)
-      values[i] = Tensor(dim, all_values.v + i*dim_size, all_values.device, all_values.mem_pool);
+    for (int i = 0; i < num; ++i)
+      values[i] = Tensor(dim, all_values.v + i * dim_size, all_values.device, all_values.mem_pool);
   }
-  if(grads.size() == 0 && all_grads.v != nullptr) {
+  if (grads.size() == 0 && all_grads.v != nullptr) {
     grads.resize(num);
-    for(int i = 0; i < num; ++i)
-      grads[i] = Tensor(dim, all_grads.v + i*dim_size, all_grads.device, all_grads.mem_pool);
+    for (int i = 0; i < num; ++i)
+      grads[i] = Tensor(dim, all_grads.v + i * dim_size, all_grads.device, all_grads.mem_pool);
   }
 }
 
@@ -163,7 +163,7 @@ void LookupParameterStorage::copy(const LookupParameterStorage& param) {
 
 void LookupParameterStorage::clear() {
   // TODO: this is hacky, probably need a better heuristic
-  if(all_grads.device->type == DeviceType::GPU) {
+  if (all_grads.device->type == DeviceType::GPU) {
     TensorTools::Zero(all_grads);
   } else {
     for (auto i : non_zero_grads)
@@ -208,11 +208,16 @@ void ParameterInitIdentity::initialize_params(Tensor & values) const {
 }
 
 void ParameterInitGlorot::initialize_params(Tensor & values) const {
-  int dims = 0, dim_len = values.d.nd-(lookup?1:0);
-  for(int i = 0; i < dim_len; ++i) dims += values.d[i];
-  float my_scale = sqrt(6) / sqrt(dims);
+  int dims = 0, dim_len = values.d.nd - (lookup ? 1 : 0);
+  for (int i = 0; i < dim_len; ++i) dims += values.d[i];
+  float my_scale = gain * sqrt(6) / sqrt(dims);
   TensorTools::RandomizeUniform(values, -my_scale, my_scale);
 }
+
+void ParameterInitSaxe::initialize_params(Tensor & values) const {
+  TensorTools::RandomizeOrthogonal(values, gain);
+}
+
 
 void ParameterInitFromVector::initialize_params(Tensor & values) const {
   TensorTools::SetElements(values, vec);
@@ -300,7 +305,7 @@ Model::Model() : gradient_norm_scratch(nullptr) {
 
 Model::~Model() {
   for (auto p : all_params) delete p;
-  if(gradient_norm_scratch)
+  if (gradient_norm_scratch)
     default_device->mem->free(gradient_norm_scratch);
 }
 
@@ -345,7 +350,7 @@ Parameter Model::add_parameters(const Dim& d, const ParameterInit & init) {
 
 
 LookupParameter Model::add_lookup_parameters(unsigned n, const Dim& d) {
-  LookupParameterStorage* p = new LookupParameterStorage(n,d);
+  LookupParameterStorage* p = new LookupParameterStorage(n, d);
   LookupParameter r(this, lookup_params.size());
   //cerr << "Adding lookup parameters with dim " << d << " and size " << n << endl;
   all_params.push_back(p);
@@ -355,7 +360,7 @@ LookupParameter Model::add_lookup_parameters(unsigned n, const Dim& d) {
 }
 
 LookupParameter Model::add_lookup_parameters(unsigned n, const Dim& d, const ParameterInit & init) {
-  LookupParameterStorage* p = new LookupParameterStorage(n,d,init);
+  LookupParameterStorage* p = new LookupParameterStorage(n, d, init);
   LookupParameter r(this, lookup_params.size());
   //cerr << "Adding lookup parameters with dim " << d << " and size " << n << endl;
   all_params.push_back(p);
@@ -437,15 +442,15 @@ DYNET_SERIALIZE_IMPL(Model)
 #endif
 
 void save_dynet_model(std::string filename, Model* model) {
-    std::ofstream out(filename);
-    boost::archive::text_oarchive oa(out);
-    oa << (*model);
+  std::ofstream out(filename);
+  boost::archive::text_oarchive oa(out);
+  oa << (*model);
 };
 
 void load_dynet_model(std::string filename, Model* model) {
-    std::ifstream in(filename);
-    boost::archive::text_iarchive ia(in);
-    ia >> (*model);
+  std::ifstream in(filename);
+  boost::archive::text_iarchive ia(in);
+  ia >> (*model);
 };
 
 #endif
@@ -480,21 +485,21 @@ void ParameterStorage::accumulate_grad_dev(MyDevice & dev, const Tensor& d) {
   g.tvec().device(*dev.edevice) += d.tvec();
 }
 #ifdef __CUDACC__
-  template void ParameterStorage::accumulate_grad_dev<Device_GPU>(Device_GPU & dev, const Tensor& d);
+template void ParameterStorage::accumulate_grad_dev<Device_GPU>(Device_GPU & dev, const Tensor& d);
 #elif defined(HAVE_CUDA)
-  extern template void ParameterStorage::accumulate_grad_dev<Device_GPU>(Device_GPU & dev, const Tensor& d);
-  template void ParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, const Tensor& d);
-  void ParameterStorage::accumulate_grad(const Tensor& d) {
-    if(values.device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values.device,d); }
-    else if(values.device->type == DeviceType::GPU) { accumulate_grad_dev(*(Device_GPU*)values.device,d); }
-    else { abort(); }
-  }
+extern template void ParameterStorage::accumulate_grad_dev<Device_GPU>(Device_GPU & dev, const Tensor& d);
+template void ParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, const Tensor& d);
+void ParameterStorage::accumulate_grad(const Tensor& d) {
+  if (values.device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values.device, d); }
+  else if (values.device->type == DeviceType::GPU) { accumulate_grad_dev(*(Device_GPU*)values.device, d); }
+  else { abort(); }
+}
 #else
-  template void ParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, const Tensor& d);
-  void ParameterStorage::accumulate_grad(const Tensor& d) {
-    if(values.device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values.device,d); }
-    else { abort(); }
-  }
+template void ParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, const Tensor& d);
+void ParameterStorage::accumulate_grad(const Tensor& d) {
+  if (values.device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values.device, d); }
+  else { abort(); }
+}
 #endif
 
 template <class MyDevice>
@@ -502,21 +507,21 @@ void ParameterStorage::scale_parameters_dev(MyDevice & dev, float a) {
   values.tvec().device(*dev.edevice) = values.tvec() * a;
 }
 #ifdef __CUDACC__
-  template void ParameterStorage::scale_parameters_dev<Device_GPU>(Device_GPU & dev, float a);
+template void ParameterStorage::scale_parameters_dev<Device_GPU>(Device_GPU & dev, float a);
 #elif defined(HAVE_CUDA)
-  extern template void ParameterStorage::scale_parameters_dev<Device_GPU>(Device_GPU & dev, float a);
-  template void ParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
-  void ParameterStorage::scale_parameters(float a) {
-    if(values.device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values.device,a); }
-    else if(values.device->type == DeviceType::GPU) { scale_parameters_dev(*(Device_GPU*)values.device,a); }
-    else { abort(); }
-  }
+extern template void ParameterStorage::scale_parameters_dev<Device_GPU>(Device_GPU & dev, float a);
+template void ParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
+void ParameterStorage::scale_parameters(float a) {
+  if (values.device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values.device, a); }
+  else if (values.device->type == DeviceType::GPU) { scale_parameters_dev(*(Device_GPU*)values.device, a); }
+  else { abort(); }
+}
 #else
-  template void ParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
-  void ParameterStorage::scale_parameters(float a) {
-    if(values.device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values.device,a); }
-    else { abort(); }
-  }
+template void ParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
+void ParameterStorage::scale_parameters(float a) {
+  if (values.device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values.device, a); }
+  else { abort(); }
+}
 #endif
 
 template <class MyDevice>
@@ -529,21 +534,21 @@ void LookupParameterStorage::initialize_dev(MyDevice & dev, unsigned index, cons
 #endif
 }
 #ifdef __CUDACC__
-  template void LookupParameterStorage::initialize_dev<Device_GPU>(Device_GPU & dev, unsigned index, const vector<float>& val);
+template void LookupParameterStorage::initialize_dev<Device_GPU>(Device_GPU & dev, unsigned index, const vector<float>& val);
 #elif defined(HAVE_CUDA)
-  extern template void LookupParameterStorage::initialize_dev<Device_GPU>(Device_GPU & dev, unsigned index, const vector<float>& val);
-  template void LookupParameterStorage::initialize_dev<Device_CPU>(Device_CPU & dev, unsigned index, const vector<float>& val);
-  void LookupParameterStorage::initialize(unsigned index, const vector<float>& val) {
-    if(values[index].device->type == DeviceType::CPU) { initialize_dev(*(Device_CPU*)values[index].device,index,val); }
-    else if(values[index].device->type == DeviceType::GPU) { initialize_dev(*(Device_GPU*)values[index].device,index,val); }
-    else { abort(); }
-  }
+extern template void LookupParameterStorage::initialize_dev<Device_GPU>(Device_GPU & dev, unsigned index, const vector<float>& val);
+template void LookupParameterStorage::initialize_dev<Device_CPU>(Device_CPU & dev, unsigned index, const vector<float>& val);
+void LookupParameterStorage::initialize(unsigned index, const vector<float>& val) {
+  if (values[index].device->type == DeviceType::CPU) { initialize_dev(*(Device_CPU*)values[index].device, index, val); }
+  else if (values[index].device->type == DeviceType::GPU) { initialize_dev(*(Device_GPU*)values[index].device, index, val); }
+  else { abort(); }
+}
 #else
-  template void LookupParameterStorage::initialize_dev<Device_CPU>(Device_CPU & dev, unsigned index, const vector<float>& val);
-  void LookupParameterStorage::initialize(unsigned index, const vector<float>& val) {
-    if(values[index].device->type == DeviceType::CPU) { initialize_dev(*(Device_CPU*)values[index].device,index,val); }
-    else { abort(); }
-  }
+template void LookupParameterStorage::initialize_dev<Device_CPU>(Device_CPU & dev, unsigned index, const vector<float>& val);
+void LookupParameterStorage::initialize(unsigned index, const vector<float>& val) {
+  if (values[index].device->type == DeviceType::CPU) { initialize_dev(*(Device_CPU*)values[index].device, index, val); }
+  else { abort(); }
+}
 #endif
 
 template <class MyDevice>
@@ -558,7 +563,7 @@ void LookupParameterStorage::g_squared_l2norm_dev(MyDevice & dev, float* sqnorm)
   Tensor sqnorm_t({1}, sqnorm, &dev, DeviceMempool::NONE);
   auto it = non_zero_grads.begin();
   TensorTools::Zero(sqnorm_t);
-  while(it != non_zero_grads.end())
+  while (it != non_zero_grads.end())
     sqnorm_t.t<0>().device(*dev.edevice) += grads[*(it++)].tvec().square().sum();
 }
 DYNET_PARAMNORM_INST_DEV_IMPL(LookupParameterStorage, g_squared_l2norm, g_squared_l2norm_dev)
@@ -569,33 +574,33 @@ void LookupParameterStorage::accumulate_grad_dev(MyDevice & dev, unsigned index,
   grads[index].tvec().device(*dev.edevice) += d.tvec();
 }
 #ifdef __CUDACC__
-  template void LookupParameterStorage::accumulate_grad_dev<Device_GPU>(Device_GPU & dev, unsigned index, const Tensor& d);
+template void LookupParameterStorage::accumulate_grad_dev<Device_GPU>(Device_GPU & dev, unsigned index, const Tensor& d);
 #elif defined(HAVE_CUDA)
-  extern template void LookupParameterStorage::accumulate_grad_dev<Device_GPU>(Device_GPU & dev, unsigned index, const Tensor& d);
-  template void LookupParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, unsigned index, const Tensor& d);
-  void LookupParameterStorage::accumulate_grad(unsigned index, const Tensor& d) {
-    if(values[index].device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values[index].device,index,d); }
-    else if(values[index].device->type == DeviceType::GPU) { accumulate_grad_dev(*(Device_GPU*)values[index].device,index,d); }
-    else { abort(); }
-  }
+extern template void LookupParameterStorage::accumulate_grad_dev<Device_GPU>(Device_GPU & dev, unsigned index, const Tensor& d);
+template void LookupParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, unsigned index, const Tensor& d);
+void LookupParameterStorage::accumulate_grad(unsigned index, const Tensor& d) {
+  if (values[index].device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values[index].device, index, d); }
+  else if (values[index].device->type == DeviceType::GPU) { accumulate_grad_dev(*(Device_GPU*)values[index].device, index, d); }
+  else { abort(); }
+}
 #else
-  template void LookupParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, unsigned index, const Tensor& d);
-  void LookupParameterStorage::accumulate_grad(unsigned index, const Tensor& d) {
-    if(values[index].device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values[index].device,index,d); }
-    else { abort(); }
-  }
+template void LookupParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, unsigned index, const Tensor& d);
+void LookupParameterStorage::accumulate_grad(unsigned index, const Tensor& d) {
+  if (values[index].device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values[index].device, index, d); }
+  else { abort(); }
+}
 #endif
 
 template <class MyDevice>
 void LookupParameterStorage::accumulate_grads_dev(MyDevice & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g) {
 #ifdef __CUDACC__
-  for(unsigned i = 0; i < n; ++i)
+  for (unsigned i = 0; i < n; ++i)
     non_zero_grads.insert(ids_host[i]);
   dynet::gpu::dense_to_sparse_block_add(n, ids_dev, dim.size(), g, all_grads.v);
 #else
   size_t gsize = dim.size();
   Tensor gt(dim, g, all_grads.device, all_grads.mem_pool);
-  for(unsigned i = 0; i < n; ++i) {
+  for (unsigned i = 0; i < n; ++i) {
     non_zero_grads.insert(ids_host[i]);
     grads[ids_host[i]].tvec().device(*dev.edevice) += gt.tvec();
     gt.v += gsize;
@@ -603,21 +608,21 @@ void LookupParameterStorage::accumulate_grads_dev(MyDevice & dev, unsigned n, co
 #endif
 }
 #ifdef __CUDACC__
-  template void LookupParameterStorage::accumulate_grads_dev<Device_GPU>(Device_GPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
+template void LookupParameterStorage::accumulate_grads_dev<Device_GPU>(Device_GPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
 #elif defined(HAVE_CUDA)
-  extern template void LookupParameterStorage::accumulate_grads_dev<Device_GPU>(Device_GPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
-  template void LookupParameterStorage::accumulate_grads_dev<Device_CPU>(Device_CPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
-  void LookupParameterStorage::accumulate_grads(unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g) {
-    if(all_values.device->type == DeviceType::CPU) { accumulate_grads_dev(*(Device_CPU*)all_values.device,n,ids_host,ids_dev,g); }
-    else if(all_values.device->type == DeviceType::GPU) { accumulate_grads_dev(*(Device_GPU*)all_values.device,n,ids_host,ids_dev,g); }
-    else { abort(); }
-  }
+extern template void LookupParameterStorage::accumulate_grads_dev<Device_GPU>(Device_GPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
+template void LookupParameterStorage::accumulate_grads_dev<Device_CPU>(Device_CPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
+void LookupParameterStorage::accumulate_grads(unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g) {
+  if (all_values.device->type == DeviceType::CPU) { accumulate_grads_dev(*(Device_CPU*)all_values.device, n, ids_host, ids_dev, g); }
+  else if (all_values.device->type == DeviceType::GPU) { accumulate_grads_dev(*(Device_GPU*)all_values.device, n, ids_host, ids_dev, g); }
+  else { abort(); }
+}
 #else
-  template void LookupParameterStorage::accumulate_grads_dev<Device_CPU>(Device_CPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
-  void LookupParameterStorage::accumulate_grads(unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g) {
-    if(all_values.device->type == DeviceType::CPU) { accumulate_grads_dev(*(Device_CPU*)all_values.device,n,ids_host,ids_dev,g); }
-    else { abort(); }
-  }
+template void LookupParameterStorage::accumulate_grads_dev<Device_CPU>(Device_CPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
+void LookupParameterStorage::accumulate_grads(unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g) {
+  if (all_values.device->type == DeviceType::CPU) { accumulate_grads_dev(*(Device_CPU*)all_values.device, n, ids_host, ids_dev, g); }
+  else { abort(); }
+}
 #endif
 
 template <class MyDevice>
@@ -625,57 +630,57 @@ void LookupParameterStorage::scale_parameters_dev(MyDevice & dev, float a) {
   all_values.tvec().device(*dev.edevice) = all_values.tvec() * a;
 }
 #ifdef __CUDACC__
-  template void LookupParameterStorage::scale_parameters_dev<Device_GPU>(Device_GPU & dev, float a);
+template void LookupParameterStorage::scale_parameters_dev<Device_GPU>(Device_GPU & dev, float a);
 #elif defined(HAVE_CUDA)
-  extern template void LookupParameterStorage::scale_parameters_dev<Device_GPU>(Device_GPU & dev, float a);
-  template void LookupParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
-  void LookupParameterStorage::scale_parameters(float a) {
-    if(values[0].device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values[0].device,a); }
-    else if(values[0].device->type == DeviceType::GPU) { scale_parameters_dev(*(Device_GPU*)values[0].device,a); }
-    else { abort(); }
-  }
+extern template void LookupParameterStorage::scale_parameters_dev<Device_GPU>(Device_GPU & dev, float a);
+template void LookupParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
+void LookupParameterStorage::scale_parameters(float a) {
+  if (values[0].device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values[0].device, a); }
+  else if (values[0].device->type == DeviceType::GPU) { scale_parameters_dev(*(Device_GPU*)values[0].device, a); }
+  else { abort(); }
+}
 #else
-  template void LookupParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
-  void LookupParameterStorage::scale_parameters(float a) {
-    if(values[0].device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values[0].device,a); }
-    else { abort(); }
-  }
+template void LookupParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
+void LookupParameterStorage::scale_parameters(float a) {
+  if (values[0].device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values[0].device, a); }
+  else { abort(); }
+}
 #endif
 
 template <class MyDevice>
 float Model::gradient_l2_norm_dev(MyDevice & dev) const {
   if (!gradient_norm_scratch)
-    gradient_norm_scratch = (float*)default_device->mem->malloc((all_params.size()+1) * sizeof(float));
+    gradient_norm_scratch = (float*)default_device->mem->malloc((all_params.size() + 1) * sizeof(float));
   size_t pi;
-  for(pi = 0; pi < all_params.size(); ++pi)
+  for (pi = 0; pi < all_params.size(); ++pi)
     all_params[pi]->g_squared_l2norm(&gradient_norm_scratch[pi]);
   Tensor scratch_t({(unsigned int)all_params.size()}, gradient_norm_scratch, &dev, DeviceMempool::NONE);
-  Tensor sum_t({1}, gradient_norm_scratch+pi, &dev, DeviceMempool::NONE);
+  Tensor sum_t({1}, gradient_norm_scratch + pi, &dev, DeviceMempool::NONE);
   sum_t.t<0>().device(*dev.edevice) = scratch_t.t<1>().sum().sqrt();
 #ifdef __CUDACC__
   float res = 0;
-  cudaMemcpy(&res, gradient_norm_scratch+pi, sizeof(float),  cudaMemcpyDeviceToHost);
+  cudaMemcpy(&res, gradient_norm_scratch + pi, sizeof(float),  cudaMemcpyDeviceToHost);
   return res;
 #else
   return gradient_norm_scratch[pi];
 #endif
 }
 #ifdef __CUDACC__
-  template float Model::gradient_l2_norm_dev<Device_GPU>(Device_GPU & dev) const;
+template float Model::gradient_l2_norm_dev<Device_GPU>(Device_GPU & dev) const;
 #elif defined(HAVE_CUDA)
-  extern template float Model::gradient_l2_norm_dev<Device_GPU>(Device_GPU & dev) const;
-  template float Model::gradient_l2_norm_dev<Device_CPU>(Device_CPU & dev) const;
-  float Model::gradient_l2_norm() const {
-    if(default_device->type == DeviceType::CPU) { return gradient_l2_norm_dev(*(Device_CPU*)default_device); }
-    else if(default_device->type == DeviceType::GPU) { return gradient_l2_norm_dev(*(Device_GPU*)default_device); }
-    else { abort(); }
-  }
+extern template float Model::gradient_l2_norm_dev<Device_GPU>(Device_GPU & dev) const;
+template float Model::gradient_l2_norm_dev<Device_CPU>(Device_CPU & dev) const;
+float Model::gradient_l2_norm() const {
+  if (default_device->type == DeviceType::CPU) { return gradient_l2_norm_dev(*(Device_CPU*)default_device); }
+  else if (default_device->type == DeviceType::GPU) { return gradient_l2_norm_dev(*(Device_GPU*)default_device); }
+  else { abort(); }
+}
 #else
-  template float Model::gradient_l2_norm_dev<Device_CPU>(Device_CPU & dev) const;
-  float Model::gradient_l2_norm() const {
-    if(default_device->type == DeviceType::CPU) { return gradient_l2_norm_dev(*(Device_CPU*)default_device); }
-    else { abort(); }
-  }
+template float Model::gradient_l2_norm_dev<Device_CPU>(Device_CPU & dev) const;
+float Model::gradient_l2_norm() const {
+  if (default_device->type == DeviceType::CPU) { return gradient_l2_norm_dev(*(Device_CPU*)default_device); }
+  else { abort(); }
+}
 #endif
 
 } // namespace dynet

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -1,7 +1,7 @@
 /**
  * \file model.h
  * \defgroup params params
- * 
+ *
  */
 
 #ifndef DYNET_PARAMS_H_
@@ -130,7 +130,7 @@ private:
 class Model;
 /**
  * \brief Object representing a trainable parameter
- * 
+ *
  */
 struct Parameter {
   Parameter();
@@ -147,14 +147,14 @@ struct Parameter {
 
   /**
    * \brief Shape of the parameter
-   * 
+   *
    * \return Shape as a `Dim` object
    */
   Dim dim() { return get()->dim; }
 
   /**
    * \brief Values of the parameter
-   * 
+   *
    * \return Values as a `Tensor` object
    */
   Tensor* values() { return &(get()->values); }
@@ -171,7 +171,7 @@ private:
 /**
  * \ingroup params
  * \brief Object representing a trainable lookup parameter
- * 
+ *
  */
 struct LookupParameter {
   LookupParameter();
@@ -189,13 +189,13 @@ struct LookupParameter {
 
   /**
    * \brief Shape of the lookup parameter
-   * 
+   *
    * \return Shape as a `Dim` object
    */
   Dim dim() { return get()->dim; }
   /**
    * \brief Values of the lookup parameter
-   * 
+   *
    * \return Values as a `Tensor` object
    */
   std::vector<Tensor>* values() { return &(get()->values); }
@@ -314,11 +314,13 @@ struct ParameterInitGlorot : public ParameterInit {
    * \brief Constructor
    *
    * \param is_lookup Boolean value identifying the parameter as a LookupParameter
+   * \param gain Value of the derivative of the activation function in 0
    */
-  ParameterInitGlorot(bool is_lookup = false) : lookup(is_lookup) {}
+  ParameterInitGlorot(bool is_lookup = false, float gain = 1.f) : lookup(is_lookup), gain(gain) {}
   virtual void initialize_params(Tensor & values) const override;
 private:
   bool lookup;
+  float gain;
 };
 
 /**
@@ -330,17 +332,17 @@ struct ParameterInitSaxe : public ParameterInit {
   /**
    * \brief Constructor
    */
-  ParameterInitSaxe() {}
+  ParameterInitSaxe(float gain=1.0) : gain(gain) {}
   virtual void initialize_params(Tensor & values) const override;
 private:
-  float cnst;
+  float gain;
 };
 
 /**
  * \ingroup params
  * \brief Initializes from a file
  * \details Useful for reusing weights, etc...
- * 
+ *
  */
 struct ParameterInitFromFile : public ParameterInit {
   /**
@@ -360,7 +362,7 @@ private:
 struct ParameterInitFromVector : public ParameterInit {
   /**
    * \brief Constructor
-   * 
+   *
    * \param v Vector of values to be used
    */
   ParameterInitFromVector(std::vector<float> v) : vec(v) {}
@@ -440,7 +442,7 @@ public:
    * \return LookupParameter object to be used in the computation graph
    */
   LookupParameter add_lookup_parameters(unsigned n, const Dim& d, const ParameterInit & init);
-  // 
+  //
   /**
    * \brief project weights so their L2 norm = radius
    * \details NOTE (Paul) : I am not sure this is doing anything currently. The argument doesn't seem to be used anywhere... If you need this raise an issue on github
@@ -472,13 +474,13 @@ public:
   // indexes into params and lookup_params
   /**
    * \brief Returns list of indices of updated params
-   * 
+   *
    * \return list of indices of updated params
    */
   const std::vector<unsigned>& updated_parameters_list() const { return updated_params; }
   /**
    * \brief Returns list of indices of updated lookup params
-   * 
+   *
    * \return list of indices of updated lookup params
    */
   const std::vector<unsigned>& updated_lookup_parameters_list() const { return updated_lookup_params; }
@@ -493,7 +495,7 @@ public:
   size_t parameter_count() const;
   /**
    * \brief Returns total number of (scalar) parameters updated
-   * 
+   *
    * \return number of updated parameters
    */
   size_t updated_parameter_count() const;

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -305,8 +305,7 @@ struct ParameterInitIdentity : public ParameterInit {
  * \ingroup params
  * \brief Initialize with the methods described in [Glorot, 2010](http://www.jmlr.org/proceedings/papers/v9/glorot10a/glorot10a.pdf?hc_location=ufi)
  * \details In order to preserve the variance of the forward and backward flow across layers, the parameters \f$\theta\f$ are initialized such that \f$\mathrm{Var}(\theta)=\frac 2 {n_1+n_2}\f$ where \f$n_1,n_2\f$ are the input and output dim.
- * Important note : For now the Glorot Initializer is only correct for tanh activated layers (or more specifically activation functions such that \f$f'(0)=1\f$).
- * Other important note : The underlying distribution is uniform (not gaussian)
+ * Important note : The underlying distribution is uniform (not gaussian)
  *
  */
 struct ParameterInitGlorot : public ParameterInit {
@@ -314,7 +313,7 @@ struct ParameterInitGlorot : public ParameterInit {
    * \brief Constructor
    *
    * \param is_lookup Boolean value identifying the parameter as a LookupParameter
-   * \param gain Value of the derivative of the activation function in 0
+   * \param gain Scaling parameter. In order for the Glorot initialization to be correct, you should ût this equal to \f$\frac 1 {f'(0)}\f$ where \f$f\f$ is your activation function
    */
   ParameterInitGlorot(bool is_lookup = false, float gain = 1.f) : lookup(is_lookup), gain(gain) {}
   virtual void initialize_params(Tensor & values) const override;
@@ -322,7 +321,6 @@ private:
   bool lookup;
   float gain;
 };
-
 /**
  * \ingroup params
  * \brief Initializes according to [Saxe et al., 2014](https://arxiv.org/abs/1312.6120)

--- a/dynet/tensor.cc
+++ b/dynet/tensor.cc
@@ -29,7 +29,7 @@ ostream& operator<<(ostream& os, const Tensor& t) {
 }
 
 real as_scalar(const Tensor& t) {
-  if(t.d.size() != 1) throw std::runtime_error("Input tensor has more than one element, cannot convert to scalar.");
+  if (t.d.size() != 1) throw std::runtime_error("Input tensor has more than one element, cannot convert to scalar.");
 #if HAVE_CUDA
   float res;
   CUDA_CHECK(cudaMemcpy(&res, t.v, sizeof(float), cudaMemcpyDeviceToHost));
@@ -120,20 +120,20 @@ void TensorTools::Zero(Tensor& d) {
 }
 
 void TensorTools::Identity(Tensor& val) {
-  if(val.d.nd != 2 || val.d[0] != val.d[1])
+  if (val.d.nd != 2 || val.d[0] != val.d[1])
     throw std::runtime_error("Attempt to set a tensor that is not a square matrix to identity");
   size_t pos = 0;
 #if HAVE_CUDA
   float* t = new float[val.d.size()];
-  for(size_t i = 0; i < val.d[0]; ++i)
-    for(size_t j = 0; j < val.d[1]; ++j)
-      t[pos++] = (i==j?1:0);
+  for (size_t i = 0; i < val.d[0]; ++i)
+    for (size_t j = 0; j < val.d[1]; ++j)
+      t[pos++] = (i == j ? 1 : 0);
   CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
   delete[] t;
 #else
-  for(size_t i = 0; i < val.d[0]; ++i)
-    for(size_t j = 0; j < val.d[1]; ++j)
-      val.v[pos++] = (i==j?1:0);
+  for (size_t i = 0; i < val.d[0]; ++i)
+    for (size_t j = 0; j < val.d[1]; ++j)
+      val.v[pos++] = (i == j ? 1 : 0);
 #endif
 }
 
@@ -177,14 +177,22 @@ void TensorTools::RandomizeUniform(Tensor& val, real left, real right) {
 #endif
 }
 
+void TensorTools::RandomizeOrthogonal(Tensor& val, real scale) {
+  if (val.d.nd != 2 || val.d[0] != val.d[1])
+    throw std::runtime_error("Attempt to set a tensor that is not a square matrix to an orthogonal matrix");
+  RandomizeUniform(val, -1.0, 1.0);
+  Eigen::JacobiSVD<Eigen::MatrixXf> svd(*val, Eigen::ComputeFullU | Eigen::ComputeThinV);
+  *val = scale * svd.matrixU();
+}
+
 template<class Archive>
 void Tensor::save(Archive& ar, const unsigned int ver) const {
   ar & d;
-  int dev_id = ((device == default_device) ? (int)-1 : device->device_id);
+  int dev_id = ((device == default_device) ? (int) - 1 : device->device_id);
   ar & dev_id;
   ar & mem_pool;
 #ifdef HAVE_CUDA
-  if(device->type == DeviceType::GPU) {
+  if (device->type == DeviceType::GPU) {
     float* vc = static_cast<float*>(std::malloc(d.size() * sizeof(float)));
     CUDA_CHECK(cudaMemcpyAsync(vc, v, d.size() * sizeof(float), cudaMemcpyDeviceToHost));
     ar & boost::serialization::make_array(vc, d.size());
@@ -203,11 +211,11 @@ void Tensor::load(Archive& ar, const unsigned int ver) {
   // This default value is for backward compatibility with models that were
   // saved without information about what mempool a tensor belongs to.
   mem_pool = DeviceMempool::PS;
-  if(ver > 0) {
+  if (ver > 0) {
     ar & dev_id;
     ar & mem_pool;
   }
-  if(dev_id == -1) {
+  if (dev_id == -1) {
     device = default_device;
   } else {
     assert(dev_id > 0 && dev_id < (int)devices.size());
@@ -215,7 +223,7 @@ void Tensor::load(Archive& ar, const unsigned int ver) {
   }
   device->allocate_tensor(mem_pool, *this);
 #ifdef HAVE_CUDA
-  if(device->type == DeviceType::GPU) {
+  if (device->type == DeviceType::GPU) {
     float* vc = static_cast<float*>(std::malloc(d.size() * sizeof(float)));
     ar & boost::serialization::make_array(vc, d.size());
     CUDA_CHECK(cudaMemcpyAsync(v, vc, d.size() * sizeof(float), cudaMemcpyHostToDevice));
@@ -235,9 +243,9 @@ real rand01() {
 }
 
 int rand0n(int n) {
-  if(n <= 0) throw std::runtime_error("Integer upper bound is non-positive");
+  if (n <= 0) throw std::runtime_error("Integer upper bound is non-positive");
   int x = rand01() * n;
-  while(n == x) { x = rand01() * n; }
+  while (n == x) { x = rand01() * n; }
   return x;
 }
 

--- a/dynet/tensor.h
+++ b/dynet/tensor.h
@@ -444,6 +444,14 @@ struct TensorTools {
    */
   static void RandomizeUniform(Tensor& val, real left = 0.0f, real right = 0.0f);
   /**
+   * \brief Takes a square matrix tensor and sets it as a random orthogonal matrix
+   * \details More specifically this samples a random matrix with RandomizeUniform and then performs SVD and returns the left orthogonal matrix in the decomposition, scaled by `scale`
+   *
+   * \param val Input tensor
+   * \param scale Value to which the resulting orthogonal matrix will be scaled
+   */
+  static void RandomizeOrthogonal(Tensor& val, real scale = 1.0f);
+  /**
    * \brief Access element of the tensor by index in the values array
    * \details AccessElement and SetElement are very, very slow (potentially) - use appropriately
    *

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -78,10 +78,10 @@ cdef extern from "dynet/model.h" namespace "dynet":
         CParameterInitIdentity()
 
     cdef cppclass CParameterInitGlorot "dynet::ParameterInitGlorot" (CParameterInit):
-        CParameterInitGlorot(bool is_lookup) # is_lookup = False
+        CParameterInitGlorot(bool is_lookup, float gain) # is_lookup = False
 
     cdef cppclass CParameterInitSaxe "dynet::ParameterInitSaxe" (CParameterInit):
-        ParameterInitSaxe()
+        CParameterInitSaxe(float scale)
 
     cdef cppclass CParameterInitFromFile "dynet::ParameterInitFromFile" (CParameterInit):
         CParameterInitFromFile(string filename)

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -230,12 +230,12 @@ cdef class IdentityInitializer(PyInitializer):
         self.initializer = new CParameterInitIdentity()
 
 cdef class GlorotInitializer(PyInitializer):
-    def __init__(self, bool is_lookup=False):
-        self.initializer = new CParameterInitGlorot(is_lookup)
+    def __init__(self, bool is_lookup=False,float gain=1.0):
+        self.initializer = new CParameterInitGlorot(is_lookup,gain)
 
-#cdef class SaxeInitializer(PyInitializer):
-#    def __init__(self):
-#        self.initializer = new CParameterInitSaxe()
+cdef class SaxeInitializer(PyInitializer):
+   def __init__(self,scale=1.0):
+       self.initializer = new CParameterInitSaxe(scale)
 
 cdef class FromFileInitializer(PyInitializer):
     def __init__(self, string fname):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ set(test_dynet_SRCS
     test-nodes.cc
     test-trainers.cc
     test-io.cc
+    test-params.cc
 )
 
 add_executable (test-dynet test-dynet.cc ${test_dynet_SRCS})

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -1,0 +1,62 @@
+#include <dynet/dynet.h>
+#include <dynet/expr.h>
+#include <dynet/model.h>
+#include <boost/test/unit_test.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <iostream>
+#include <fstream>
+
+#include <stdexcept>
+
+using namespace dynet;
+using namespace dynet::expr;
+using namespace std;
+
+struct ParamsTest {
+    ParamsTest() {
+        // initialize if necessary
+        if (default_device == nullptr) {
+            for (auto x : {"ParamsTest", "--dynet-mem", "512"}) {
+                av.push_back(strdup(x));
+            }
+            char **argv = &av[0];
+            int argc = av.size();
+            dynet::initialize(argc, argv);
+        }
+        gain = 2.0;
+        epsilon = 1e-9; 
+        d = dynet::Dim({10, 10});
+    }
+    ~ParamsTest() {
+        for (auto x : av) free(x);
+    }
+
+
+    float gain, epsilon;
+    dynet::Dim d;
+    std::vector<char*> av;
+};
+
+// define the test suite
+BOOST_FIXTURE_TEST_SUITE(params_test, ParamsTest);
+
+BOOST_AUTO_TEST_CASE( init_saxe ) {
+    dynet::Model mod;
+    // Random orthogonal matrix scaled by gain
+    dynet::Parameter saxe_p = mod.add_parameters({10, 10}, ParameterInitSaxe(gain));
+    // gain^2 * identity matrix
+    dynet::Parameter identity_p = mod.add_parameters({10, 10}, ParameterInitIdentity());
+    // Initialize graph
+    dynet::ComputationGraph cg;
+    dynet::Expression saxe = dynet::parameter(cg, saxe_p);
+    dynet::Expression identity = dynet::parameter(cg, identity_p);
+    // check that the matrix is indeed orthogonal
+    dynet::Expression diff_expr_left = dynet::squared_norm(dynet::transpose(saxe) * saxe - (gain * gain) * identity);
+    dynet::Expression diff_expr_right = dynet::squared_norm(saxe * dynet::transpose(saxe) - (gain * gain) * identity);
+    float diff = dynet::as_scalar(cg.forward((diff_expr_left + diff_expr_right) / 2.0));
+    // Leave a margin of error of epsilon=10^9, ie each element on average is <= 10 ^ -6
+    BOOST_CHECK_LT(diff, epsilon);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -25,7 +25,7 @@ struct ParamsTest {
             dynet::initialize(argc, argv);
         }
         gain = 2.0;
-        epsilon = 1e-9; 
+        epsilon = 1e-6; 
         d = dynet::Dim({10, 10});
     }
     ~ParamsTest() {
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE( init_saxe ) {
     dynet::Expression diff_expr_left = dynet::squared_norm(dynet::transpose(saxe) * saxe - (gain * gain) * identity);
     dynet::Expression diff_expr_right = dynet::squared_norm(saxe * dynet::transpose(saxe) - (gain * gain) * identity);
     float diff = dynet::as_scalar(cg.forward((diff_expr_left + diff_expr_right) / 2.0));
-    // Leave a margin of error of epsilon=10^9, ie each element on average is <= 10 ^ -6
+    // Leave a margin of error of epsilon=10^-6
     BOOST_CHECK_LT(diff, epsilon);
 }
 


### PR DESCRIPTION
This does mainly two things : 

- Add a `gain` parameter to the `ParameterInitGlorot` constructor and modifies the doc accordingly. Indeed, for Glorot to be correct, the actual scale should be : 

![eq](https://cloud.githubusercontent.com/assets/10391785/22844582/fd000168-efac-11e6-8612-a75c94acb003.gif)

Where f is the activation function.

Here are quantitative results with a 2 hidden layers MLP with hidden size 512 and sigmoid activations on MNIST (averaged over 20 experiments)

![glorot](https://cloud.githubusercontent.com/assets/10391785/22844775/c131ce2c-efad-11e6-8149-4aa01738beb4.png)

- Implemented the Saxe initializer (random orthogonal matrix, useful for vanilla RNNs). Added unit test for this one.

Also added python bindings for all of those (tested)

Addresses #262 
