### PR TITLE
Speedup softmax/logsoftmax for GPU

### DIFF
--- a/dynet/mem.cc
+++ b/dynet/mem.cc
@@ -10,7 +10,7 @@
 
 #include <fcntl.h>
 #if !_WINDOWS
-	#include <mm_malloc.h>
+#include <mm_malloc.h>
 #endif
 #include "dynet/except.h"
 #if HAVE_CUDA
@@ -44,8 +44,8 @@ void CPUAllocator::zero(void* p, size_t n) {
 
 void* SharedAllocator::malloc(size_t n) {
 #if _WINDOWS
-	cerr << "Shared memory not supported in Windows" << endl;
-	throw dynet::out_of_memory("Shared memory allocation failed");
+  cerr << "Shared memory not supported in Windows" << endl;
+  throw dynet::out_of_memory("Shared memory allocation failed");
 #else
   void* ptr = mmap(NULL, n, PROT_READ|PROT_WRITE, MAP_ANON|MAP_SHARED, -1, 0);
   if (!ptr) {

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -158,10 +158,19 @@ template <class MyDevice>
 EIGEN_STRONG_INLINE void logsumexp(const MyDevice & dev, const Tensor& x, Tensor & m, Tensor& z) {
   if(x.d.bd == 1 && x.d[1] == 1) {
     m.t<0>().device(*dev.edevice) = x.t<1>().maximum();
+#ifdef __CUDACC__
+    Eigen::array<int, 1> bcast;
+    bcast[0] = x.d[0];
+    // This needs to be split into two lines to prevent memory allocation
+    // TODO? Here and in logsoftmax: Is there a better way to subtract a scalar that is already on the GPU without using broadcasting (and without copying the scalar back to the host first)
+    z.t<0>().device(*dev.edevice) = (x.t<1>() - m.t<1>().broadcast(bcast)).exp().sum();
+    z.t<0>().device(*dev.edevice) = z.t<0>().log() + m.t<0>();
+#else
     float mval = as_scalar(m);
     // This needs to be split into two lines to prevent memory allocation
     z.t<0>().device(*dev.edevice) = (x.t<1>() - mval).exp().sum();
     z.t<0>().device(*dev.edevice) = z.t<0>().log() + mval;
+#endif
   } else {
     Eigen::array<int, 1> red_axis; red_axis[0] = 0;
     m.tb<1>().device(*dev.edevice) = x.tb<2>().maximum(red_axis);
@@ -847,7 +856,7 @@ void Hinge::backward_dev_impl(const MyDevice & dev,
 #if defined(__CUDACC__) && defined(EIGEN_NO_MALLOC)
       throw std::runtime_error("CUDA memory allocation in hinge");
 #endif
-	  // nvcc with MSVC can't this all as one expression, so it's intentionally split into multiple lines
+      // nvcc with MSVC can't this all as one expression, so it's intentionally split into multiple lines
       auto&& elossVec = eloss.tvec();
       auto&& hinge_sum = (elossVec > 0.f).cast<float>().sum() * d;
       dEdxi.tvec().chip<0>(*pelement).device(*dev.edevice) -= hinge_sum;
@@ -868,7 +877,7 @@ void Hinge::backward_dev_impl(const MyDevice & dev,
         auto&& elossChip = elossVec.chip<1>(b);
         auto&& hinge_sum = (elossChip > 0.f).cast<float>().sum() * d_vec[b];
         dEdxi.tb<1>().chip<1>(b).chip<0>((*pelements)[b]).device(*dev.edevice) -= hinge_sum;
-	  }
+      }
     }
   }
 }
@@ -1045,7 +1054,13 @@ void LogSoftmax::forward_dev_impl(const MyDevice & dev, const vector<const Tenso
   Tensor m(Dim({xs[0]->d.cols()},fx.d.bd), (float*)aux_mem + z.d.size(), fx.device, DeviceMempool::FXS);
   logsumexp(dev, *xs[0], m, z);
   if(fx.d.size() == fx.d.rows()) {
+#ifdef __CUDACC__
+    Eigen::array<int, 1> bcast;
+    bcast[0] = xs[0]->d[0];
+    fx.t<1>().device(*dev.edevice) = xs[0]->t<1>() - z.t<1>().broadcast(bcast);
+#else
     fx.t<1>().device(*dev.edevice) = xs[0]->t<1>() - as_scalar(z);
+#endif
   } else {
     // TODO? Is this broadcast efficient on CPU?
     Eigen::array<int, 3> bcasts = {(int)xs[0]->d.rows(), 1, 1};


### PR DESCRIPTION
Removing two extra memcopies (m and z) which required GPU synchronization. Also fix tabs->spaces in a couple places.

For my code, sped up GPU computation about 5-10%.