### PR TITLE
Speedup sum on GPU by merging together sets of sums (less overhead calling CUDA kernels)

### DIFF
--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1915,24 +1915,50 @@ DYNET_NODE_INST_DEV_IMPL(Sqrt)
 template<class MyDevice>
 void Sum::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   const unsigned num_args = xs.size();
-  if (num_args == 1) {
+  if (num_args == 1) 
     fx.v = xs[0]->v;
-    return;
-  }
-  TensorTools::Zero(fx);
+  else if (num_args == 2 && xs[0]->d.bd == xs[1]->d.bd)
+    fx.tvec().device(*dev.edevice) = xs[0]->tvec() + xs[1]->tvec();
+  else if (num_args == 3 && xs[0]->d.bd == xs[1]->d.bd && xs[1]->d.bd == xs[2]->d.bd)
+    fx.tvec().device(*dev.edevice) = xs[0]->tvec() + xs[1]->tvec() + xs[2]->tvec();
+  else if (num_args == 4 && xs[0]->d.bd == xs[1]->d.bd && xs[1]->d.bd == xs[2]->d.bd && xs[2]->d.bd == xs[3]->d.bd)
+    fx.tvec().device(*dev.edevice) = xs[0]->tvec() + xs[1]->tvec() + xs[2]->tvec() + xs[3]->tvec();
+  else {
+    bool allSameBatchSize = std::all_of(xs.begin(), xs.end(), [&](const Tensor* x) { return x->d.bd == xs[0]->d.bd;});
+    if (allSameBatchSize) {
+      // Since they are all the same batch size, we can easily unroll the addition (results in lower GPU latency by merging multiple adds together in one CUDA call):
+      assert(num_args > 4);        // If it was <=4, we would have handled it in the special cases above
+      fx.tvec().device(*dev.edevice) = xs[0]->tvec() + xs[1]->tvec() + xs[2]->tvec() + xs[3]->tvec();
+
+      const unsigned remainder = (num_args - 4 ) % 4;
+      switch (remainder) {
+      case 0: break;
+      case 1: fx.tvec().device(*dev.edevice) += xs[4]->tvec(); break;
+      case 2: fx.tvec().device(*dev.edevice) += xs[4]->tvec() + xs[5]->tvec(); break;
+      case 3: fx.tvec().device(*dev.edevice) += xs[4]->tvec() + xs[5]->tvec() + xs[6]->tvec(); break;
+      }
+      for (unsigned i = 4 + remainder; i < num_args; i += 4)
+        fx.tvec().device(*dev.edevice) += xs[i]->tvec() + xs[i + 1]->tvec() + xs[i + 2]->tvec() + xs[i + 3]->tvec();
+    }
+    else {
+      // Not all the same batch size, so need to broadcast in the cases where they differ
+      TensorTools::Zero(fx);
 #if __CUDACC__
-  Eigen::array<int, 2> bcast({1, (int)fx.d.bd});
+      Eigen::array<int, 2> bcast({ 1, (int)fx.d.bd });
 #endif
-  for (unsigned i = 0; i < num_args; ++i) {
-    if(xs[i]->d.bd == fx.d.bd) {
-      fx.tvec().device(*dev.edevice) += xs[i]->tvec();
-    } else {
+      for (unsigned i = 0; i < num_args; ++i) {
+        if (xs[i]->d.bd == fx.d.bd) {
+          fx.tvec().device(*dev.edevice) += xs[i]->tvec();
+        }
+        else {
 #if __CUDACC__
-      fx.tbvec().device(*dev.edevice) += xs[i]->tbvec().broadcast(bcast);
+          fx.tbvec().device(*dev.edevice) += xs[i]->tbvec().broadcast(bcast);
 #else
-      for(unsigned b = 0; b < fx.d.bd; ++b)
-        fx.tbvec().chip<1>(b).device(*dev.edevice) += xs[i]->tvec();
+          for (unsigned b = 0; b < fx.d.bd; ++b)
+            fx.tbvec().chip<1>(b).device(*dev.edevice) += xs[i]->tvec();
 #endif
+        }
+      }
     }
   }
 }

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1932,10 +1932,10 @@ void Sum::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs
 
       const unsigned remainder = (num_args - 4 ) % 4;
       switch (remainder) {
-      case 0: break;
-      case 1: fx.tvec().device(*dev.edevice) += xs[4]->tvec(); break;
-      case 2: fx.tvec().device(*dev.edevice) += xs[4]->tvec() + xs[5]->tvec(); break;
-      case 3: fx.tvec().device(*dev.edevice) += xs[4]->tvec() + xs[5]->tvec() + xs[6]->tvec(); break;
+        case 0: break;
+        case 1: fx.tvec().device(*dev.edevice) += xs[4]->tvec(); break;
+        case 2: fx.tvec().device(*dev.edevice) += xs[4]->tvec() + xs[5]->tvec(); break;
+        case 3: fx.tvec().device(*dev.edevice) += xs[4]->tvec() + xs[5]->tvec() + xs[6]->tvec(); break;
       }
       for (unsigned i = 4 + remainder; i < num_args; i += 4)
         fx.tvec().device(*dev.edevice) += xs[i]->tvec() + xs[i + 1]->tvec() + xs[i + 2]->tvec() + xs[i + 3]->tvec();


### PR DESCRIPTION
Unrolled sum when all of the items have the same batch dimension, so there are less CUDA calls (reduces GPU overhead). Also added special-casing for sum of 2,3, or 4 items (with same batch size). I think a sum of 2 items is probably very common, so it's worth special-casing. My experiments were 1-4% faster on GPU with no speed difference on CPU. Adds complexity to the function, but I felt it was worth the tradeoff for a little speed boost (and probably more significant speed boost for people doing a lot of summing).