### PR TITLE
adding flip_gradient operation for adversarial training

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -31,6 +31,8 @@ Expression random_uniform(ComputationGraph& g, const Dim& d, real left, real rig
 
 // identity function, but derivative is not propagated through it
 Expression nobackprop(const Expression& x) { return Expression(x.pg, x.pg->add_function<NoBackprop>({x.i})); }
+// identity function, but derivative is propagated as negative
+Expression flip_gradient(const Expression& x) { return Expression(x.pg, x.pg->add_function<FlipGradient>({x.i})); }
 
 Expression operator-(const Expression& x) { return Expression(x.pg, x.pg->add_function<Negate>({x.i})); }
 Expression operator+(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Sum>({x.i, y.i})); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1092,7 +1092,7 @@ Expression nobackprop(const Expression& x);
  * \ingroup flowoperations
  * \brief Negative backprop 
  * \details This node has no effect on the forward pass, but takes negative on backprop process. 
- *          This is useful when you want to create a domain adaption network
+ *          This operation is widely used in adversarial networks.
  *          
  * \param x The input expression
  * 

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1090,6 +1090,18 @@ Expression nobackprop(const Expression& x);
 
 /**
  * \ingroup flowoperations
+ * \brief Negative backprop 
+ * \details This node has no effect on the forward pass, but takes negative on backprop process. 
+ *          This is useful when you want to create a domain adaption network
+ *          
+ * \param x The input expression
+ * 
+ * \return An output expression containing the same as input (only effects on backprop process)
+ */ 
+Expression flip_gradient(const Expression& x);  
+  
+/**
+ * \ingroup flowoperations
  * \brief Reshape to another size
  * \details This node reshapes a tensor to another size, without changing the
  *          underlying layout of the data. The layout of the data in DyNet is

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -552,6 +552,17 @@ Dim NoBackprop::dim_forward(const vector<Dim>& xs) const {
   return xs[0];
 }
 
+string FlipGradient::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "flip_gradient(" << arg_names[0] << ')';
+  return s.str();
+}
+
+Dim FlipGradient::dim_forward(const vector<Dim>& xs) const {
+  assert(xs.size() == 1);
+  return xs[0];
+}  
+  
 string Softmax::as_string(const vector<string>& arg_names) const {
   ostringstream s;
   s << "softmax(" << arg_names[0] << ')';

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1287,7 +1287,7 @@ void FlipGradient::backward_dev_impl(const MyDevice & dev,
                                    unsigned i,
                                    Tensor& dEdxi) const {
   // takes negative on backprop
-  dEdxi.tvec().device(*dev.edevice) -= dEdf.tvec()
+  dEdxi.tvec().device(*dev.edevice) -= dEdf.tvec();
 }
 DYNET_NODE_INST_DEV_IMPL(FlipGradient)  
   

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1276,7 +1276,6 @@ DYNET_NODE_INST_DEV_IMPL(NoBackprop)
 
 template<class MyDevice>
 void FlipGradient::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  fx.d = xs[0]->d;
   fx.v = xs[0]->v;
 }
 

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1287,7 +1287,7 @@ void FlipGradient::backward_dev_impl(const MyDevice & dev,
                                    unsigned i,
                                    Tensor& dEdxi) const {
   // takes negative on backprop
-  dEdxi.tvec().device(*dev.edevice) = dEdf.tvec().unaryExpr(scalar_negative_op<float>());
+  dEdxi.tvec().device(*dev.edevice) -= dEdf.tvec()
 }
 DYNET_NODE_INST_DEV_IMPL(FlipGradient)  
   

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1275,6 +1275,24 @@ void NoBackprop::backward_dev_impl(const MyDevice & dev,
 DYNET_NODE_INST_DEV_IMPL(NoBackprop)
 
 template<class MyDevice>
+void FlipGradient::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
+  fx.d = xs[0]->d;
+  fx.v = xs[0]->v;
+}
+
+template<class MyDevice>
+void FlipGradient::backward_dev_impl(const MyDevice & dev,
+                                   const vector<const Tensor*>& xs,
+                                   const Tensor& fx,
+                                   const Tensor& dEdf,
+                                   unsigned i,
+                                   Tensor& dEdxi) const {
+  // takes negative on backprop
+  dEdxi.tvec().device(*dev.edevice) = dEdf.tvec().unaryExpr(scalar_negative_op<float>());
+}
+DYNET_NODE_INST_DEV_IMPL(FlipGradient)  
+  
+template<class MyDevice>
 void MaxPooling1D::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   throw std::runtime_error("MaxPooling1D::forward_dev_impl not implemented yet");
 #if 0

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -284,6 +284,13 @@ struct NoBackprop : public Node {
   DYNET_NODE_DEFINE_DEV_IMPL()
 };
 
+// y = x_1, dy/dx is set to negative. 
+struct FlipGradient : public Node {
+  explicit FlipGradient(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  virtual bool supports_multibatch() const override { return true; }
+  DYNET_NODE_DEFINE_DEV_IMPL()
+};  
+  
 // y = x_1
 struct Identity : public Node {
   explicit Identity(const std::initializer_list<VariableIndex>& a) : Node(a) {}

--- a/dynet/simd-functors.h
+++ b/dynet/simd-functors.h
@@ -71,6 +71,30 @@ struct functor_traits<dynet::const_minus_op<Scalar> > {
 } }
 
 namespace dynet {
+template<typename Scalar> struct scalar_negative_op {
+  EIGEN_EMPTY_STRUCT_CTOR(scalar_negative_op)
+  DYNET_DEVICE_FUNC inline const Scalar operator() (const Scalar& x) const {
+    return -x;
+  }
+  template <typename Packet>
+  DYNET_DEVICE_FUNC inline Packet packetOp(const Packet& x) const {
+    using namespace Eigen::internal;
+    return pnegate(x);
+  }
+};
+}
+
+namespace Eigen { namespace internal {
+template<typename Scalar>
+struct functor_traits<dynet::scalar_negative_op<Scalar> > {
+  enum {
+    Cost = NumTraits<Scalar>::MulCost * 2,
+    PacketAccess = packet_traits<Scalar>::HasNegate
+  };
+};
+} }
+
+namespace dynet {
 template<typename Scalar> struct scalar_logistic_sigmoid_op {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_logistic_sigmoid_op)
   DYNET_DEVICE_FUNC inline const Scalar operator() (const Scalar& x) const {

--- a/dynet/simd-functors.h
+++ b/dynet/simd-functors.h
@@ -71,30 +71,6 @@ struct functor_traits<dynet::const_minus_op<Scalar> > {
 } }
 
 namespace dynet {
-template<typename Scalar> struct scalar_negative_op {
-  EIGEN_EMPTY_STRUCT_CTOR(scalar_negative_op)
-  DYNET_DEVICE_FUNC inline const Scalar operator() (const Scalar& x) const {
-    return -x;
-  }
-  template <typename Packet>
-  DYNET_DEVICE_FUNC inline Packet packetOp(const Packet& x) const {
-    using namespace Eigen::internal;
-    return pnegate(x);
-  }
-};
-}
-
-namespace Eigen { namespace internal {
-template<typename Scalar>
-struct functor_traits<dynet::scalar_negative_op<Scalar> > {
-  enum {
-    Cost = NumTraits<Scalar>::MulCost * 2,
-    PacketAccess = packet_traits<Scalar>::HasNegate
-  };
-};
-} }
-
-namespace dynet {
 template<typename Scalar> struct scalar_logistic_sigmoid_op {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_logistic_sigmoid_op)
   DYNET_DEVICE_FUNC inline const Scalar operator() (const Scalar& x) const {

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -216,7 +216,9 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
 
     # identity function, but derivative is not propagated through it
     CExpression c_nobackprop "dynet::expr::nobackprop" (CExpression& x) #
-
+    # identity function, but derivative takes negative as propagated through it
+    CExpression c_flip_gradient "dynet::expr::flip_gradient" (CExpression& x) #
+    
     CExpression c_op_neg "dynet::expr::operator-" (CExpression& x) #
     CExpression c_op_add "dynet::expr::operator+" (CExpression& x, CExpression& y) #
     CExpression c_op_scalar_add "dynet::expr::operator+" (CExpression& x, float y) #

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -961,6 +961,7 @@ cpdef Expression random_bernoulli(dim, float p, float scale=1.0, int batch_size=
 cpdef Expression random_uniform(dim, float left, float right, int batch_size=1): return Expression.from_cexpr(_cg.version(), c_random_uniform(_cg.thisptr[0], CDim(dim, batch_size), left, right))
 
 cpdef Expression nobackprop(Expression x): return Expression.from_cexpr(x.cg_version, c_nobackprop(x.c()))
+cpdef Expression flip_gradient(Expression x): return Expression.from_cexpr(x.cg_version, c_flip_gradient(x.c()))
 
 # binary-exp
 cpdef Expression cdiv(Expression x, Expression y): ensure_freshness(y); return Expression.from_cexpr(x.cg_version, c_cdiv(x.c(), y.c()))

--- a/python/dynet_viz.py
+++ b/python/dynet_viz.py
@@ -252,6 +252,7 @@ def pick_batch(a, indices): return GVExpr('pick_batch', [a, indices], make_dim(l
 def hinge(x, index, m=1.0): return GVExpr('hinge', [x, index, m], copy_dim(x))
 
 def nobackprop(x): return GVExpr('nobackprop', [x], copy_dim(x))
+def flip_gradient(x): return GVExpr('flip_gradient', [x], copy_dim(x))
 
 # binary-exp
 def cdiv(x, y): return GVExpr('cdiv', [x,y], ensure_same_dim(x,y))


### PR DESCRIPTION
This topic is discussed in #318 . For learnings in domain separated networks, you will need flip_gradient operation, GRL (Gradient Reversal Layer) in different term,  in many purpose. 

In order to implement it, I changed these files (incl. python bindings) as the advice from the thread #318 , but if there's any unnecessary or wrong changes, please give me a feedback. I checked with my networks and it worked as expected. 

Thanks,
YJ