### PR TITLE
Fixed usage of HAVE_CUDA to prepare for multi-dev

### DIFF
--- a/dynet/tensor.cc
+++ b/dynet/tensor.cc
@@ -19,43 +19,60 @@ namespace dynet {
 
 ostream& operator<<(ostream& os, const Tensor& t) {
 #if HAVE_CUDA
-  vector<real> vt = as_vector(t);
-  Eigen::Map<Eigen::MatrixXf> m(&vt[0], t.d.rows(), t.d.cols());
-  os << m;
-#else
-  os << (*t);
+  if (t.device->type == DeviceType::GPU) {
+    vector<real> vt = as_vector(t);
+    Eigen::Map<Eigen::MatrixXf> m(&vt[0], t.d.rows(), t.d.cols());
+    os << m;
+  } else {
+#endif
+    os << (*t);
+#if HAVE_CUDA
+  }
 #endif
   return os;
 }
 
 real as_scalar(const Tensor& t) {
-  if (t.d.size() != 1) throw std::runtime_error("Input tensor has more than one element, cannot convert to scalar.");
+  if (t.d.size() != 1)
+    throw std::runtime_error("Input tensor has more than one element, cannot convert to scalar.");
 #if HAVE_CUDA
-  float res;
-  CUDA_CHECK(cudaMemcpy(&res, t.v, sizeof(float), cudaMemcpyDeviceToHost));
-  return res;
-#else
-  return t.v[0];
+  if (t.device->type == DeviceType::GPU) {
+    float res;
+    CUDA_CHECK(cudaMemcpy(&res, t.v, sizeof(float), cudaMemcpyDeviceToHost));
+    return res;
+  } else {
+#endif
+    return t.v[0];
+#if HAVE_CUDA
+  }
 #endif
 }
 
 vector<real> as_vector(const Tensor& v) {
   vector<real> res(v.d.size());
 #if HAVE_CUDA
-  CUDA_CHECK(cudaMemcpy(&res[0], v.v, sizeof(real) * res.size(), cudaMemcpyDeviceToHost));
-#else
-  memcpy(&res[0], v.v, sizeof(real) * res.size());
+  if (v.device->type == DeviceType::GPU) {
+    CUDA_CHECK(cudaMemcpy(&res[0], v.v, sizeof(real) * res.size(), cudaMemcpyDeviceToHost));
+  } else {
+#endif
+    memcpy(&res[0], v.v, sizeof(real) * res.size());
+#if HAVE_CUDA
+  }
 #endif
   return res;
 }
 
 float TensorTools::AccessElement(const Tensor& v, int index) {
 #if HAVE_CUDA
-  float ret;
-  cudaMemcpyAsync(&ret, &v.v[index], sizeof(real), cudaMemcpyDeviceToHost);
-  return ret;
-#else
-  return v.v[index];
+  if (v.device->type == DeviceType::GPU) {
+    float ret;
+    cudaMemcpyAsync(&ret, &v.v[index], sizeof(real), cudaMemcpyDeviceToHost);
+    return ret;
+  } else {
+#endif
+    return v.v[index];
+#if HAVE_CUDA
+  }
 #endif
 }
 
@@ -69,48 +86,72 @@ float TensorTools::AccessElement(const Tensor& v, const Dim& index) {
 
 void TensorTools::SetElement(const Tensor& v, int index, float value) {
 #if HAVE_CUDA
-  cudaMemcpyAsync(&v.v[index], &value, sizeof(real), cudaMemcpyHostToDevice);
-#else
-  v.v[index] = value;
+  if (v.device->type == DeviceType::GPU) {
+    cudaMemcpyAsync(&v.v[index], &value, sizeof(real), cudaMemcpyHostToDevice);
+  } else {
+#endif
+    v.v[index] = value;
+#if HAVE_CUDA
+  }
 #endif
 }
 
 void TensorTools::CopyElement(const Tensor& l, int lindex, Tensor& r, int rindex) {
 #if HAVE_CUDA
-  cudaMemcpyAsync(&r.v[rindex], &l.v[lindex], sizeof(real), cudaMemcpyDeviceToDevice);
-#else
-  r.v[rindex] = l.v[lindex];
+  if (l.device != r.device)
+    throw std::invalid_argument("TensorTools::CopyElement doesn't support inter-device copy yet");
+  if (l.device->type == DeviceType::GPU) {
+    cudaMemcpyAsync(&r.v[rindex], &l.v[lindex], sizeof(real), cudaMemcpyDeviceToDevice);
+  } else {
+#endif
+    r.v[rindex] = l.v[lindex];
+#if HAVE_CUDA
+  }
 #endif
 }
 
 void TensorTools::SetElements(const Tensor& v, const vector<float>& vec) {
 #if HAVE_CUDA
-  cudaMemcpyAsync(v.v, &vec[0], sizeof(real) * vec.size(), cudaMemcpyHostToDevice);
-#else
-  memcpy(v.v, &vec[0], sizeof(real) * vec.size());
+  if (v.device->type == DeviceType::GPU) {
+    cudaMemcpyAsync(v.v, &vec[0], sizeof(real) * vec.size(), cudaMemcpyHostToDevice);
+  } else {
+#endif
+    memcpy(v.v, &vec[0], sizeof(real) * vec.size());
+#if HAVE_CUDA
+  }
 #endif
 }
 
 void TensorTools::CopyElements(const Tensor& v, const Tensor& v_src) {
 #if HAVE_CUDA
-  cudaMemcpyAsync(v.v, v_src.v, sizeof(real) * v.d.size(), cudaMemcpyDeviceToDevice);
-#else
-  memcpy(v.v, v_src.v, sizeof(real) * v.d.size());
+  if (v.device != v_src.device)
+    throw std::invalid_argument("TensorTools::CopyElement doesn't support inter-device copy yet");
+  if (v.device->type == DeviceType::GPU) {
+    cudaMemcpyAsync(v.v, v_src.v, sizeof(real) * v.d.size(), cudaMemcpyDeviceToDevice);
+  } else {
+#endif
+    memcpy(v.v, v_src.v, sizeof(real) * v.d.size());
+#if HAVE_CUDA
+  }
 #endif
 }
 
 void TensorTools::Constant(Tensor& d, float c) {
 #if HAVE_CUDA
-  if (!c) {
-    CUDA_CHECK(cudaMemsetAsync(d.v, 0, d.d.size() * sizeof(float)));
+  if (d.device->type == DeviceType::GPU) {
+    if (!c) {
+      CUDA_CHECK(cudaMemsetAsync(d.v, 0, d.d.size() * sizeof(float)));
+    } else {
+      dynet::gpu::const_init(d.d.size(), c, d.v);
+    }
   } else {
-    dynet::gpu::const_init(d.d.size(), c, d.v);
-  }
-#else
-  if (!c) {
-    memset(d.v, c, d.d.size() * sizeof(float));
-  } else {
-    fill(d.v, d.v + d.d.size(), c);
+#endif
+    if (!c) {
+      memset(d.v, c, d.d.size() * sizeof(float));
+    } else {
+      fill(d.v, d.v + d.d.size(), c);
+    }
+#if HAVE_CUDA
   }
 #endif
 }
@@ -124,16 +165,20 @@ void TensorTools::Identity(Tensor& val) {
     throw std::runtime_error("Attempt to set a tensor that is not a square matrix to identity");
   size_t pos = 0;
 #if HAVE_CUDA
-  float* t = new float[val.d.size()];
-  for (size_t i = 0; i < val.d[0]; ++i)
-    for (size_t j = 0; j < val.d[1]; ++j)
-      t[pos++] = (i == j ? 1 : 0);
-  CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
-  delete[] t;
-#else
-  for (size_t i = 0; i < val.d[0]; ++i)
-    for (size_t j = 0; j < val.d[1]; ++j)
-      val.v[pos++] = (i == j ? 1 : 0);
+  if (val.device->type == DeviceType::GPU) {
+    float* t = new float[val.d.size()];
+    for (size_t i = 0; i < val.d[0]; ++i)
+      for (size_t j = 0; j < val.d[1]; ++j)
+        t[pos++] = (i == j ? 1 : 0);
+    CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
+    delete[] t;
+  } else {
+#endif
+    for (size_t i = 0; i < val.d[0]; ++i)
+      for (size_t j = 0; j < val.d[1]; ++j)
+        val.v[pos++] = (i == j ? 1 : 0);
+#if HAVE_CUDA
+  }
 #endif
 }
 
@@ -142,12 +187,16 @@ void TensorTools::RandomizeBernoulli(Tensor& val, real p, real scale) {
   bernoulli_distribution distribution(p);
   auto b = [&] {return distribution(*rndeng) * scale;};
 #if HAVE_CUDA
-  float* t = new float[val.d.size()];
-  generate(t, t + val.d.size(), b);
-  CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
-  delete[] t;
-#else
-  generate(val.v, val.v + val.d.size(), b);
+  if (val.device->type == DeviceType::GPU) {
+    float* t = new float[val.d.size()];
+    generate(t, t + val.d.size(), b);
+    CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
+    delete[] t;
+  } else {
+#endif
+    generate(val.v, val.v + val.d.size(), b);
+#if HAVE_CUDA
+  }
 #endif
 }
 
@@ -155,12 +204,16 @@ void TensorTools::RandomizeNormal(Tensor& val, real mean, real stddev) {
   normal_distribution<real> distribution(mean, stddev);
   auto b = [&] {return distribution(*rndeng);};
 #if HAVE_CUDA
-  float* t = new float[val.d.size()];
-  generate(t, t + val.d.size(), b);
-  CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
-  delete[] t;
-#else
-  generate(val.v, val.v + val.d.size(), b);
+  if (val.device->type == DeviceType::GPU) {
+    float* t = new float[val.d.size()];
+    generate(t, t + val.d.size(), b);
+    CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
+    delete[] t;
+  } else {
+#endif
+    generate(val.v, val.v + val.d.size(), b);
+#if HAVE_CUDA
+  }
 #endif
 }
 
@@ -168,21 +221,25 @@ void TensorTools::RandomizeUniform(Tensor& val, real left, real right) {
   uniform_real_distribution<real> distribution(left, right);
   auto b = [&] {return distribution(*rndeng);};
 #if HAVE_CUDA
-  float* t = new float[val.d.size()];
-  generate(t, t + val.d.size(), b);
-  CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
-  delete[] t;
-#else
-  generate(val.v, val.v + val.d.size(), b);
+  if (val.device->type == DeviceType::GPU) {
+    float* t = new float[val.d.size()];
+    generate(t, t + val.d.size(), b);
+    CUDA_CHECK(cudaMemcpy(val.v, t, sizeof(real) * val.d.size(), cudaMemcpyHostToDevice));
+    delete[] t;
+  } else {
+#endif
+    generate(val.v, val.v + val.d.size(), b);
+#if HAVE_CUDA
+  }
 #endif
 }
 
 void TensorTools::RandomizeOrthonormal(Tensor& val, real scale) {
+  if (val.d.nd != 2 || val.d[0] != val.d[1])
+    throw std::runtime_error("Attempt to set a tensor that is not a square matrix to an orthogonal matrix");
 #ifdef HAVE_CUDA
   throw std::runtime_error("Orthonormal initialization not implemented in CUDA (we welcome pull requests)");
 #else
-  if (val.d.nd != 2 || val.d[0] != val.d[1])
-    throw std::runtime_error("Attempt to set a tensor that is not a square matrix to an orthogonal matrix");
   RandomizeUniform(val, -1.0, 1.0);
   Eigen::JacobiSVD<Eigen::MatrixXf> svd(*val, Eigen::ComputeFullU | Eigen::ComputeThinV);
   *val = scale * svd.matrixU();
@@ -202,10 +259,10 @@ void Tensor::save(Archive& ar, const unsigned int ver) const {
     ar & boost::serialization::make_array(vc, d.size());
     free(vc);
   } else {
+#endif
     ar & boost::serialization::make_array(v, d.size());
+#ifdef HAVE_CUDA
   }
-#else
-  ar & boost::serialization::make_array(v, d.size());
 #endif
 }
 template<class Archive>
@@ -233,10 +290,10 @@ void Tensor::load(Archive& ar, const unsigned int ver) {
     CUDA_CHECK(cudaMemcpyAsync(v, vc, d.size() * sizeof(float), cudaMemcpyHostToDevice));
     free(vc);
   } else {
+#endif
     ar & boost::serialization::make_array(v, d.size());
+#ifdef HAVE_CUDA
   }
-#else
-  ar & boost::serialization::make_array(v, d.size());
 #endif
 }
 DYNET_SAVELOAD_IMPL(Tensor)

--- a/dynet/tensor.h
+++ b/dynet/tensor.h
@@ -181,18 +181,22 @@ struct Tensor {
   }
   /**
    * \brief Check for NaNs and infinite values
-   * \details This is very slow: use sparingly (it's linear in the number of elements). This raises a `std::runtime_error` exception if dynet was compiled with HAVE_CUDA because it's not implemented yet
+   * \details This is very slow: use sparingly (it's linear in the number of elements). This raises a `std::runtime_error` exception if the Tensor is on GPU because it's not implemented yet
    * \return Whether the tensor contains any invalid value
    */
   inline bool is_valid() const {
 #if HAVE_CUDA
     // TODO : replace this with a custom exception
-    throw std::runtime_error("is_valid() not implemented with HAVE_CUDA");
-#else
-    const size_t s = d.size();
-    for (unsigned i = 0; i < s; ++i)
-      if (std::isnan(v[i]) || std::isinf(v[i])) return false;
-    return true;
+    if (device->type == DeviceType::GPU) {
+      throw std::runtime_error("is_valid() not implemented on GPU");
+    } else {
+#endif
+      const size_t s = d.size();
+      for (unsigned i = 0; i < s; ++i)
+        if (std::isnan(v[i]) || std::isinf(v[i])) return false;
+      return true;
+#if HAVE_CUDA
+    }
 #endif
   }
 


### PR DESCRIPTION
Partially addresses https://github.com/clab/dynet/issues/92

Now HAVE_CUDA only is used to decide whether to compile additional GPU code, and should never change functionality on CPU.