### PR TITLE
dynet-84. Add macro interfaces for serialization, refactor code.

### DIFF
--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -5,8 +5,6 @@
 
 #include <boost/serialization/vector.hpp>
 
-#include "dynet/io-macros.h"
-
 using namespace std;
 
 namespace dynet {
@@ -54,12 +52,7 @@ Expression StandardSoftmaxBuilder::full_log_distribution(const Expression& rep) 
   return log(softmax(affine_transform({b, w, rep})));
 }
 
-template<class Archive>
-void StandardSoftmaxBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<SoftmaxBuilder>(*this);
-  ar & p_w;
-  ar & p_b;
-}
+DYNET_SERIALIZE_COMMIT(StandardSoftmaxBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(SoftmaxBuilder, p_w, p_b))
 DYNET_SERIALIZE_IMPL(StandardSoftmaxBuilder)
 
 ClassFactoredSoftmaxBuilder::ClassFactoredSoftmaxBuilder() {}
@@ -220,20 +213,8 @@ void ClassFactoredSoftmaxBuilder::read_cluster_file(const std::string& cluster_f
   cerr << "Read " << wc << " words in " << cdict.size() << " clusters (" << scs << " singleton clusters)\n";
 }
 
-template<class Archive>
-void ClassFactoredSoftmaxBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<SoftmaxBuilder>(*this);
-  ar & cdict;
-  ar & widx2cidx;
-  ar & widx2cwidx;
-  ar & cidx2words;
-  ar & singleton_cluster;
-  ar & p_r2c;
-  ar & p_cbias;
-  ar & p_rc2ws;
-  ar & p_rcwbiases;
-}
-
+DYNET_SERIALIZE_COMMIT(ClassFactoredSoftmaxBuilder,
+		       DYNET_SERIALIZE_DERIVED_DEFINE(SoftmaxBuilder, cdict, widx2cidx, widx2cwidx, cidx2words, singleton_cluster, p_r2c, p_cbias, p_rc2ws, p_rcwbiases))
 
 void ClassFactoredSoftmaxBuilder::initialize_expressions() {
   for (unsigned c = 0; c < p_rc2ws.size(); ++c) {

--- a/dynet/cfsm-builder.h
+++ b/dynet/cfsm-builder.h
@@ -7,6 +7,7 @@
 #include "dynet/dynet.h"
 #include "dynet/expr.h"
 #include "dynet/dict.h"
+#include "dynet/io-macros.h"
 
 namespace dynet {
 
@@ -27,9 +28,7 @@ public:
   // The ith dimension gives log p(w_i | rep). This function may be SLOW. Avoid if possible.
   virtual expr::Expression full_log_distribution(const expr::Expression& rep) = 0;
 
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int) {}
+  DYNET_SERIALIZE_COMMIT_EMPTY()
 };
 
 class StandardSoftmaxBuilder : public SoftmaxBuilder {
@@ -48,9 +47,7 @@ private:
   expr::Expression b;
   ComputationGraph* pcg;
 
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 // helps with implementation of hierarchical softmax
@@ -103,10 +100,7 @@ class ClassFactoredSoftmaxBuilder : public SoftmaxBuilder {
   expr::Expression cbias;
   std::vector<expr::Expression> rc2ws;
   std::vector<expr::Expression> rc2biases;
-
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 }  // namespace dynet
 

--- a/dynet/dict.cc
+++ b/dynet/dict.cc
@@ -4,16 +4,6 @@
 #include <vector>
 #include <sstream>
 
-#include <boost/version.hpp>
-#include <boost/serialization/vector.hpp>
-#include <boost/serialization/string.hpp>
-#if BOOST_VERSION >= 105600
-#include <boost/serialization/unordered_map.hpp>
-#endif
-
-#include "dynet/io-macros.h"
-
-
 using namespace std;
 
 namespace dynet {
@@ -44,17 +34,14 @@ void read_sentence_pair(const std::string& line, std::vector<int>& s, Dict& sd, 
   }
 }
 
-template<class Archive> void Dict::serialize(Archive& ar, const unsigned int) {
 #if BOOST_VERSION >= 105600
-  ar & frozen;
-  ar & map_unk;
-  ar & unk_id;
-  ar & words_;
-  ar & d_;
+  DYNET_SERIALIZE_COMMIT(Dict, DYNET_SERIALIZE_DEFINE(frozen, map_unk, unk_id, words_, d_))
 #else
-  throw std::invalid_argument("Serializing dictionaries is only supported on versions of boost 1.56 or higher");
+  template<class Archive>
+  void Dict::serialize(Archive& ar, const unsigned int) {
+    throw std::invalid_argument("Serializing dictionaries is only supported on versions of boost 1.56 or higher");
+  }
 #endif
-}
 DYNET_SERIALIZE_IMPL(Dict)
 
 } // namespace dynet

--- a/dynet/dict.h
+++ b/dynet/dict.h
@@ -8,6 +8,8 @@
 #include <iostream>
 #include <stdexcept>
 
+#include "dynet/io-macros.h"
+
 namespace boost { namespace serialization { class access; } }
 
 namespace dynet {
@@ -78,10 +80,7 @@ private:
   std::vector<std::string> words_;
   Map d_;
 
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
-
+  DYNET_SERIALIZE_DECLARE()
 };
 
 std::vector<int> read_sentence(const std::string& line, Dict& sd);

--- a/dynet/dim.cc
+++ b/dynet/dim.cc
@@ -2,8 +2,6 @@
 
 #include <iostream>
 
-#include "dynet/io-macros.h"
-
 using namespace std;
 
 namespace dynet {
@@ -25,11 +23,7 @@ ostream& operator<<(ostream& os, const vector<Dim>& ds) {
   return os << ']';
 }
 
-template<class Archive>
-void Dim::serialize(Archive& ar, const unsigned int) {
-  ar & nd;
-  ar & d;
-}
+DYNET_SERIALIZE_COMMIT(Dim, DYNET_SERIALIZE_DEFINE(nd, d))
 DYNET_SERIALIZE_IMPL(Dim)
 
 } // namespace dynet

--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -16,6 +16,8 @@
 #include <cstring>
 #include <vector>
 
+#include "dynet/io-macros.h"
+
 /**
  * \ingroup dim
  * Maximum number of dimensions supported by dynet : 7
@@ -202,8 +204,7 @@ struct Dim {
   unsigned int nd; /**< Number of dimensions */
   unsigned int bd; /**< Batch dimension */
 private:
-  friend class boost::serialization::access;
-  template<class Archive> void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 //static_assert(std::is_trivially_copyable<Dim>::value, "Dim must be trivially copyable");

--- a/dynet/hsm-builder.cc
+++ b/dynet/hsm-builder.cc
@@ -5,13 +5,6 @@
 #include <cassert>
 #include <sstream>
 
-#include <boost/serialization/vector.hpp>
-#if BOOST_VERSION >= 105600
-#include <boost/serialization/unordered_map.hpp>
-#endif
-
-#include "dynet/io-macros.h"
-
 #undef assert
 #define assert(x) {}
 
@@ -183,18 +176,14 @@ string Cluster::toString() const {
   return ss.str();
 }
 
-template<class Archive>
-void Cluster::serialize(Archive& ar, const unsigned int) {
-#if BOOST_VERSION >= 105600  
-  ar & rep_dim;
-  ar & children;
-  ar & path;
-  ar & terminals;
-  ar & word2ind;
+#if BOOST_VERSION >= 105600
+  DYNET_SERIALIZE_COMMIT(Cluster, DYNET_SERIALIZE_DEFINE(rep_dim, children, path, terminals, word2ind))
 #else
-  throw std::invalid_argument("Serializing clusters is only supported on versions of boost 1.56 or higher");
+  template<class Archive>
+  void Cluster::serialize(Archive& ar, const unsigned int) {
+    throw std::invalid_argument("Serializing clusters is only supported on versions of boost 1.56 or higher");
+  }
 #endif
-}
 DYNET_SERIALIZE_IMPL(Cluster)
 
 HierarchicalSoftmaxBuilder::HierarchicalSoftmaxBuilder(unsigned rep_dim,

--- a/dynet/hsm-builder.h
+++ b/dynet/hsm-builder.h
@@ -8,6 +8,7 @@
 #include "dynet/expr.h"
 #include "dynet/dict.h"
 #include "dynet/cfsm-builder.h"
+#include "dynet/io-macros.h"
 
 namespace dynet {
 
@@ -26,9 +27,7 @@ private:
   unsigned output_size;
 
   expr::Expression predict(expr::Expression h, ComputationGraph& cg) const;
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 
 public:
   Cluster();

--- a/dynet/io-macros.h
+++ b/dynet/io-macros.h
@@ -6,6 +6,20 @@
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 
+#if BOOST_VERSION >= 105600
+#include <boost/serialization/unordered_map.hpp>
+#endif
+
+#ifndef __CUDACC__
+#include <boost/serialization/vector.hpp>
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/serialization.hpp>
+#include <boost/serialization/split_member.hpp>
+#endif
+
+#define MAX_SERIALIZE_VERSION 1024
+
 #define DYNET_SERIALIZE_IMPL(MyClass) \
   template void MyClass::serialize<boost::archive::text_oarchive>(boost::archive::text_oarchive &ar, const unsigned int); \
   template void MyClass::serialize<boost::archive::text_iarchive>(boost::archive::text_iarchive &ar, const unsigned int); \
@@ -17,5 +31,113 @@
   template void MyClass::load<boost::archive::text_iarchive>(boost::archive::text_iarchive &ar, const unsigned int); \
   template void MyClass::save<boost::archive::binary_oarchive>(boost::archive::binary_oarchive &ar, const unsigned int) const; \
   template void MyClass::load<boost::archive::binary_iarchive>(boost::archive::binary_iarchive &ar, const unsigned int);
+
+#define DYNET_PP_NARG_(x64, x63, x62, x61, x60, x59, x58, x57, x56, x55, x54, x53, x52, x51, x50, x49, x48, x47, x46, x45, x44, x43, x42, x41, x40, x39, x38, x37, x36, x35, x34, x33, x32, x31, x30, x29, x28, x27, x26, x25, x24, x23, x22, x21, x20, x19, x18, x17, x16, x15, x14, x13, x12, x11, x10, x9, x8, x7, x6, x5, x4, x3, x2, x1, n, ...) n
+
+// currently only support max 64 number of parameters
+#define DYNET_PP_NARG(...) DYNET_PP_NARG_(__VA_ARGS__, 64, 63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+
+// for BOOST_PP_REPEAT usage, wrap the parameters with PP_NARG
+#define DYNET_PP_FOREACH_ARRAY( ... )  ( DYNET_PP_NARG(__VA_ARGS__) , ( __VA_ARGS__ ) )
+
+// apply A to all following parameters
+#define DYNET_PP_FOREACH( A, ... )  BOOST_PP_REPEAT(DYNET_PP_NARG(__VA_ARGS__), A, DYNET_PP_FOREACH_ARRAY(__VA_ARGS__) )
+
+#define DYNET_ARCHIVE(z, n, data) \
+  ar & BOOST_PP_ARRAY_ELEM(n, data);
+
+#define DYNET_UNFOLD(z, n, data) \
+  BOOST_PP_ARRAY_ELEM(n, data);
+
+#define DYNET_FUNCTOR(z, n, data) \
+  data;
+
+// declare INTERFACE 
+#define DYNET_SERIALIZE_DECLARE() \
+  friend class boost::serialization::access; \
+  template <class Archive> \
+  void serialize(Archive &ar, const unsigned int);
+
+// split declare INTERFACE
+#define DYNET_SERIALIZE_SPLIT_DECLARE() \
+  friend class boost::serialization::access; \
+  template <class Archive> \
+  void save(Archive & ar, const unsigned int) const; \
+  template <class Archive> \
+  void load(Archive & ar, const unsigned int); \
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
+
+// INTERFACE: empty serialization definition macro
+#define DYNET_SERIALIZE_COMMIT_EMPTY(...) \
+  friend class boost::serialization::access; \
+  template <class Archive> \
+  void serialize(Archive & ar, const unsigned int version) {}
+
+// INTERFACE: commit serialization operation macro
+#define DYNET_SERIALIZE_COMMIT(MyClass, ...) \
+  template <class Archive> \
+  void MyClass::serialize(Archive & ar, const unsigned int version) { \
+    DYNET_PP_FOREACH(DYNET_UNFOLD, __VA_ARGS__) \
+  }
+
+// INTERFACE: commit serialization save operation macro
+#define DYNET_SERIALIZE_SAVE_COMMIT(MyClass, ...) \
+  template <class Archive> \
+  void MyClass::save(Archive & ar, const unsigned int version) const { \
+    DYNET_PP_FOREACH(DYNET_UNFOLD, __VA_ARGS__) \
+  }
+
+// INTERFACE: commit serialization load operation macro
+#define DYNET_SERIALIZE_LOAD_COMMIT(MyClass, FUNC, ...) \
+  template <class Archive> \
+  void MyClass::load(Archive & ar, const unsigned int version) { \
+    DYNET_PP_FOREACH(DYNET_UNFOLD, __VA_ARGS__) \
+    FUNC; \
+  }
+
+// INTERFACE: specify serialize version macro
+#define DYNET_VERSION_DEFINE(T, VERSION) BOOST_CLASS_VERSION(T, VERSION)
+
+// INTERFACE: serialize definition macro
+#define DYNET_SERIALIZE_DEFINE(...) \
+  DYNET_PP_FOREACH(DYNET_ARCHIVE, __VA_ARGS__)
+
+// INTERFACE: serialize definition macro for derived class
+#define DYNET_SERIALIZE_DERIVED_DEFINE(T, ...) \
+  ar & boost::serialization::base_object<T>(*this); \
+  DYNET_PP_FOREACH(DYNET_ARCHIVE, __VA_ARGS__)
+
+// INTERFACE: serialize definition macro for derived class which is equal to base class
+#define DYNET_SERIALIZE_DERIVED_EQ_DEFINE(T) \
+  ar & boost::serialization::base_object<T>(*this);
+
+// INTERFACE: serialize definition with version macro, l <= version < r
+#define DYNET_VERSION_SERIALIZE_DEFINE(l, r, ...) \
+  !(l >= 0) ? (void)0 :                           \
+  !(r >= 0) ? (void)0 :                           \
+  !(l < r) ? (void)0 :                            \
+  ({ if (version >= l && version < r) {           \
+    DYNET_PP_FOREACH(DYNET_ARCHIVE, __VA_ARGS__)  \
+  } })
+
+// INTERFACE: serialize definition with version macro for derived class, l <= version < r
+#define DYNET_VERSION_SERIALIZE_DERIVED_DEFINE(T, l, r, ...)  \
+  !(l >= 0) ? (void)0 :                                       \
+  !(r >= 0) ? (void)0 :                                       \
+  !(l < r) ? (void)0 :                                        \
+  ({ if (version >= l && version < r) {                       \
+    ar & boost::serialization::base_object<T>(*this);         \
+    DYNET_PP_FOREACH(DYNET_ARCHIVE, __VA_ARGS__)              \
+  } })
+
+// INTERFACE: serialize definition macro for non-intrusive impl
+#define DYNET_NINTRUSIVE_SERIALIZE_DEFINE(param, ...)       \
+namespace boost {                                           \
+namespace serialization {                                   \
+  template <class Archive>                                  \
+  void serialize(Archive & ar, param, const unsigned int) { \
+    DYNET_PP_FOREACH(DYNET_ARCHIVE, __VA_ARGS__)            \
+  }                                                         \
+} /* namespace serialization */ } /* namespace boost */
 
 #endif

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -6,12 +6,7 @@
 #include <vector>
 #include <iostream>
 
-#include <boost/serialization/utility.hpp>
-#include <boost/serialization/vector.hpp>
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
 #include "dynet/nodes.h"
-#include "dynet/io-macros.h"
 
 using namespace std;
 using namespace dynet::expr;
@@ -316,20 +311,9 @@ void LSTMBuilder::disable_dropout() {
   dropout_rate_c = 0.f;
 }
 
-template<class Archive>
-void LSTMBuilder::serialize(Archive& ar, const unsigned int version ) {
-  ar & boost::serialization::base_object<RNNBuilder>(*this);
-  ar & params;
-  ar & layers;
-  ar & dropout_rate;
-  // Backward compatibility
-  if (version > 0) {
-    ar & dropout_rate_h;
-    ar & dropout_rate_c;
-    ar & input_dim;
-    ar & hid;
-  }
-}
+DYNET_SERIALIZE_COMMIT(LSTMBuilder,
+		       DYNET_SERIALIZE_DERIVED_DEFINE(RNNBuilder, params, layers, dropout_rate),
+		       DYNET_VERSION_SERIALIZE_DEFINE(1, MAX_SERIALIZE_VERSION, dropout_rate_h, dropout_rate_c, input_dim, hid))
 
 DYNET_SERIALIZE_IMPL(LSTMBuilder);
 
@@ -564,16 +548,7 @@ void VanillaLSTMBuilder::disable_dropout() {
   dropout_rate_h = 0.f;
 }
 
-template<class Archive>
-void VanillaLSTMBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<RNNBuilder>(*this);
-  ar & params;
-  ar & layers;
-  ar & dropout_rate;
-  ar & dropout_rate_h;
-  ar & hid;
-  ar & input_dim;
-}
+DYNET_SERIALIZE_COMMIT(VanillaLSTMBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(RNNBuilder, params, layers, dropout_rate, dropout_rate_h, hid, input_dim))
 DYNET_SERIALIZE_IMPL(VanillaLSTMBuilder);
 
 } // namespace dynet

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -154,9 +154,7 @@ public:
   float dropout_rate_h = 0.f, dropout_rate_c = 0.f;
 
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
   ComputationGraph  *_cg;
 
 };
@@ -290,9 +288,7 @@ public:
 
 
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
   ComputationGraph* _cg; // Pointer to current cg
 
 };

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <boost/serialization/export.hpp>
 
+#include "dynet/io-macros.h"
 #include "dynet/tensor.h"
 #include "dynet/weight-decay.h"
 
@@ -63,9 +64,7 @@ struct ParameterStorageBase {
    */
   virtual size_t size() const = 0;
   virtual ~ParameterStorageBase();
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& /* ar */, const unsigned int) {}
+  DYNET_SERIALIZE_COMMIT_EMPTY()
 };
 
 // represents parameters (e.g., a weight matrix) that will be optimized
@@ -115,9 +114,7 @@ private:
   explicit ParameterStorage(const Dim& d, float minmax); // initialize with ~U(-minmax,+minmax)
   // or Glorot initialization if minmax = 0
   explicit ParameterStorage(const Dim& d, const ParameterInit & init); // initialize with custom initializer
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 // represents a matrix/vector embedding of a discrete set
@@ -196,12 +193,7 @@ private:
   LookupParameterStorage() {}
   LookupParameterStorage(unsigned n, const Dim& d);
   LookupParameterStorage(unsigned n, const Dim& d, const ParameterInit & init);
-  friend class boost::serialization::access;
-  template<class Archive>
-  void save(Archive& ar, const unsigned int) const;
-  template<class Archive>
-  void load(Archive& ar, const unsigned int);
-  BOOST_SERIALIZATION_SPLIT_MEMBER()
+  DYNET_SERIALIZE_SPLIT_DECLARE()
 };
 
 class Model;
@@ -265,9 +257,7 @@ struct Parameter {
   bool is_updated();
 
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -325,9 +315,7 @@ struct LookupParameter {
   bool is_updated();
 
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -654,10 +642,7 @@ public:
 
   L2WeightDecay weight_decay;
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
-
+  DYNET_SERIALIZE_DECLARE()
   std::vector<ParameterStorageBase*> all_params;
   std::vector<ParameterStorage*> params;
   std::vector<LookupParameterStorage*> lookup_params;
@@ -668,7 +653,7 @@ private:
   std::vector<unsigned> updated_lookup_params;
 
   mutable float* gradient_norm_scratch;
-};
+}; // class Model
 
 void save_dynet_model(std::string filename, Model* model);
 void load_dynet_model(std::string filename, Model* model);

--- a/dynet/rnn-state-machine.cc
+++ b/dynet/rnn-state-machine.cc
@@ -3,7 +3,6 @@
 #include <iostream>
 
 #include "dynet/dynet.h"
-#include "dynet/io-macros.h"
 
 using namespace std;
 
@@ -14,10 +13,7 @@ void RNNStateMachine::failure(RNNOp op) {
   throw std::invalid_argument(oss.str());
 }
 
-template <class Archive>
-void RNNStateMachine::serialize(Archive& ar, const unsigned int) {
-  ar & q_;
-}
+DYNET_SERIALIZE_COMMIT(RNNStateMachine, DYNET_SERIALIZE_DEFINE(q_))
 DYNET_SERIALIZE_IMPL(RNNStateMachine)
 
 } // namespace dynet

--- a/dynet/rnn-state-machine.h
+++ b/dynet/rnn-state-machine.h
@@ -1,7 +1,7 @@
 #ifndef DYNET_RNN_STATE_MACHINE_H_
 #define DYNET_RNN_STATE_MACHINE_H_
 
-namespace boost { namespace serialization { class access; } }
+#include "dynet/io-macros.h"
 
 namespace dynet {
 
@@ -39,9 +39,7 @@ class RNNStateMachine {
  private:
   RNNState q_;
 
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 } // namespace dynet

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -1,16 +1,10 @@
 #include "dynet/rnn.h"
-#include "dynet/io-macros.h"
 
 #include <string>
 #include <cassert>
 #include <vector>
 #include <fstream>
 #include <iostream>
-#include <boost/archive/binary_oarchive.hpp>
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/vector.hpp>
-
 
 #include "dynet/nodes.h"
 #include "dynet/expr.h"
@@ -33,13 +27,7 @@ void RNNBuilder::load_parameters_pretraining(const string& fname) {
   throw std::runtime_error("RNNBuilder::load_parameters_pretraining not overridden.");
 }
 
-template<class Archive>
-void RNNBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & cur;
-  ar & head;
-  ar & sm;
-} 
-
+DYNET_SERIALIZE_COMMIT(RNNBuilder, DYNET_SERIALIZE_DEFINE(cur, head, sm))
 DYNET_SERIALIZE_IMPL(RNNBuilder)
 
 SimpleRNNBuilder::SimpleRNNBuilder(unsigned layers,
@@ -191,13 +179,7 @@ void SimpleRNNBuilder::load_parameters_pretraining(const string& fname) {
   }
 }
 
-template<class Archive>
-void SimpleRNNBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<RNNBuilder>(*this);
-  ar & params;
-  ar & layers;
-  ar & lagging;
-}
+DYNET_SERIALIZE_COMMIT(SimpleRNNBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(RNNBuilder, params, layers, lagging))
 DYNET_SERIALIZE_IMPL(SimpleRNNBuilder)
 
 } // namespace dynet

--- a/dynet/rnn.h
+++ b/dynet/rnn.h
@@ -14,6 +14,7 @@
 #include "dynet/dynet.h"
 #include "dynet/rnn-state-machine.h"
 #include "dynet/expr.h"
+#include "dynet/io-macros.h"
 
 using namespace dynet::expr;
 
@@ -283,9 +284,7 @@ private:
   RNNStateMachine sm;
   std::vector<RNNPointer> head; // head[i] returns the head position
 
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -364,25 +363,13 @@ private:
 
   unsigned layers;
   bool lagging;
-
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
-
+ 
+  DYNET_SERIALIZE_DECLARE()
 };
 
 } // namespace dynet
 
-
-namespace boost {
-namespace serialization {
-template<class Archive>
-void serialize(Archive& ar, dynet::RNNPointer& p, const unsigned int)
-{
-  ar & p.t;
-}
-} // namespace serialization
-} // namespace boost
+DYNET_NINTRUSIVE_SERIALIZE_DEFINE(dynet::RNNPointer & p, p.t)
 
 BOOST_CLASS_EXPORT_KEY(dynet::RNNBuilder)
 BOOST_CLASS_EXPORT_KEY(dynet::SimpleRNNBuilder)

--- a/dynet/shadow-params.cc
+++ b/dynet/shadow-params.cc
@@ -1,12 +1,11 @@
 #include "dynet/dynet.h"
 
-#include <boost/serialization/vector.hpp>
-
 #include "dynet/shadow-params.h"
 #include "dynet/tensor.h"
 #include "dynet/aligned-mem-pool.h"
 #include "dynet/model.h"
-#include "dynet/io-macros.h"
+
+#define LOAD_INIT_FUNC() initialize_lookups()
 
 using namespace std;
 
@@ -50,21 +49,11 @@ vector<ShadowLookupParameters> allocate_shadow_lookup_parameters(const Model& m)
   return v;
 }
 
-template<class Archive>
-void ShadowParameters::serialize(Archive& ar, const unsigned int) {
-  ar & h;
-}
+DYNET_SERIALIZE_COMMIT(ShadowParameters, DYNET_SERIALIZE_DEFINE(h))
 DYNET_SERIALIZE_IMPL(ShadowParameters)
 
-template<class Archive>
-void ShadowLookupParameters::save(Archive& ar, const unsigned int) const {
-  ar << h;
-}
-template<class Archive>
-void ShadowLookupParameters::load(Archive& ar, const unsigned int) {
-  ar >> h;
-  initialize_lookups();
-}
+DYNET_SERIALIZE_SAVE_COMMIT(ShadowLookupParameters, DYNET_SERIALIZE_DEFINE(h))
+DYNET_SERIALIZE_LOAD_COMMIT(ShadowLookupParameters, LOAD_INIT_FUNC(), DYNET_SERIALIZE_DEFINE(h))
 DYNET_SAVELOAD_IMPL(ShadowLookupParameters)
 
 } // namespace dynet

--- a/dynet/shadow-params.h
+++ b/dynet/shadow-params.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include "dynet/tensor.h"
+#include "dynet/io-macros.h"
 
 // if your learner needs to keep track of an extra set of values (one per
 // parameter), use the Shadow classes. this can be used to implement, e.g.,
@@ -19,9 +20,7 @@ struct ShadowParameters {
   explicit ShadowParameters(const ParameterStorage& p);
   Tensor h;
  private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 struct ShadowLookupParameters {
@@ -31,12 +30,7 @@ struct ShadowLookupParameters {
   std::vector<Tensor> h;
  private:
   void initialize_lookups();
-  friend class boost::serialization::access;
-  template<class Archive>
-  void save(Archive& ar, const unsigned int) const;
-  template<class Archive>
-  void load(Archive& ar, const unsigned int);
-  BOOST_SERIALIZATION_SPLIT_MEMBER()
+  DYNET_SERIALIZE_SPLIT_DECLARE()
 };
 
 // one per element in model.parameters_list

--- a/dynet/tensor.cc
+++ b/dynet/tensor.cc
@@ -11,7 +11,6 @@
 #include "dynet/gpu-ops.h"
 #include "dynet/cuda.h"
 #endif
-#include "dynet/io-macros.h"
 
 using namespace std;
 

--- a/dynet/tensor.h
+++ b/dynet/tensor.h
@@ -12,13 +12,11 @@
 #include <sstream>
 #include <stdexcept>
 
-#include <boost/serialization/split_member.hpp>
-#include <boost/serialization/version.hpp>
-
 #include "dynet/dim.h"
 #include "dynet/globals.h"
 #include "dynet/aligned-mem-pool.h"
 #include "dynet/devices.h"
+#include "dynet/io-macros.h"
 
 #if HAVE_CUDA
 #include <cuda.h>
@@ -251,12 +249,7 @@ struct Tensor {
   DeviceMempool mem_pool;
 
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void save(Archive& ar, const unsigned int ver) const;
-  template<class Archive>
-  void load(Archive& ar, const unsigned int ver);
-  BOOST_SERIALIZATION_SPLIT_MEMBER()
+  DYNET_SERIALIZE_SPLIT_DECLARE()
 };
 
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 0>> Tensor::t<0>() {

--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -6,7 +6,6 @@
 // #include "dynet/gpu-ops.h"
 #include "dynet/param-nodes.h"
 #include "dynet/weight-decay.h"
-#include "dynet/io-macros.h"
 
 // Macros for defining parameter update functions
 #ifdef __CUDACC__
@@ -317,59 +316,27 @@ void AdamTrainer::alloc_impl() {
 // BOOST_CLASS_EXPORT_IMPLEMENT(dynet::RmsPropTrainer)
 // BOOST_CLASS_EXPORT_IMPLEMENT(dynet::AdamTrainer)
 
-template<class Archive>
-void Trainer::serialize(Archive& ar, const unsigned int) {
-  ar & eta0 & eta & eta_decay & epoch;
-  ar & clipping_enabled & clip_threshold & clips & updates;
-  ar & aux_allocated;
-  ar & model;
-}
+DYNET_SERIALIZE_COMMIT(Trainer, DYNET_SERIALIZE_DEFINE(eta0, eta, eta_decay, epoch,
+						       clipping_enabled, clip_threshold, clips, updates,
+						       aux_allocated, model))
 DYNET_SERIALIZE_IMPL(Trainer)
 
-template<class Archive>
-void SimpleSGDTrainer::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<Trainer>(*this);
-}
+DYNET_SERIALIZE_COMMIT(SimpleSGDTrainer, DYNET_SERIALIZE_DERIVED_EQ_DEFINE(Trainer))
 DYNET_SERIALIZE_IMPL(SimpleSGDTrainer)
 
-template<class Archive>
-void MomentumSGDTrainer::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<Trainer>(*this);
-  ar & momentum;
-  ar & vp & vlp;
-}
+DYNET_SERIALIZE_COMMIT(MomentumSGDTrainer, DYNET_SERIALIZE_DERIVED_DEFINE(Trainer, momentum, vp, vlp))
 DYNET_SERIALIZE_IMPL(MomentumSGDTrainer)
 
-template<class Archive>
-void AdagradTrainer::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<Trainer>(*this);
-  ar & epsilon;
-  ar & vp & vlp;
-}
+DYNET_SERIALIZE_COMMIT(AdagradTrainer, DYNET_SERIALIZE_DERIVED_DEFINE(Trainer, epsilon, vp, vlp))
 DYNET_SERIALIZE_IMPL(AdagradTrainer)
 
-template<class Archive>
-void AdadeltaTrainer::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<Trainer>(*this);
-  ar & epsilon & rho;
-  ar & hg & hlg & hd & hld;
-}
+DYNET_SERIALIZE_COMMIT(AdadeltaTrainer, DYNET_SERIALIZE_DERIVED_DEFINE(Trainer, epsilon, rho, hg, hlg, hd, hld))
 DYNET_SERIALIZE_IMPL(AdadeltaTrainer)
 
-template<class Archive>
-void RmsPropTrainer::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<Trainer>(*this);
-  ar & epsilon & rho;
-  ar & hg & hlg;
-}
+DYNET_SERIALIZE_COMMIT(RmsPropTrainer, DYNET_SERIALIZE_DERIVED_DEFINE(Trainer, epsilon, rho, hg, hlg))
 DYNET_SERIALIZE_IMPL(RmsPropTrainer)
 
-template<class Archive>
-void AdamTrainer::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<Trainer>(*this);
-  ar & beta_1 & beta_2 & epsilon;
-  ar & m & lm & v & lv;
-}
+DYNET_SERIALIZE_COMMIT(AdamTrainer, DYNET_SERIALIZE_DERIVED_DEFINE(Trainer, beta_1, beta_2, epsilon, m, lm, v, lv))
 DYNET_SERIALIZE_IMPL(AdamTrainer)
 
 #endif

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -18,6 +18,7 @@
 
 #include "dynet/model.h"
 #include "dynet/shadow-params.h"
+#include "dynet/io-macros.h"
 
 #define DYNET_TRAINER_DEFINE_DEV_IMPL() \
   void update_params(real scale, real gscale, size_t idx) override; \
@@ -140,9 +141,7 @@ struct Trainer {
   virtual void update_lookup_params(real scale, real gscale, size_t idx) = 0;
 
  private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -168,9 +167,7 @@ struct SimpleSGDTrainer : public Trainer {
   DYNET_TRAINER_DEFINE_DEV_IMPL()
  private:
   SimpleSGDTrainer() {}
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -208,9 +205,7 @@ struct MomentumSGDTrainer : public Trainer {
   //std::unordered_map<LookupParameterStorage*, std::unordered_map<unsigned, Tensor>> vl;
  private:
   MomentumSGDTrainer() {}
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -243,9 +238,7 @@ struct AdagradTrainer : public Trainer {
   std::vector<ShadowLookupParameters> vlp;
  private:
   AdagradTrainer() {}
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -283,9 +276,7 @@ struct AdadeltaTrainer : public Trainer {
   std::vector<ShadowLookupParameters> hld;
  private:
   AdadeltaTrainer() {}
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -319,9 +310,7 @@ struct RmsPropTrainer : public Trainer {
   std::vector<std::vector<real> > hlg;
  private:
   RmsPropTrainer() {}
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 /**
@@ -361,9 +350,7 @@ struct AdamTrainer : public Trainer {
   std::vector<ShadowLookupParameters> lv;
  private:
   AdamTrainer() {}
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 } // namespace dynet

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -5,7 +5,6 @@
 
 #include "dynet/nodes.h"
 #include "dynet/treelstm.h"
-#include "dynet/io-macros.h"
 
 using namespace std;
 using namespace dynet;
@@ -26,11 +25,7 @@ std::vector<Expression> TreeLSTMBuilder::final_s() const { throw std::runtime_er
 unsigned TreeLSTMBuilder::num_h0_components() const { throw std::runtime_error("num_h0_components() not a valid function for TreeLSTMBuilder"); }
 void TreeLSTMBuilder::copy(const RNNBuilder&) { throw std::runtime_error("copy() not a valid function for TreeLSTMBuilder"); }
 
-template<class Archive>
-void TreeLSTMBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<RNNBuilder>(*this);
-}
-
+DYNET_SERIALIZE_COMMIT(TreeLSTMBuilder, DYNET_SERIALIZE_DERIVED_EQ_DEFINE(RNNBuilder))
 DYNET_SERIALIZE_IMPL(TreeLSTMBuilder);
 
 // See "Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks"
@@ -287,15 +282,7 @@ void NaryTreeLSTMBuilder::copy(const RNNBuilder & rnn) {
   }
 }
 
-template<class Archive>
-void NaryTreeLSTMBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<TreeLSTMBuilder>(*this);
-  ar & params;
-  ar & lparams;
-  ar & layers;
-  ar & N;
-}
-
+DYNET_SERIALIZE_COMMIT(NaryTreeLSTMBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(TreeLSTMBuilder, params, lparams, layers, N))
 DYNET_SERIALIZE_IMPL(NaryTreeLSTMBuilder);
 
 UnidirectionalTreeLSTMBuilder::UnidirectionalTreeLSTMBuilder(unsigned layers,
@@ -331,12 +318,7 @@ Expression UnidirectionalTreeLSTMBuilder::add_input(int id, vector<int> children
   return embedding;
 }
 
-template<class Archive>
-void UnidirectionalTreeLSTMBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<TreeLSTMBuilder>(*this);
-  ar & node_builder;
-}
-
+DYNET_SERIALIZE_COMMIT(UnidirectionalTreeLSTMBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(TreeLSTMBuilder, node_builder))
 DYNET_SERIALIZE_IMPL(UnidirectionalTreeLSTMBuilder);
 
 BidirectionalTreeLSTMBuilder::BidirectionalTreeLSTMBuilder(unsigned layers,
@@ -389,11 +371,5 @@ Expression BidirectionalTreeLSTMBuilder::add_input(int id, vector<int> children,
 
 Expression BidirectionalTreeLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new) { throw std::runtime_error("set_h() not a valid function for BidirectionalTreeLSTMBuilder"); }
 
-template<class Archive>
-void BidirectionalTreeLSTMBuilder::serialize(Archive& ar, const unsigned int) {
-  ar & boost::serialization::base_object<TreeLSTMBuilder>(*this);
-  ar & fwd_node_builder;
-  ar & rev_node_builder;
-}
-
+DYNET_SERIALIZE_COMMIT(BidirectionalTreeLSTMBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(TreeLSTMBuilder, fwd_node_builder, rev_node_builder))
 DYNET_SERIALIZE_IMPL(BidirectionalTreeLSTMBuilder);

--- a/dynet/treelstm.h
+++ b/dynet/treelstm.h
@@ -7,6 +7,7 @@
 #include "dynet/rnn.h"
 #include "dynet/expr.h"
 #include "dynet/lstm.h"
+#include "dynet/io-macros.h"
 
 using namespace dynet::expr;
 
@@ -29,9 +30,7 @@ public:
   virtual Expression add_input_impl(int prev, const Expression& x) override;
 
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 struct NaryTreeLSTMBuilder : public TreeLSTMBuilder {
@@ -70,10 +69,8 @@ struct NaryTreeLSTMBuilder : public TreeLSTMBuilder {
   unsigned N; // Max branching factor
 private:
   ComputationGraph* cg;
-
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  
+  DYNET_SERIALIZE_DECLARE()
 };
 
 struct UnidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
@@ -93,9 +90,7 @@ struct UnidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
   std::vector<Expression> h;
 
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 
 struct BidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
@@ -117,9 +112,7 @@ struct BidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
   std::vector<Expression> h;
 
 private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 };
 } // namespace dynet
 

--- a/dynet/weight-decay.cc
+++ b/dynet/weight-decay.cc
@@ -1,13 +1,8 @@
 #include "dynet/weight-decay.h"
-#include "dynet/io-macros.h"
 
 namespace dynet {
 
-template<class Archive>
-void L2WeightDecay::serialize(Archive& ar, const unsigned int) {
-  ar & weight_decay;
-  ar & lambda;
-}
+DYNET_SERIALIZE_COMMIT(L2WeightDecay, DYNET_SERIALIZE_DEFINE(weight_decay, lambda))
 DYNET_SERIALIZE_IMPL(L2WeightDecay)
 
 }

--- a/dynet/weight-decay.h
+++ b/dynet/weight-decay.h
@@ -4,8 +4,7 @@
 #include <stdexcept>
 #include <cmath>
 #include <iostream>
-
-namespace boost { namespace serialization { class access; } }
+#include "dynet/io-macros.h"
 
 namespace dynet {
 
@@ -36,9 +35,7 @@ struct L2WeightDecay {
     weight_decay = 1.0f;
   }
  private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int);
+  DYNET_SERIALIZE_DECLARE()
 
   float weight_decay;
   float lambda;


### PR DESCRIPTION
This is the first step trying to resolve https://github.com/clab/dynet/issues/84: refactor serialization logic using Macro interfaces. In this case, we don't need to modify codes in a lot when importing other serialization tools and remove boost dependencies later.

I will write unit tests for demonstrating the interfaces' usage and for testing these interfaces in next pull request because it will take some time.