### PR TITLE
These device->host memory copies shouldn't be async.

### DIFF
--- a/dynet/nodes-conv.cc
+++ b/dynet/nodes-conv.cc
@@ -395,7 +395,7 @@ void KMaxPooling::backward_dev_impl(const MyDevice & dev,
 #ifdef __CUDACC__
   vector<Eigen::DenseIndex> indices(dim.size());
   const Eigen::DenseIndex* maxmap = &indices[0];
-  CUDA_CHECK(cudaMemcpyAsync((void*)maxmap, aux_mem, sizeof(Eigen::DenseIndex) * dim.size(), cudaMemcpyDeviceToHost));
+  CUDA_CHECK(cudaMemcpy((void*)maxmap, aux_mem, sizeof(Eigen::DenseIndex) * dim.size(), cudaMemcpyDeviceToHost));
 #else
   const Eigen::DenseIndex* maxmap = static_cast<const Eigen::DenseIndex*>(aux_mem);
 #endif

--- a/dynet/tensor.cc
+++ b/dynet/tensor.cc
@@ -52,7 +52,7 @@ vector<real> as_vector(const Tensor& v) {
 float TensorTools::AccessElement(const Tensor& v, int index) {
 #if HAVE_CUDA
   float ret;
-  cudaMemcpyAsync(&ret, &v.v[index], sizeof(real), cudaMemcpyDeviceToHost);
+  cudaMemcpy(&ret, &v.v[index], sizeof(real), cudaMemcpyDeviceToHost);
   return ret;
 #else
   return v.v[index];
@@ -198,7 +198,7 @@ void Tensor::save(Archive& ar, const unsigned int ver) const {
 #ifdef HAVE_CUDA
   if (device->type == DeviceType::GPU) {
     float* vc = static_cast<float*>(std::malloc(d.size() * sizeof(float)));
-    CUDA_CHECK(cudaMemcpyAsync(vc, v, d.size() * sizeof(float), cudaMemcpyDeviceToHost));
+    CUDA_CHECK(cudaMemcpy(vc, v, d.size() * sizeof(float), cudaMemcpyDeviceToHost));
     ar & boost::serialization::make_array(vc, d.size());
     free(vc);
   } else {


### PR DESCRIPTION
I haven't been bitten by these lines, but I'm surprised no one else has had a problem with them. Unless I misunderstand the way cudamemcpy works, we should never do an asynchronous copy from device->host and then use the memory on the host immediately (without having done any synchronizing). I changed these to be synchronous calls to cudamemcpy since we use the memory immediately.