### PR TITLE
Add access to parameter gradient and direct numpy array + tests

### DIFF
--- a/dynet/model.h
+++ b/dynet/model.h
@@ -107,7 +107,7 @@ struct ParameterStorage : public ParameterStorageBase {
 
   Dim dim; /**< Dimensions of the parameter tensor*/
   Tensor values;/**< Values of the parameter */
-  Tensor g;/*< Values of the gradient w.r.t. this parameter */
+  Tensor g;/**< Values of the gradient w.r.t. this parameter */
 
 private:
   ParameterStorage() {}

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -34,6 +34,7 @@ cdef extern from "dynet/dim.h" namespace "dynet":
         int ndims()
         int rows()
         int cols()
+        unsigned operator[](unsigned i)
         void set(unsigned i, unsigned s)
         int size(unsigned i)
         CDim transpose()
@@ -58,6 +59,7 @@ cdef extern from "dynet/model.h" namespace "dynet":
         vector[CTensor] values
         vector[CTensor] grads
         CDim dim
+        CDim all_dim
 
     cdef cppclass CParameters "dynet::Parameter":
         CParameters()

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -50,11 +50,13 @@ cdef extern from "dynet/model.h" namespace "dynet":
     cdef cppclass CParameterStorage "dynet::ParameterStorage":
         CParameterStorage()
         CTensor values
+        CTensor g
         CDim dim
 
     cdef cppclass CLookupParameterStorage "dynet::LookupParameterStorage":
         CLookupParameterStorage()
         vector[CTensor] values
+        vector[CTensor] grads
         CDim dim
 
     cdef cppclass CParameters "dynet::Parameter":

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -114,6 +114,14 @@ cdef CDim Dim(dim, unsigned int batch_size=1):
     else:
         return CDim(cvec)
 
+cdef tuple c_dim_as_dim(CDim d):
+    """
+    Returns a tuple (dims,batch_dim) where dims is the tuple of dimensions of each batch element
+    """
+    dim = tuple([d[i] for i in range(d.ndims())])
+    dim= (dim,d.batch_elems())
+    return tuple(dim)
+
 cdef tuple c_dim_as_shape(CDim d,bool force_batch=False):
     dim = [d[i] for i in range(d.ndims())]
     if force_batch or d.batch_elems()>1: dim.append(d.batch_elems())
@@ -698,10 +706,13 @@ cdef class Expression: #{{{
         return CExpression(self.cgp(), self.vindex)
 
     cpdef dim(self):
+        """
+        Returns a tuple (dims,batch_dim) where dims is the tuple of dimensions of each batch element
+        """
         cdef CDim d;
         if self.cg_version != _cg._cg_version: raise RuntimeError("Stale Expression (created before renewing the Computation Graph).")
         d=self.c().dim()
-        return c_dim_as_shape(d,force_batch=True)
+        return c_dim_as_dim(d)
         # return (d.size(), d.rows(), d.cols(), d.batch_elems())
 
     def __repr__(self):

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -773,7 +773,7 @@ cdef class Expression: #{{{
         cdef CTensor t
         if recalculate: self.cg().forward(self.vindex)
         t = self.cgp().get_value(self.vindex)
-        if t.d.ndims() == 2:
+        if t.d.ndims() >= 2:
             return self.npvalue()
         vec = self.vec_value()
         if len(vec) == 1: return vec[0]

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -888,10 +888,15 @@ def inputTensor(arr,bool batched=False):
     """
     Creates a tensor expression based on a numpy array or a list.
     The dimension is inferred from the shape of the input.
-    if batched=True, the last dimension is used as abatch dimension
+    if batched=True, the last dimension is used as a batch dimension
+    if arr is a list of numpy ndarrays, this returns a batched expression where the batch elements are the elements of the list
     """
     if isinstance(arr,list):
-        arr=np.asarray(arr,dtype=float)
+        if all([isinstance(x,np.ndarray) for x in arr]):
+            arr = np.stack(arr,axis=-1)
+            batched=True
+        else:
+            arr=np.asarray(arr,dtype=float)
     if not isinstance(arr,np.ndarray):
         raise TypeError("Input Tensor should be a numpy.ndarray or a valid list pf floats")
     if batched:

--- a/python_tests/test_grads.py
+++ b/python_tests/test_grads.py
@@ -1,0 +1,20 @@
+import dynet as dy
+import numpy as np
+
+# create model
+m=dy.Model()
+# add parameter
+p=m.parameters_from_numpy(np.ones((1,5)))
+# create cg
+dy.renew_cg()
+# input tensor
+x= dy.inputTensor(np.arange(5).reshape((5,1)))
+# add parameter to computation graph
+e_p=dy.parameter(p)
+# compute dot product
+res = e_p * x
+# Run forward and backward pass
+res.forward()
+res.backward()
+# Should print the value of x
+print p.grad_as_array()

--- a/python_tests/test_input.py
+++ b/python_tests/test_input.py
@@ -3,27 +3,28 @@ import dynet as dy
 import numpy as np
 
 input_vals = np.arange(81)
-shapes=[(81),(3,27),(3,3,9)]
-for i in range(3):
+squared_norm = (input_vals**2).sum()
+shapes = [(81,), (3, 27), (3, 3, 9), (3, 3, 3, 3)]
+for i in range(4):
     # Not batched
     dy.renew_cg()
-    input_tensor=input_vals.reshape(shapes[i])
-    x=dy.inputTensor(input_tensor)
-    print(x.dim())
-    print(x.npvalue())
-    print(dy.squared_norm(x).npvalue())
+    input_tensor = input_vals.reshape(shapes[i])
+    x = dy.inputTensor(input_tensor)
+    assert (x.dim()[:-1] == shapes[i] and x.dim()[-1] == 1),"Dimension mismatch : {} : {}, {} : 1".format(x.dim()[:-1], shapes[i], x.dim()[-1])
+    assert (x.npvalue() == input_tensor).all(), "Expression value different from initial value"
+    assert dy.squared_norm(x).scalar_value() == squared_norm, "Value mismatch"
     # Batched
     dy.renew_cg()
-    xb=dy.inputTensor(input_tensor,batched=True)
-    print(xb.dim())
-    print(xb.npvalue())
-    print(dy.sum_batches(dy.squared_norm(xb)).npvalue())
+    xb = dy.inputTensor(input_tensor, batched=True)
+    assert (xb.dim() == shapes[i] or (i == 0 and xb.dim() == (1,shapes[0][0]))), "Dimension mismatch with batch size"
+    assert (xb.npvalue() == input_tensor).all(), "Batched expression value different from initial value"
+    assert dy.sum_batches(dy.squared_norm(xb)).scalar_value() == squared_norm, "Value mismatch"
 
 caught = False
 try:
     dy.renew_cg()
-    x=dy.inputTensor("This is not a tensor",batched=True)
+    x = dy.inputTensor("This is not a tensor", batched=True)
 except TypeError:
-    caught=True
+    caught = True
 
-assert(caught,"Exception wasn't caught")
+assert caught, "Exception wasn't caught"

--- a/python_tests/test_input.py
+++ b/python_tests/test_input.py
@@ -10,19 +10,19 @@ for i in range(4):
     dy.renew_cg()
     input_tensor = input_vals.reshape(shapes[i])
     x = dy.inputTensor(input_tensor)
-    assert (x.dim()[:-1] == shapes[i] and x.dim()[-1] == 1),"Dimension mismatch : {} : {}, {} : 1".format(x.dim()[:-1], shapes[i], x.dim()[-1])
+    assert (x.dim()[0] == shapes[i] and x.dim()[1] == 1),"Dimension mismatch : {} : ({}, {})".format(x.dim(), shapes[i],1)
     assert (x.npvalue() == input_tensor).all(), "Expression value different from initial value"
     assert dy.squared_norm(x).scalar_value() == squared_norm, "Value mismatch"
     # Batched
     dy.renew_cg()
     xb = dy.inputTensor(input_tensor, batched=True)
-    assert (xb.dim() == shapes[i] or (i == 0 and xb.dim() == (1,shapes[0][0]))), "Dimension mismatch with batch size"
+    assert (xb.dim()[0] == (shapes[i][:-1] if i>0 else (1,)) and xb.dim()[1] == shapes[i][-1]), "Dimension mismatch with batch size : {} : ({}, {})".format(xb.dim(), (shapes[i][:-1] if i>0 else 1),shapes[i][-1])
     assert (xb.npvalue() == input_tensor).all(), "Batched expression value different from initial value"
     assert dy.sum_batches(dy.squared_norm(xb)).scalar_value() == squared_norm, "Value mismatch"
     # Batched with list
     dy.renew_cg()
     xb = dy.inputTensor([np.asarray(x).transpose() for x in input_tensor.transpose()])
-    assert (xb.dim() == shapes[i] or (i == 0 and xb.dim() == (1,shapes[0][0]))), "Dimension mismatch with batch size"
+    assert (xb.dim()[0] == (shapes[i][:-1] if i>0 else (1,)) and xb.dim()[1] == shapes[i][-1]) , "Dimension mismatch with batch size : {} : ({}, {})".format(xb.dim(), (shapes[i][:-1] if i>0 else 1),shapes[i][-1])
     assert (xb.npvalue() == input_tensor).all(), "Batched expression value different from initial value"
     assert dy.sum_batches(dy.squared_norm(xb)).scalar_value() == squared_norm, "Value mismatch"
 

--- a/python_tests/test_input.py
+++ b/python_tests/test_input.py
@@ -19,6 +19,12 @@ for i in range(4):
     assert (xb.dim() == shapes[i] or (i == 0 and xb.dim() == (1,shapes[0][0]))), "Dimension mismatch with batch size"
     assert (xb.npvalue() == input_tensor).all(), "Batched expression value different from initial value"
     assert dy.sum_batches(dy.squared_norm(xb)).scalar_value() == squared_norm, "Value mismatch"
+    # Batched with list
+    dy.renew_cg()
+    xb = dy.inputTensor([np.asarray(x).transpose() for x in input_tensor.transpose()])
+    assert (xb.dim() == shapes[i] or (i == 0 and xb.dim() == (1,shapes[0][0]))), "Dimension mismatch with batch size"
+    assert (xb.npvalue() == input_tensor).all(), "Batched expression value different from initial value"
+    assert dy.sum_batches(dy.squared_norm(xb)).scalar_value() == squared_norm, "Value mismatch"
 
 caught = False
 try:

--- a/python_tests/test_input.py
+++ b/python_tests/test_input.py
@@ -1,0 +1,29 @@
+from __future__ import print_function
+import dynet as dy
+import numpy as np
+
+input_vals = np.arange(81)
+shapes=[(81),(3,27),(3,3,9)]
+for i in range(3):
+    # Not batched
+    dy.renew_cg()
+    input_tensor=input_vals.reshape(shapes[i])
+    x=dy.inputTensor(input_tensor)
+    print(x.dim())
+    print(x.npvalue())
+    print(dy.squared_norm(x).npvalue())
+    # Batched
+    dy.renew_cg()
+    xb=dy.inputTensor(input_tensor,batched=True)
+    print(xb.dim())
+    print(xb.npvalue())
+    print(dy.sum_batches(dy.squared_norm(xb)).npvalue())
+
+caught = False
+try:
+    dy.renew_cg()
+    x=dy.inputTensor("This is not a tensor",batched=True)
+except TypeError:
+    caught=True
+
+assert(caught,"Exception wasn't caught")


### PR DESCRIPTION
Changelog : 

- `p.grad_as_array()` can now be called on a parameter or a lookupparameter to get the gradient computed by `backward`
- Add a `dy.inputTensor()` function : 

        Creates a tensor expression based on a numpy array or a list.
        The dimension is inferred from the shape of the input.
        if batched=True, the last dimension is used as abatch dimension

- Add rudimentary test files in `python_tests`
