### PR TITLE
Add sanity check in expressions to avoid memory violation

### DIFF
--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -46,7 +46,7 @@ DeviceMempoolSizes::DeviceMempoolSizes(const std::string & descriptor) {
 Device::~Device() {}
 
 DeviceMempoolSizes Device::mark(ComputationGraph *cg) {
-  cg->incremental_forward({cg, (VariableIndex)(cg->nodes.size() - 1), "Mark expression"}); // needed so that we actually allocate the needed memory
+  cg->incremental_forward({cg, (VariableIndex)(cg->nodes.size() - 1)}); // needed so that we actually allocate the needed memory
   // for all existing nodes.
   return DeviceMempoolSizes(pools[0]->used, pools[1]->used, pools[2]->used);
 }

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -14,9 +14,9 @@ using namespace std;
 namespace dynet {
 
 DeviceMempoolSizes::DeviceMempoolSizes(size_t total_size) {
-  used[0] = total_size/3;
-  used[1] = total_size/3;
-  used[2] = total_size/3;
+  used[0] = total_size / 3;
+  used[1] = total_size / 3;
+  used[2] = total_size / 3;
 }
 
 DeviceMempoolSizes::DeviceMempoolSizes(size_t fx_s, size_t dEdfs_s, size_t ps_s) {
@@ -28,17 +28,17 @@ DeviceMempoolSizes::DeviceMempoolSizes(size_t fx_s, size_t dEdfs_s, size_t ps_s)
 DeviceMempoolSizes::DeviceMempoolSizes(const std::string & descriptor) {
   vector<string> strs;
   boost::algorithm::split(strs, descriptor, boost::is_any_of(","));
-  if(strs.size() == 1) {
+  if (strs.size() == 1) {
     size_t total_size = stoi(strs[0]);
-    used[0] = total_size/3;
-    used[1] = total_size/3;
-    used[2] = total_size/3;
-  } else if(strs.size() == 3) {
+    used[0] = total_size / 3;
+    used[1] = total_size / 3;
+    used[2] = total_size / 3;
+  } else if (strs.size() == 3) {
     used[0] = stoi(strs[0]);
     used[1] = stoi(strs[1]);
     used[2] = stoi(strs[2]);
   } else {
-    ostringstream s; s<<"the format of --dynet-mem is invalid:"<<descriptor;
+    ostringstream s; s << "the format of --dynet-mem is invalid:" << descriptor;
     throw std::invalid_argument(s.str());
   }
 }
@@ -46,8 +46,8 @@ DeviceMempoolSizes::DeviceMempoolSizes(const std::string & descriptor) {
 Device::~Device() {}
 
 DeviceMempoolSizes Device::mark(ComputationGraph *cg) {
-  cg->incremental_forward({cg, (VariableIndex)(cg->nodes.size() - 1)}); // needed so that we actually allocate the needed memory
-                             // for all existing nodes.
+  cg->incremental_forward({cg, (VariableIndex)(cg->nodes.size() - 1), "Mark expression"}); // needed so that we actually allocate the needed memory
+  // for all existing nodes.
   return DeviceMempoolSizes(pools[0]->used, pools[1]->used, pools[2]->used);
 }
 
@@ -69,7 +69,7 @@ void Device::allocate_tensor(DeviceMempool mp, Tensor & tens) {
 
 #if HAVE_CUDA
 Device_GPU::Device_GPU(int my_id, const DeviceMempoolSizes & mbs, int device_id) :
-    Device(my_id, DeviceType::GPU, &gpu_mem), cuda_device_id(device_id), gpu_mem(device_id) {
+  Device(my_id, DeviceType::GPU, &gpu_mem), cuda_device_id(device_id), gpu_mem(device_id) {
   CUDA_CHECK(cudaSetDevice(device_id));
   CUBLAS_CHECK(cublasCreate(&cublas_handle));
   CUBLAS_CHECK(cublasSetPointerMode(cublas_handle, CUBLAS_POINTER_MODE_DEVICE));
@@ -97,7 +97,7 @@ Device_GPU::~Device_GPU() {}
 #endif
 
 Device_CPU::Device_CPU(int my_id, const DeviceMempoolSizes & mbs, bool shared) :
-    Device(my_id, DeviceType::CPU, &cpu_mem), shmem(mem) {
+  Device(my_id, DeviceType::CPU, &cpu_mem), shmem(mem) {
   if (shared) shmem = new SharedAllocator();
   kSCALAR_MINUSONE = (float*) mem->malloc(sizeof(float));
   *kSCALAR_MINUSONE = -1;

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -15,6 +15,10 @@ float* kSCALAR_MINUSONE;
 float* kSCALAR_ONE;
 float* kSCALAR_ZERO;
 int n_hgs = 0;
+unsigned n_cumul_hgs = 0;
+
+const int get_number_of_active_graphs() {return n_hgs;};
+const unsigned get_current_graph_id() {return n_cumul_hgs;};
 
 Node::~Node() {}
 size_t Node::aux_storage_size() const { return 0; }
@@ -23,14 +27,14 @@ size_t Node::aux_storage_size() const { return 0; }
 // TODO: This is a lot of code for something simple. Can it be shortened?
 void Node::forward(const std::vector<const Tensor*>& xs,
                    Tensor& fx) const {
-  if(this->supports_multibatch() || fx.d.batch_elems() == 1) {
+  if (this->supports_multibatch() || fx.d.batch_elems() == 1) {
     forward_impl(xs, fx);
   } else {
     size_t i;
     std::vector<Tensor> xs_elems(xs.size());
     std::vector<const Tensor*> xs_ptrs(xs.size());
     std::vector<size_t> xs_sizes(xs.size());
-    for(i = 0; i < xs.size(); ++i) {
+    for (i = 0; i < xs.size(); ++i) {
       xs_elems[i] = xs[i]->batch_elem(0);
       xs_ptrs[i] = &xs_elems[i];
       xs_sizes[i] = xs_elems[i].d.size();
@@ -38,9 +42,9 @@ void Node::forward(const std::vector<const Tensor*>& xs,
     Tensor fx_elem(fx.batch_elem(0));
     size_t fx_size = fx_elem.d.size();
     forward_impl(xs_ptrs, fx_elem);
-    for(unsigned b = 1; b < fx.d.batch_elems(); ++b) {
-      for(i = 0; i < xs.size(); ++i)
-        if(xs[i]->d.bd > 1)
+    for (unsigned b = 1; b < fx.d.batch_elems(); ++b) {
+      for (i = 0; i < xs.size(); ++i)
+        if (xs[i]->d.bd > 1)
           xs_elems[i].v += xs_sizes[i];
       fx_elem.v += fx_size;
       forward_impl(xs_ptrs, fx_elem);
@@ -53,14 +57,14 @@ void Node::backward(const std::vector<const Tensor*>& xs,
                     const Tensor& dEdf,
                     unsigned xs_i,
                     Tensor& dEdxi) const {
-  if(this->supports_multibatch() || fx.d.batch_elems() == 1) {
+  if (this->supports_multibatch() || fx.d.batch_elems() == 1) {
     backward_impl(xs, fx, dEdf, xs_i, dEdxi);
   } else {
     size_t i;
     std::vector<Tensor> xs_elems(xs.size());
     std::vector<const Tensor*> xs_ptrs(xs.size());
     std::vector<size_t> xs_sizes(xs.size());
-    for(i = 0; i < xs.size(); ++i) {
+    for (i = 0; i < xs.size(); ++i) {
       xs_elems[i] = xs[i]->batch_elem(0);
       xs_ptrs[i] = &xs_elems[i];
       xs_sizes[i] = xs_elems[i].d.size();
@@ -72,13 +76,13 @@ void Node::backward(const std::vector<const Tensor*>& xs,
     Tensor dEdxi_elem(dEdxi.batch_elem(0));
     size_t dEdxi_size = dEdxi_elem.d.size();
     backward_impl(xs_ptrs, fx_elem, dEdf_elem, xs_i, dEdxi_elem);
-    for(unsigned b = 1; b < fx.d.batch_elems(); ++b) {
-      for(i = 0; i < xs.size(); ++i)
-        if(xs[i]->d.bd > 1)
+    for (unsigned b = 1; b < fx.d.batch_elems(); ++b) {
+      for (i = 0; i < xs.size(); ++i)
+        if (xs[i]->d.bd > 1)
           xs_elems[i].v += xs_sizes[i];
       fx_elem.v += fx_size;
       dEdf_elem.v += dEdf_size;
-      if(dEdxi.d.bd > 1)
+      if (dEdxi.d.bd > 1)
         dEdxi_elem.v += dEdxi_size;
       backward_impl(xs_ptrs, fx_elem, dEdf_elem, xs_i, dEdxi_elem);
     }
@@ -87,13 +91,15 @@ void Node::backward(const std::vector<const Tensor*>& xs,
 
 ComputationGraph::ComputationGraph():
   ee(new SimpleExecutionEngine(*this)) {
-  ++n_hgs;
-  immediate_compute = false;
-  check_validity = false;
-  if (n_hgs > 1) {
+  if (n_hgs > 0) {
     cerr << "Memory allocator assumes only a single ComputationGraph at a time.\n";
     throw std::runtime_error("Attempted to create >1 CG");
   }
+  ++n_hgs;
+  immediate_compute = false;
+  check_validity = false;
+  ++n_cumul_hgs;
+  graph_id = n_cumul_hgs;
 }
 
 ComputationGraph::~ComputationGraph() {
@@ -109,38 +115,38 @@ void ComputationGraph::clear() {
 }
 
 CGCheckpoint ComputationGraph::_get_checkpoint() {
-    CGCheckpoint p;
-    p.device_mem_checkpoint = default_device->mark(this);
-    p.node_idx = nodes.size();
-    p.par_node_idx = parameter_nodes.size();
-    return p;
+  CGCheckpoint p;
+  p.device_mem_checkpoint = default_device->mark(this);
+  p.node_idx = nodes.size();
+  p.par_node_idx = parameter_nodes.size();
+  return p;
 }
 
 void ComputationGraph::_revert(CGCheckpoint p) {
-    default_device->revert(p.device_mem_checkpoint);
-    // clear all nodes at position >= p.node_idx
-    if ((int)nodes.size() > p.node_idx) {
-        nodes.resize(p.node_idx); // TODO verify deletion of nodes.
-        ee->invalidate(p.node_idx-1); // clear precomputed forward values
-    }
-    // clear all parameter nodes at position >= p.par_node_idx
-    if ((int)parameter_nodes.size() > p.par_node_idx) {
-        parameter_nodes.resize(p.par_node_idx);
-    }
+  default_device->revert(p.device_mem_checkpoint);
+  // clear all nodes at position >= p.node_idx
+  if ((int)nodes.size() > p.node_idx) {
+    nodes.resize(p.node_idx); // TODO verify deletion of nodes.
+    ee->invalidate(p.node_idx - 1); // clear precomputed forward values
+  }
+  // clear all parameter nodes at position >= p.par_node_idx
+  if ((int)parameter_nodes.size() > p.par_node_idx) {
+    parameter_nodes.resize(p.par_node_idx);
+  }
 }
 
 void ComputationGraph::checkpoint() {
-    checkpoints.push_back(_get_checkpoint());
+  checkpoints.push_back(_get_checkpoint());
 }
 
 void ComputationGraph::revert() {
-    if (checkpoints.size() == 0) return;
-    _revert(checkpoints.back());
-    checkpoints.pop_back();
+  if (checkpoints.size() == 0) return;
+  _revert(checkpoints.back());
+  checkpoints.pop_back();
 }
 
 Dim& ComputationGraph::get_dimension(VariableIndex index) const {
-  return nodes[index]->dim; 
+  return nodes[index]->dim;
 }
 
 
@@ -281,7 +287,7 @@ void ComputationGraph::set_dim_for_new_node(const VariableIndex& i) {
   node->dim = node->dim_forward(xds);
   if (immediate_compute) {
     const Tensor& value = incremental_forward(i);
-    if (check_validity) 
+    if (check_validity)
       if (!value.is_valid()) {
         cerr << "NaN or Inf detected\n";
         throw std::runtime_error("NaN or Inf detected");

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -27,6 +27,21 @@ extern float* kSCALAR_MINUSONE;
 extern float* kSCALAR_ONE;
 extern float* kSCALAR_ZERO;
 
+/**
+ * \ingroup compgraph
+ * \brief Gets the number of active graphs
+ * \details This is 0 or 1, you can't create more than one graph at once
+ * \return Number of active graphs
+ */
+const int get_number_of_active_graphs();
+/**
+ * \ingroup compgraph
+ * \brief Get id of the current active graph
+ * \details This can help check whether a graph is stale 
+ * \return Id of the current graph
+ */
+const unsigned get_current_graph_id();
+
 // devices provide information about GPUs and CPUs
 // these include any API information that is required to make calls
 // to the GPU as well as the memory pools for the device
@@ -57,7 +72,7 @@ inline void swap(VariableIndex& i1, VariableIndex& i2) {
 /**
  * \ingroup compgraph
  * \brief Computation graph where nodes represent forward and backward intermediate values, and edges represent functions of multiple values.
- * \details To represent the fact that a function may have multiple arguments, edges have a single head and 0, 1, 2, or more tails. (Constants, inputs, and parameters are represented as functions of 0 parameters.) 
+ * \details To represent the fact that a function may have multiple arguments, edges have a single head and 0, 1, 2, or more tails. (Constants, inputs, and parameters are represented as functions of 0 parameters.)
  * Example: given the function z = f(x, y), z, x, and y are nodes, and there is an edge representing f with which points to the z node (i.e., its head), and x and y are the tails of the edge.
  * You shouldn't need to use most methods from the ComputationGraph except for `backward` since most of them are available directly from the Expression class.
  */
@@ -72,7 +87,7 @@ struct ComputationGraph {
   /**
    * \brief Add scalar input
    * \details The computational network will pull inputs in from the user's data structures and make them available to the computation
-   * 
+   *
    * \param s Real number
    * \return The index of the created variable
    */
@@ -80,7 +95,7 @@ struct ComputationGraph {
   /**
    * \brief Add scalar input by pointer
    * \details The computational network will pull inputs in from the user's data structures and make them available to the computation
-   * 
+   *
    * \param ps Pointer to a real number
    * \return The index of the created variable
    */
@@ -88,7 +103,7 @@ struct ComputationGraph {
   /**
    * \brief Add multidimentsional input
    * \details The computational network will pull inputs in from the user's data structures and make them available to the computation
-   * 
+   *
    * \param d Desired shape of the input
    * \param data Input data (as a 1 dimensional array)
    * \return The index of the created variable
@@ -97,7 +112,7 @@ struct ComputationGraph {
   /**
    * \brief Add multidimentsional input by pointer
    * \details The computational network will pull inputs in from the user's data structures and make them available to the computation
-   * 
+   *
    * \param d Desired shape of the input
    * \param pdata Pointer to the input data (as a 1 dimensional array)
    * \return The index of the created variable
@@ -106,7 +121,7 @@ struct ComputationGraph {
   /**
    * \brief Add sparse input
    * \details The computational network will pull inputs in from the user's data structures and make them available to the computation. Represents specified (not learned) inputs to the network in sparse array format, with an optional default value.
-   * 
+   *
    * \param d Desired shape of the input
    * \param ids The indexes of the data points to update
    * \param data  The data points corresponding to each index
@@ -121,14 +136,14 @@ struct ComputationGraph {
   // parameters are just parameters
   /**
    * \brief Add a parameter to the computation graph
-   * 
+   *
    * \param p Parameter to be added
    * \return The index of the created variable
    */
   VariableIndex add_parameters(Parameter p);
   /**
    * \brief Add a parameter to the computation graph (but don't update)
-   * 
+   *
    * \param p Parameter to be added
    * \return The index of the created variable
    */
@@ -138,79 +153,79 @@ struct ComputationGraph {
   /**
    * \brief Add a lookup parameter to the computation graph
    * \details Use pindex to point to a memory location where the index will live that the caller owns
-   * 
+   *
    * \param p Lookup parameter from which to pick
    * \param pindex Pointer to the index to lookup
-   * 
+   *
    * \return The index of the created variable
    */
   VariableIndex add_lookup(LookupParameter p, const unsigned* pindex);
   /**
    * \brief Add a lookup parameter to the computation graph
-   * 
+   *
    * \param p Lookup parameter from which to pick
    * \param index Index to lookup
-   * 
+   *
    * \return The index of the created variable
    */
   VariableIndex add_lookup(LookupParameter p, unsigned index);
   /**
    * \brief Add lookup parameters to the computation graph
    * \details Use pindices to point to a memory location where the indices will live that the caller owns
-   * 
+   *
    * \param p Lookup parameter from which to pick
    * \param pindices Pointer to the indices to lookup
-   * 
+   *
    * \return The index of the created variable
    */
   VariableIndex add_lookup(LookupParameter p, const std::vector<unsigned>* pindices);
   /**
    * \brief Add lookup parameters to the computation graph
-   * 
+   *
    * \param p Lookup parameter from which to pick
    * \param indices Indices to lookup
-   * 
+   *
    * \return The index of the created variable
    */
   VariableIndex add_lookup(LookupParameter p, const std::vector<unsigned>& indices);
-  // 
+  //
   /**
    * \brief Add a lookup parameter to the computation graph
    * \details Just like add_lookup, but don't optimize the lookup parameters
-   * 
+   *
    * \param p Lookup parameter from which to pick
    * \param pindex Pointer to the indices to lookup
-   * 
+   *
    * \return The index of the created variable
    */
   VariableIndex add_const_lookup(LookupParameter p, const unsigned* pindex);
   /**
    * \brief Add a lookup parameter to the computation graph
    * \details Just like add_lookup, but don't optimize the lookup parameters
-   * 
+   *
    * \param p Lookup parameter from which to pick
    * \param index Index to lookup
-   * 
+   *
    * \return The index of the created variable
    */
   VariableIndex add_const_lookup(LookupParameter p, unsigned index);
   /**
    * \brief Add lookup parameters to the computation graph
    * \details Just like add_lookup, but don't optimize the lookup parameters
-   * 
+   *
    * \param p Lookup parameter from which to pick
    * \param pindices Pointer to the indices to lookup
-   * 
+   *
    * \return The index of the created variable
    */
   VariableIndex add_const_lookup(LookupParameter p, const std::vector<unsigned>* pindices);
   /**
    * \brief Add lookup parameters to the computation graph
    * \details Just like add_lookup, but don't optimize the lookup parameters
-   * 
+   *
    * \param p Lookup parameter from which to pick
    * \param indices Indices to lookup
-   * 
+   *
    * \return The index of the created variable
    */
   VariableIndex add_const_lookup(LookupParameter p, const std::vector<unsigned>& indices);
@@ -219,7 +234,7 @@ struct ComputationGraph {
   /**
    * \brief Add a function to the computation graph
    * \details This what is called when creating an expression
-   * 
+   *
    * \param arguments List of the arguments indices
    * \tparam Function Function to be applied
    * \return The index of the output variable
@@ -228,7 +243,7 @@ struct ComputationGraph {
   /**
    * \brief Add a function to the computation graph (with side information)
    * \details This what is called when creating an expression
-   * 
+   *
    * \param arguments List of the arguments indices
    * \param side_information Side information that is needed to compute the function
    * \tparam Function Function to be applied
@@ -256,7 +271,7 @@ struct ComputationGraph {
 
   /**
    * \brief Get dimension of a node
-   * 
+   *
    * \param index Variable index of the node
    * \return Dimension
    */
@@ -268,14 +283,14 @@ struct ComputationGraph {
   // run complete forward pass from first node to given one, ignoring all precomputed values.
   /**
    * \brief Run complete forward pass from first node to given one, ignoring all precomputed values.
-   * 
+   *
    * \param last Expression up to which the forward pass must be computed
    * \return Value of the `last` Expression after execution
    */
   const Tensor& forward(const expr::Expression& last);
   /**
    * \brief Run complete forward pass from first node to given one, ignoring all precomputed values.
-   * 
+   *
    * \param i Variable index of the node up to which the forward pass must be computed
    * \return Value of the end Node after execution
    */
@@ -283,7 +298,7 @@ struct ComputationGraph {
   /**
    * \brief Run forward pass from the last computed node to given one.
    * \details Useful if you want to add nodes and evaluate just the new parts.
-   * 
+   *
    * \param last Expression up to which the forward pass must be computed
    * \return Value of the `last` Expression after execution
    */
@@ -291,7 +306,7 @@ struct ComputationGraph {
   /**
    * \brief Run forward pass from the last computed node to given one.
    * \details Useful if you want to add nodes and evaluate just the new parts.
-   * 
+   *
    * \param last Variable index of the node up to which the forward pass must be computed
    * \return Value of the end Node after execution
    */
@@ -299,7 +314,7 @@ struct ComputationGraph {
   /**
    * \brief Get forward value for node at index i.
    * \details Performs forward evaluation if note available (may compute more than strictly what is needed).
-   * 
+   *
    * \param i Index of the variable from which you want the value
    * \return Requested value
    */
@@ -307,7 +322,7 @@ struct ComputationGraph {
   /**
    * \brief Get forward value for the given expression
    * \details Performs forward evaluation if note available (may compute more than strictly what is needed).
-   * 
+   *
    * \param e Expression from which you want the value
    * \return Requested value
    */
@@ -318,13 +333,13 @@ struct ComputationGraph {
   void invalidate();
   /**
    * \brief Computes backward gradients from the front-most evaluated node.
-   * 
+   *
    * \param last Expression from which to compute the gradient
    */
   void backward(const expr::Expression& last);
   /**
    * \brief Computes backward gradients from node i (assuming it already been evaluated).
-   * 
+   *
    * \param i Index of the node from which to compute the gradient
    */
   void backward(VariableIndex i);
@@ -338,12 +353,20 @@ struct ComputationGraph {
    */
   void print_graphviz() const;
 
+  /**
+   * \brief Get the unique graph ID
+   * \details This ID is incremented by 1 each time a computation graph is created
+   * \return graph is
+   */
+  unsigned get_id() const {return graph_id;};
+
   // data
   std::vector<Node*> nodes;       // **stored in topological order**
   std::vector<VariableIndex> parameter_nodes; // nodes that contain parameters that can be updated (subset of nodes)
 
   ExecutionEngine* ee;  // handles the execution
- private:
+private:
+  unsigned graph_id;
   // flag of whether to compute immediately for each expression, i.e., an imperative execution style to help debug.
   bool immediate_compute;
   // flag of checking Inf/NaN of each layer. Only performing checking when immediate_compute is also set to true.
@@ -372,7 +395,7 @@ struct Node {
   /**
    * \brief Compute dimensions of result for given dimensions of inputs
    * \details Also checks to make sure inputs are compatible with each other
-   * 
+   *
    * \param xs Vector containing the dimensions of the inputs
    * \return Dimension of the output
    */
@@ -382,7 +405,7 @@ struct Node {
   /**
    * \brief Returns important information for debugging
    * \details See nodes-conv.cc for examples
-   * 
+   *
    * \param args String descriptions of the arguments
    * \return String description of the node
    */
@@ -400,7 +423,7 @@ struct Node {
    */
   virtual size_t aux_storage_size() const;
 
-  
+
   // computation
   /**
    * \brief Forward computation
@@ -410,28 +433,28 @@ struct Node {
    * 3. fx can be repointed to an input, if forward(x) evaluates to x (e.g., in reshaping)
    * 4. scalars results of forward are placed in fx.v[0]
    * 5. DYNET manages its own memory, not Eigen, and it is configured with the EIGEN_NO_MALLOC option. If you get an error about Eigen attempting to allocate memory, it is (probably) because of an implicit creation of a temporary variable. To tell Eigen this is not necessary, the noalias() method is available. If you really do need a temporary variable, its capacity must be requested by Node::aux_storage_size
-   * 
+   *
    * Note on debugging problems with differentiable components
-   * 
+   *
    * - fx is uninitialized when forward is called- are you relying on it being 0?
-   * 
+   *
    * \param xs Pointers to the inputs
    * \param fx pointer to the (preallocated) location for the result of forward to be stored
    */
   virtual void forward_impl(const std::vector<const Tensor*>& xs,
                             Tensor& fx) const = 0;
-  // 
+  //
   /**
    * \brief Accumulates the derivative of E with respect to the ith argument to f, that is, xs[i]
    * \details This function contains the logic for the backward pass. Some implementation remarks from nodes.cc:
    * 1. dEdxi MUST **ACCUMULATE** a result since multiple calls to forward may depend on the same x_i. Even, e.g., Identity must be implemented as dEdx1 += dEdf. THIS IS EXTREMELY IMPORTANT
    * 2. scalars results of forward are placed in fx.v[0]
    * 3. DYNET manages its own memory, not Eigen, and it is configured with the EIGEN_NO_MALLOC option. If you get an error about Eigen attempting to allocate memory, it is (probably) because of an implicit creation of a temporary variable. To tell Eigen this is not necessary, the noalias() method is available. If you really do need a temporary variable, its capacity must be requested by Node::aux_storage_size
-   * 
+   *
    * Note on debugging problems with differentiable components
-   * 
+   *
    * - dEdxi must accummulate (see point 4 above!)
-   * 
+   *
    * \param xs Pointers to inputs
    * \param fx Output
    * \param dEdf Gradient of the objective w.r.t the output of the node
@@ -454,7 +477,7 @@ struct Node {
   // perform the forward/backward passes in one or multiple calls
   /**
    * \brief perform the forward/backward passes in one or multiple calls
-   * 
+   *
    * \param xs Pointers to the inputs
    * \param fx pointer to the (preallocated) location for the result of forward to be stored
    */
@@ -462,7 +485,7 @@ struct Node {
                        Tensor& fx) const final;
   /**
    * \brief perform the backward passes in one or multiple calls
-   * 
+   *
    * \param xs Pointers to inputs
    * \param fx Output
    * \param dEdf Gradient of the objective w.r.t the output of the node
@@ -485,17 +508,17 @@ struct Node {
   std::vector<VariableIndex> args;/**< Dependency structure */
 
   // memory size
-  Dim dim; /**< Will be .size() = 0 initially filled in by forward() -- TODO fix this */ 
+  Dim dim; /**< Will be .size() = 0 initially filled in by forward() -- TODO fix this */
 
   Device* device; /**< pointer to the node, or null to inherit device from first input, or default when there is no input */
 
- protected:
+protected:
   Node() : args(), device(default_device) {}
   explicit Node(const std::initializer_list<VariableIndex>& a) : args(a), device(default_device) {}
   template <typename T>
   explicit Node(const T&c) : args(c.begin(), c.end()), device(default_device) {}
 
- public:
+public:
   // auxiliary memory
   mutable void* aux_mem; /**< this will usually be null. but, if your node needs to store intermediate values between forward and backward, you can use store it here. request the number of bytes you need from aux_storage_size(). Note: this memory will be on the CPU or GPU, depending on your computation backend*/
 };
@@ -511,7 +534,7 @@ inline VariableIndex ComputationGraph::add_function(const std::initializer_list<
 // pass side information to the function. these are likely to be nondifferentiable arguments
 template <class Function, typename... Args>
 inline VariableIndex ComputationGraph::add_function(const std::initializer_list<VariableIndex>& arguments,
-                                              Args&&... side_information) {
+    Args&&... side_information) {
   VariableIndex new_node_index(nodes.size());
   nodes.push_back(new Function(arguments, std::forward<Args>(side_information)...));
   set_dim_for_new_node(new_node_index);

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -10,124 +10,124 @@ namespace expr {
 
 using std::vector;
 
-Expression input(ComputationGraph& g, real s) { return Expression(&g, g.add_input(s), "input(ComputationGraph& g, real s)"); }
-Expression input(ComputationGraph& g, const real *ps) { return Expression(&g, g.add_input(ps), "input(ComputationGraph& g, const real *ps)"); }
-Expression input(ComputationGraph& g, const Dim& d, const vector<float>& data) { return Expression(&g, g.add_input(d, data), "input(ComputationGraph& g, const Dim& d, const vector<float>& data)"); }
-Expression input(ComputationGraph& g, const Dim& d, const vector<float>* pdata) { return Expression(&g, g.add_input(d, pdata), "input(ComputationGraph& g, const Dim& d, const vector<float>* pdata)"); }
-Expression input(ComputationGraph& g, const Dim& d, const vector<unsigned int>& ids, const vector<float>& data, float defdata) { return Expression(&g, g.add_input(d, ids, data, defdata), "input(ComputationGraph& g, const Dim& d, const vector<unsigned int>& ids, const vector<float>& data, float defdata)"); }
-Expression const_parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_const_parameters(p), "const_parameter(ComputationGraph& g, Parameter p)"); }
-Expression parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_parameters(p), "parameter(ComputationGraph& g, Parameter p)"); }
-Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_lookup(p, index), "lookup(ComputationGraph& g, LookupParameter p, unsigned index)"); }
-Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_lookup(p, pindex), "lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex)"); }
-Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_lookup(p, indices), "lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices)"); }
-Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices) { return Expression(&g, g.add_lookup(p, pindices), "lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices)"); }
-Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_const_lookup(p, index), "const_lookup(ComputationGraph& g, LookupParameter p, unsigned index)"); }
-Expression const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_const_lookup(p, pindex), "const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex)"); }
-Expression const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_const_lookup(p, indices), "const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices)"); }
-Expression const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices) { return Expression(&g, g.add_const_lookup(p, pindices), "const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices)"); }
-Expression zeroes(ComputationGraph& g, const Dim& d) { return Expression(&g, g.add_function<Zeroes>(d), "zeroes(ComputationGraph& g, const Dim& d)"); }
-Expression random_normal(ComputationGraph& g, const Dim& d) { return Expression(&g, g.add_function<RandomNormal>(d), "random_normal(ComputationGraph& g, const Dim& d)"); }
-Expression random_bernoulli(ComputationGraph& g, const Dim& d, real p, real scale) { return Expression(&g, g.add_function<RandomBernoulli>({}, d, p, scale), "random_bernoulli(ComputationGraph& g, const Dim& d, real p, real scale)"); }
-Expression random_uniform(ComputationGraph& g, const Dim& d, real left, real right) { return Expression(&g, g.add_function<RandomUniform>({}, d, left, right), "random_uniform(ComputationGraph& g, const Dim& d, real left, real right)"); }
+Expression input(ComputationGraph& g, real s) { return Expression(&g, g.add_input(s)); }
+Expression input(ComputationGraph& g, const real *ps) { return Expression(&g, g.add_input(ps)); }
+Expression input(ComputationGraph& g, const Dim& d, const vector<float>& data) { return Expression(&g, g.add_input(d, data)); }
+Expression input(ComputationGraph& g, const Dim& d, const vector<float>* pdata) { return Expression(&g, g.add_input(d, pdata)); }
+Expression input(ComputationGraph& g, const Dim& d, const vector<unsigned int>& ids, const vector<float>& data, float defdata) { return Expression(&g, g.add_input(d, ids, data, defdata)); }
+Expression const_parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_const_parameters(p)); }
+Expression parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_parameters(p)); }
+Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_lookup(p, index)); }
+Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_lookup(p, pindex)); }
+Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_lookup(p, indices)); }
+Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices) { return Expression(&g, g.add_lookup(p, pindices)); }
+Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_const_lookup(p, index)); }
+Expression const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_const_lookup(p, pindex)); }
+Expression const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_const_lookup(p, indices)); }
+Expression const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices) { return Expression(&g, g.add_const_lookup(p, pindices)); }
+Expression zeroes(ComputationGraph& g, const Dim& d) { return Expression(&g, g.add_function<Zeroes>(d)); }
+Expression random_normal(ComputationGraph& g, const Dim& d) { return Expression(&g, g.add_function<RandomNormal>(d)); }
+Expression random_bernoulli(ComputationGraph& g, const Dim& d, real p, real scale) { return Expression(&g, g.add_function<RandomBernoulli>({}, d, p, scale)); }
+Expression random_uniform(ComputationGraph& g, const Dim& d, real left, real right) { return Expression(&g, g.add_function<RandomUniform>({}, d, left, right)); }
 
 // identity function, but derivative is not propagated through it
-Expression nobackprop(const Expression& x) { return Expression(x.pg, x.pg->add_function<NoBackprop>({x.i}), "nobackprop(const Expression& x)"); }
+Expression nobackprop(const Expression& x) { return Expression(x.pg, x.pg->add_function<NoBackprop>({x.i})); }
 // identity function, but derivative is propagated as negative
-Expression flip_gradient(const Expression& x) { return Expression(x.pg, x.pg->add_function<FlipGradient>({x.i}), "flip_gradient(const Expression& x)"); }
+Expression flip_gradient(const Expression& x) { return Expression(x.pg, x.pg->add_function<FlipGradient>({x.i})); }
 
-Expression operator-(const Expression& x) { return Expression(x.pg, x.pg->add_function<Negate>({x.i}), "operator-(const Expression& x)"); }
-Expression operator+(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Sum>({x.i, y.i}), "operator+(const Expression& x, const Expression& y)"); }
-Expression operator+(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantPlusX>({y.i}, x), "operator+(real x, const Expression& y)"); }
+Expression operator-(const Expression& x) { return Expression(x.pg, x.pg->add_function<Negate>({x.i})); }
+Expression operator+(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Sum>({x.i, y.i})); }
+Expression operator+(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantPlusX>({y.i}, x)); }
 Expression operator+(const Expression& x, real y) { return y + x; }
 Expression operator-(const Expression& x, const Expression& y) { return x + (-y); }
-Expression operator-(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantMinusX>({y.i}, x), "operator-(real x, const Expression& y)"); }
+Expression operator-(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantMinusX>({y.i}, x)); }
 Expression operator-(const Expression& x, real y) { return -(y - x); }
-Expression operator*(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<MatrixMultiply>({x.i, y.i}), "operator*(const Expression& x, const Expression& y)"); }
-Expression operator*(const Expression& x, float y) { return Expression(x.pg, x.pg->add_function<ConstScalarMultiply>({x.i}, y), "operator*(const Expression& x, float y)"); }
-Expression cmult(const Expression& x, const Expression& y) {return Expression(x.pg, x.pg->add_function<CwiseMultiply>({x.i, y.i}), "cmult(const Expression& x, const Expression& y)");}
-Expression cdiv(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<CwiseQuotient>({x.i, y.i}), "cdiv(const Expression& x, const Expression& y)"); }
-Expression colwise_add(const Expression& x, const Expression& bias) { return Expression(x.pg, x.pg->add_function<AddVectorToAllColumns>({x.i, bias.i}), "colwise_add(const Expression& x, const Expression& bias)"); }
-Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D_1D>({x.i, y.i, z.i}), "contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z)"); }
-Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z, const Expression& b) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D_1D>({x.i, y.i, z.i, b.i}), "contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z, const Expression& b)"); }
-Expression contract3d_1d(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D>({x.i, y.i}), "contract3d_1d(const Expression& x, const Expression& y)"); }
-Expression contract3d_1d(const Expression& x, const Expression& y, const Expression& b) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D>({x.i, y.i, b.i}), "contract3d_1d(const Expression& x, const Expression& y, const Expression& b)"); }
+Expression operator*(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<MatrixMultiply>({x.i, y.i})); }
+Expression operator*(const Expression& x, float y) { return Expression(x.pg, x.pg->add_function<ConstScalarMultiply>({x.i}, y)); }
+Expression cmult(const Expression& x, const Expression& y) {return Expression(x.pg, x.pg->add_function<CwiseMultiply>({x.i, y.i}));}
+Expression cdiv(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<CwiseQuotient>({x.i, y.i})); }
+Expression colwise_add(const Expression& x, const Expression& bias) { return Expression(x.pg, x.pg->add_function<AddVectorToAllColumns>({x.i, bias.i})); }
+Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D_1D>({x.i, y.i, z.i})); }
+Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z, const Expression& b) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D_1D>({x.i, y.i, z.i, b.i})); }
+Expression contract3d_1d(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D>({x.i, y.i})); }
+Expression contract3d_1d(const Expression& x, const Expression& y, const Expression& b) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D>({x.i, y.i, b.i})); }
 
-Expression sqrt(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sqrt>({x.i}), "sqrt(const Expression& x)"); }
-Expression erf(const Expression& x) { return Expression(x.pg, x.pg->add_function<Erf>({x.i}), "erf(const Expression& x)"); }
-Expression tanh(const Expression& x) { return Expression(x.pg, x.pg->add_function<Tanh>({x.i}), "tanh(const Expression& x)"); }
-Expression lgamma(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogGamma>({x.i}), "lgamma(const Expression& x)"); }
-Expression log(const Expression& x) { return Expression(x.pg, x.pg->add_function<Log>({x.i}), "log(const Expression& x)"); }
-Expression exp(const Expression& x) { return Expression(x.pg, x.pg->add_function<Exp>({x.i}), "exp(const Expression& x)"); }
-Expression square(const Expression& x) { return Expression(x.pg, x.pg->add_function<Square>({x.i}), "square(const Expression& x)"); }
-Expression cube(const Expression& x) { return Expression(x.pg, x.pg->add_function<Cube>({x.i}), "cube(const Expression& x)"); }
-Expression logistic(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogisticSigmoid>({x.i}), "logistic(const Expression& x)"); }
-Expression rectify(const Expression& x) { return Expression(x.pg, x.pg->add_function<Rectify>({x.i}), "rectify(const Expression& x)"); }
-Expression hinge(const Expression& x, unsigned index, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, index, m), "hinge(const Expression& x, unsigned index, float m)"); }
-Expression hinge(const Expression& x, const unsigned* pindex, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, pindex, m), "hinge(const Expression& x, const unsigned* pindex, float m)"); }
-Expression hinge(const Expression& x, const std::vector<unsigned> & indices, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, indices, m), "hinge(const Expression& x, const std::vector<unsigned> & indices, float m)"); }
-Expression hinge(const Expression& x, const std::vector<unsigned> * pindices, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, pindices, m), "hinge(const Expression& x, const std::vector<unsigned> * pindices, float m)"); }
-Expression log_softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogSoftmax>({x.i}), "log_softmax(const Expression& x)"); }
-Expression log_softmax(const Expression& x, const vector<unsigned>& d) { return Expression(x.pg, x.pg->add_function<RestrictedLogSoftmax>({x.i}, d), "log_softmax(const Expression& x, const vector<unsigned>& d)"); }
-Expression sparsemax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sparsemax>({x.i}), "sparsemax(const Expression& x)"); }
-Expression sparsemax_loss(const Expression& x, const vector<unsigned>& target_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, target_support), "sparsemax_loss(const Expression& x, const vector<unsigned>& target_support)"); }
-Expression sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, ptarget_support), "sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support)"); }
-Expression softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i}), "softmax(const Expression& x)"); }
-Expression softsign(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i}), "softsign(const Expression& x)"); }
-Expression pow(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Pow>({x.i, y.i}), "pow(const Expression& x, const Expression& y)"); }
-Expression min(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Min>({x.i, y.i}), "min(const Expression& x, const Expression& y)"); }
-Expression max(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Max>({x.i, y.i}), "max(const Expression& x, const Expression& y)"); }
-Expression noise(const Expression& x, real stddev) { return Expression(x.pg, x.pg->add_function<GaussianNoise>({x.i}, stddev), "noise(const Expression& x, real stddev)"); }
-Expression dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<Dropout>({x.i}, p), "dropout(const Expression& x, real p)"); }
-Expression block_dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<BlockDropout>({x.i}, p), "block_dropout(const Expression& x, real p)"); }
+Expression sqrt(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sqrt>({x.i})); }
+Expression erf(const Expression& x) { return Expression(x.pg, x.pg->add_function<Erf>({x.i})); }
+Expression tanh(const Expression& x) { return Expression(x.pg, x.pg->add_function<Tanh>({x.i})); }
+Expression lgamma(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogGamma>({x.i})); }
+Expression log(const Expression& x) { return Expression(x.pg, x.pg->add_function<Log>({x.i})); }
+Expression exp(const Expression& x) { return Expression(x.pg, x.pg->add_function<Exp>({x.i})); }
+Expression square(const Expression& x) { return Expression(x.pg, x.pg->add_function<Square>({x.i})); }
+Expression cube(const Expression& x) { return Expression(x.pg, x.pg->add_function<Cube>({x.i})); }
+Expression logistic(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogisticSigmoid>({x.i})); }
+Expression rectify(const Expression& x) { return Expression(x.pg, x.pg->add_function<Rectify>({x.i})); }
+Expression hinge(const Expression& x, unsigned index, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, index, m)); }
+Expression hinge(const Expression& x, const unsigned* pindex, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, pindex, m)); }
+Expression hinge(const Expression& x, const std::vector<unsigned> & indices, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, indices, m)); }
+Expression hinge(const Expression& x, const std::vector<unsigned> * pindices, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, pindices, m)); }
+Expression log_softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogSoftmax>({x.i})); }
+Expression log_softmax(const Expression& x, const vector<unsigned>& d) { return Expression(x.pg, x.pg->add_function<RestrictedLogSoftmax>({x.i}, d)); }
+Expression sparsemax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sparsemax>({x.i})); }
+Expression sparsemax_loss(const Expression& x, const vector<unsigned>& target_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, target_support)); }
+Expression sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, ptarget_support)); }
+Expression softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i})); }
+Expression softsign(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i})); }
+Expression pow(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Pow>({x.i, y.i})); }
+Expression min(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Min>({x.i, y.i})); }
+Expression max(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Max>({x.i, y.i})); }
+Expression noise(const Expression& x, real stddev) { return Expression(x.pg, x.pg->add_function<GaussianNoise>({x.i}, stddev)); }
+Expression dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<Dropout>({x.i}, p)); }
+Expression block_dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<BlockDropout>({x.i}, p)); }
 
-Expression reshape(const Expression& x, const Dim& d) { return Expression(x.pg, x.pg->add_function<Reshape>({x.i}, d), "reshape(const Expression& x, const Dim& d)"); }
-Expression transpose(const Expression& x) { return Expression(x.pg, x.pg->add_function<Transpose>({x.i}), "transpose(const Expression& x)"); }
-Expression select_rows(const Expression& x, const vector<unsigned>& rows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, rows), "select_rows(const Expression& x, const vector<unsigned>& rows)"); }
-Expression select_rows(const Expression& x, const vector<unsigned>* prows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, prows), "select_rows(const Expression& x, const vector<unsigned>* prows)"); }
-Expression select_cols(const Expression& x, const vector<unsigned>& cols) { return Expression(x.pg, x.pg->add_function<SelectCols>({x.i}, cols), "select_cols(const Expression& x, const vector<unsigned>& cols)"); }
-Expression select_cols(const Expression& x, const vector<unsigned>* pcols) { return Expression(x.pg, x.pg->add_function<SelectCols>({x.i}, pcols), "select_cols(const Expression& x, const vector<unsigned>* pcols)"); }
-Expression inverse(const Expression& x) { return Expression(x.pg, x.pg->add_function<MatrixInverse>({x.i}), "inverse(const Expression& x)"); }
-Expression logdet(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogDet>({x.i}), "logdet(const Expression& x)"); }
+Expression reshape(const Expression& x, const Dim& d) { return Expression(x.pg, x.pg->add_function<Reshape>({x.i}, d)); }
+Expression transpose(const Expression& x) { return Expression(x.pg, x.pg->add_function<Transpose>({x.i})); }
+Expression select_rows(const Expression& x, const vector<unsigned>& rows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, rows)); }
+Expression select_rows(const Expression& x, const vector<unsigned>* prows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, prows)); }
+Expression select_cols(const Expression& x, const vector<unsigned>& cols) { return Expression(x.pg, x.pg->add_function<SelectCols>({x.i}, cols)); }
+Expression select_cols(const Expression& x, const vector<unsigned>* pcols) { return Expression(x.pg, x.pg->add_function<SelectCols>({x.i}, pcols)); }
+Expression inverse(const Expression& x) { return Expression(x.pg, x.pg->add_function<MatrixInverse>({x.i})); }
+Expression logdet(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogDet>({x.i})); }
 
-Expression trace_of_product(const Expression& x, const Expression& y) {return Expression(x.pg, x.pg->add_function<TraceOfProduct>({x.i, y.i}), "trace_of_product(const Expression& x, const Expression& y)");}
+Expression trace_of_product(const Expression& x, const Expression& y) {return Expression(x.pg, x.pg->add_function<TraceOfProduct>({x.i, y.i}));}
 
-Expression squared_norm(const Expression& x) { return Expression(x.pg, x.pg->add_function<SquaredNorm>({x.i}), "squared_norm(const Expression& x)"); }
+Expression squared_norm(const Expression& x) { return Expression(x.pg, x.pg->add_function<SquaredNorm>({x.i})); }
 
-Expression dot_product(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<DotProduct>({x.i, y.i}), "dot_product(const Expression& x, const Expression& y)"); }
-Expression squared_distance(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<SquaredEuclideanDistance>({x.i, y.i}), "squared_distance(const Expression& x, const Expression& y)"); }
-Expression huber_distance(const Expression& x, const Expression& y, real c) { return Expression(x.pg, x.pg->add_function<HuberDistance>({x.i, y.i}, c), "huber_distance(const Expression& x, const Expression& y, real c)"); }
-Expression l1_distance(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<L1Distance>({x.i, y.i}), "l1_distance(const Expression& x, const Expression& y)"); }
-Expression binary_log_loss(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<BinaryLogLoss>({x.i, y.i}), "binary_log_loss(const Expression& x, const Expression& y)"); }
-Expression pairwise_rank_loss(const Expression& x, const Expression& y, real m) { return Expression(x.pg, x.pg->add_function<PairwiseRankLoss>({x.i, y.i}, m), "pairwise_rank_loss(const Expression& x, const Expression& y, real m)"); }
-Expression poisson_loss(const Expression& x, unsigned y) { return Expression(x.pg, x.pg->add_function<PoissonRegressionLoss>({x.i}, y), "poisson_loss(const Expression& x, unsigned y)"); }
-Expression poisson_loss(const Expression& x, const unsigned* py) { return Expression(x.pg, x.pg->add_function<PoissonRegressionLoss>({x.i}, py), "poisson_loss(const Expression& x, const unsigned* py)"); }
+Expression dot_product(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<DotProduct>({x.i, y.i})); }
+Expression squared_distance(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<SquaredEuclideanDistance>({x.i, y.i})); }
+Expression huber_distance(const Expression& x, const Expression& y, real c) { return Expression(x.pg, x.pg->add_function<HuberDistance>({x.i, y.i}, c)); }
+Expression l1_distance(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<L1Distance>({x.i, y.i})); }
+Expression binary_log_loss(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<BinaryLogLoss>({x.i, y.i})); }
+Expression pairwise_rank_loss(const Expression& x, const Expression& y, real m) { return Expression(x.pg, x.pg->add_function<PairwiseRankLoss>({x.i, y.i}, m)); }
+Expression poisson_loss(const Expression& x, unsigned y) { return Expression(x.pg, x.pg->add_function<PoissonRegressionLoss>({x.i}, y)); }
+Expression poisson_loss(const Expression& x, const unsigned* py) { return Expression(x.pg, x.pg->add_function<PoissonRegressionLoss>({x.i}, py)); }
 
-Expression conv1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DNarrow>({x.i, f.i}), "conv1d_narrow(const Expression& x, const Expression& f)"); }
-Expression conv1d_wide(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DWide>({x.i, f.i}), "conv1d_wide(const Expression& x, const Expression& f)"); }
-Expression filter1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Filter1DNarrow>({x.i, f.i}), "filter1d_narrow(const Expression& x, const Expression& f)"); }
-Expression kmax_pooling(const Expression& x, unsigned k) { return Expression(x.pg, x.pg->add_function<KMaxPooling>({x.i}, k), "kmax_pooling(const Expression& x, unsigned k)"); }
-Expression fold_rows(const Expression& x, unsigned nrows) { return Expression(x.pg, x.pg->add_function<FoldRows>({x.i}, nrows), "fold_rows(const Expression& x, unsigned nrows)"); }
+Expression conv1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DNarrow>({x.i, f.i})); }
+Expression conv1d_wide(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DWide>({x.i, f.i})); }
+Expression filter1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Filter1DNarrow>({x.i, f.i})); }
+Expression kmax_pooling(const Expression& x, unsigned k) { return Expression(x.pg, x.pg->add_function<KMaxPooling>({x.i}, k)); }
+Expression fold_rows(const Expression& x, unsigned nrows) { return Expression(x.pg, x.pg->add_function<FoldRows>({x.i}, nrows)); }
 
-Expression pick(const Expression& x, unsigned v, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, v, d), "pick(const Expression& x, unsigned v, unsigned d)"); }
-Expression pick(const Expression& x, const vector<unsigned> & v, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, v, d), "pick(const Expression& x, const vector<unsigned> & v, unsigned d)"); }
-Expression pick(const Expression& x, const unsigned* pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d), "pick(const Expression& x, const unsigned* pv, unsigned d)"); }
-Expression pick(const Expression& x, const vector<unsigned> * pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d), "pick(const Expression& x, const vector<unsigned> * pv, unsigned d)"); }
+Expression pick(const Expression& x, unsigned v, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, v, d)); }
+Expression pick(const Expression& x, const vector<unsigned> & v, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, v, d)); }
+Expression pick(const Expression& x, const unsigned* pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
+Expression pick(const Expression& x, const vector<unsigned> * pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
 
-Expression pickrange(const Expression& x, unsigned v, unsigned u) { return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u), "pickrange(const Expression& x, unsigned v, unsigned u)"); }
+Expression pickrange(const Expression& x, unsigned v, unsigned u) { return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u)); }
 
-Expression pickneglogsoftmax(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v), "pickneglogsoftmax(const Expression& x, unsigned v)"); }
-Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> & v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v), "pickneglogsoftmax(const Expression& x, const vector<unsigned> & v)"); }
-Expression pickneglogsoftmax(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv), "pickneglogsoftmax(const Expression& x, const unsigned* pv)"); }
-Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> * pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv), "pickneglogsoftmax(const Expression& x, const vector<unsigned> * pv)"); }
+Expression pickneglogsoftmax(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v)); }
+Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> & v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v)); }
+Expression pickneglogsoftmax(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv)); }
+Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> * pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv)); }
 
-Expression average_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<AverageColumns>({x.i}), "average_cols(const Expression& x)"); }
-Expression sum_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, d), "sum_dim(const Expression& x, unsigned d)"); }
-Expression sum_rows(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 0), "sum_rows(const Expression& x)"); }
-Expression sum_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 1), "sum_cols(const Expression& x)"); }
+Expression average_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<AverageColumns>({x.i})); }
+Expression sum_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, d)); }
+Expression sum_rows(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 0)); }
+Expression sum_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 1)); }
 
-Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumBatches>({x.i}), "sum_batches(const Expression& x)"); }
+Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumBatches>({x.i})); }
 
-Expression kmh_ngram(const Expression& x, unsigned n) { return Expression(x.pg, x.pg->add_function<KMHNGram>({x.i}, n), "kmh_ngram(const Expression& x, unsigned n)"); }
+Expression kmh_ngram(const Expression& x, unsigned n) { return Expression(x.pg, x.pg->add_function<KMHNGram>({x.i}, n)); }
 
 
 }

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -5,128 +5,130 @@
 #include "dynet/nodes.h"
 #include "dynet/nodes-conv.h"
 
-namespace dynet { namespace expr {
+namespace dynet {
+namespace expr {
 
 using std::vector;
 
-Expression input(ComputationGraph& g, real s) { return Expression(&g, g.add_input(s)); }
-Expression input(ComputationGraph& g, const real *ps) { return Expression(&g, g.add_input(ps)); }
-Expression input(ComputationGraph& g, const Dim& d, const vector<float>& data) { return Expression(&g, g.add_input(d, data)); }
-Expression input(ComputationGraph& g, const Dim& d, const vector<float>* pdata) { return Expression(&g, g.add_input(d, pdata)); }
-Expression input(ComputationGraph& g, const Dim& d, const vector<unsigned int>& ids, const vector<float>& data, float defdata) { return Expression(&g, g.add_input(d, ids, data, defdata)); }
-Expression const_parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_const_parameters(p)); }
-Expression parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_parameters(p)); }
-Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_lookup(p, index)); }
-Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_lookup(p, pindex)); }
-Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_lookup(p, indices)); }
-Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices) { return Expression(&g, g.add_lookup(p, pindices)); }
-Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_const_lookup(p, index)); }
-Expression const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_const_lookup(p, pindex)); }
-Expression const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_const_lookup(p, indices)); }
-Expression const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices) { return Expression(&g, g.add_const_lookup(p, pindices)); }
-Expression zeroes(ComputationGraph& g, const Dim& d) { return Expression(&g, g.add_function<Zeroes>(d)); }
-Expression random_normal(ComputationGraph& g, const Dim& d) { return Expression(&g, g.add_function<RandomNormal>(d)); }
-Expression random_bernoulli(ComputationGraph& g, const Dim& d, real p, real scale) { return Expression(&g, g.add_function<RandomBernoulli>({}, d, p, scale)); }
-Expression random_uniform(ComputationGraph& g, const Dim& d, real left, real right) { return Expression(&g, g.add_function<RandomUniform>({}, d, left, right)); }
+Expression input(ComputationGraph& g, real s) { return Expression(&g, g.add_input(s), "input(ComputationGraph& g, real s)"); }
+Expression input(ComputationGraph& g, const real *ps) { return Expression(&g, g.add_input(ps), "input(ComputationGraph& g, const real *ps)"); }
+Expression input(ComputationGraph& g, const Dim& d, const vector<float>& data) { return Expression(&g, g.add_input(d, data), "input(ComputationGraph& g, const Dim& d, const vector<float>& data)"); }
+Expression input(ComputationGraph& g, const Dim& d, const vector<float>* pdata) { return Expression(&g, g.add_input(d, pdata), "input(ComputationGraph& g, const Dim& d, const vector<float>* pdata)"); }
+Expression input(ComputationGraph& g, const Dim& d, const vector<unsigned int>& ids, const vector<float>& data, float defdata) { return Expression(&g, g.add_input(d, ids, data, defdata), "input(ComputationGraph& g, const Dim& d, const vector<unsigned int>& ids, const vector<float>& data, float defdata)"); }
+Expression const_parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_const_parameters(p), "const_parameter(ComputationGraph& g, Parameter p)"); }
+Expression parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_parameters(p), "parameter(ComputationGraph& g, Parameter p)"); }
+Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_lookup(p, index), "lookup(ComputationGraph& g, LookupParameter p, unsigned index)"); }
+Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_lookup(p, pindex), "lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex)"); }
+Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_lookup(p, indices), "lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices)"); }
+Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices) { return Expression(&g, g.add_lookup(p, pindices), "lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices)"); }
+Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_const_lookup(p, index), "const_lookup(ComputationGraph& g, LookupParameter p, unsigned index)"); }
+Expression const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_const_lookup(p, pindex), "const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex)"); }
+Expression const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_const_lookup(p, indices), "const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices)"); }
+Expression const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices) { return Expression(&g, g.add_const_lookup(p, pindices), "const_lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>* pindices)"); }
+Expression zeroes(ComputationGraph& g, const Dim& d) { return Expression(&g, g.add_function<Zeroes>(d), "zeroes(ComputationGraph& g, const Dim& d)"); }
+Expression random_normal(ComputationGraph& g, const Dim& d) { return Expression(&g, g.add_function<RandomNormal>(d), "random_normal(ComputationGraph& g, const Dim& d)"); }
+Expression random_bernoulli(ComputationGraph& g, const Dim& d, real p, real scale) { return Expression(&g, g.add_function<RandomBernoulli>({}, d, p, scale), "random_bernoulli(ComputationGraph& g, const Dim& d, real p, real scale)"); }
+Expression random_uniform(ComputationGraph& g, const Dim& d, real left, real right) { return Expression(&g, g.add_function<RandomUniform>({}, d, left, right), "random_uniform(ComputationGraph& g, const Dim& d, real left, real right)"); }
 
 // identity function, but derivative is not propagated through it
-Expression nobackprop(const Expression& x) { return Expression(x.pg, x.pg->add_function<NoBackprop>({x.i})); }
+Expression nobackprop(const Expression& x) { return Expression(x.pg, x.pg->add_function<NoBackprop>({x.i}), "nobackprop(const Expression& x)"); }
 // identity function, but derivative is propagated as negative
-Expression flip_gradient(const Expression& x) { return Expression(x.pg, x.pg->add_function<FlipGradient>({x.i})); }
+Expression flip_gradient(const Expression& x) { return Expression(x.pg, x.pg->add_function<FlipGradient>({x.i}), "flip_gradient(const Expression& x)"); }
 
-Expression operator-(const Expression& x) { return Expression(x.pg, x.pg->add_function<Negate>({x.i})); }
-Expression operator+(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Sum>({x.i, y.i})); }
-Expression operator+(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantPlusX>({y.i}, x)); }
-Expression operator+(const Expression& x, real y) { return y+x; }
-Expression operator-(const Expression& x, const Expression& y) { return x+(-y); }
-Expression operator-(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantMinusX>({y.i}, x)); }
-Expression operator-(const Expression& x, real y) { return -(y-x); }
-Expression operator*(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<MatrixMultiply>({x.i, y.i})); }
-Expression operator*(const Expression& x, float y) { return Expression(x.pg, x.pg->add_function<ConstScalarMultiply>({x.i}, y)); }
-Expression cmult(const Expression& x, const Expression& y) {return Expression(x.pg, x.pg->add_function<CwiseMultiply>({x.i, y.i}));}
-Expression cdiv(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<CwiseQuotient>({x.i, y.i})); }
-Expression colwise_add(const Expression& x, const Expression& bias) { return Expression(x.pg, x.pg->add_function<AddVectorToAllColumns>({x.i, bias.i})); }
-Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D_1D>({x.i, y.i, z.i})); }
-Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z, const Expression& b) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D_1D>({x.i, y.i, z.i, b.i})); }
-Expression contract3d_1d(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D>({x.i, y.i})); }
-Expression contract3d_1d(const Expression& x, const Expression& y, const Expression& b) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D>({x.i, y.i, b.i})); }
+Expression operator-(const Expression& x) { return Expression(x.pg, x.pg->add_function<Negate>({x.i}), "operator-(const Expression& x)"); }
+Expression operator+(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Sum>({x.i, y.i}), "operator+(const Expression& x, const Expression& y)"); }
+Expression operator+(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantPlusX>({y.i}, x), "operator+(real x, const Expression& y)"); }
+Expression operator+(const Expression& x, real y) { return y + x; }
+Expression operator-(const Expression& x, const Expression& y) { return x + (-y); }
+Expression operator-(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantMinusX>({y.i}, x), "operator-(real x, const Expression& y)"); }
+Expression operator-(const Expression& x, real y) { return -(y - x); }
+Expression operator*(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<MatrixMultiply>({x.i, y.i}), "operator*(const Expression& x, const Expression& y)"); }
+Expression operator*(const Expression& x, float y) { return Expression(x.pg, x.pg->add_function<ConstScalarMultiply>({x.i}, y), "operator*(const Expression& x, float y)"); }
+Expression cmult(const Expression& x, const Expression& y) {return Expression(x.pg, x.pg->add_function<CwiseMultiply>({x.i, y.i}), "cmult(const Expression& x, const Expression& y)");}
+Expression cdiv(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<CwiseQuotient>({x.i, y.i}), "cdiv(const Expression& x, const Expression& y)"); }
+Expression colwise_add(const Expression& x, const Expression& bias) { return Expression(x.pg, x.pg->add_function<AddVectorToAllColumns>({x.i, bias.i}), "colwise_add(const Expression& x, const Expression& bias)"); }
+Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D_1D>({x.i, y.i, z.i}), "contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z)"); }
+Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z, const Expression& b) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D_1D>({x.i, y.i, z.i, b.i}), "contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z, const Expression& b)"); }
+Expression contract3d_1d(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D>({x.i, y.i}), "contract3d_1d(const Expression& x, const Expression& y)"); }
+Expression contract3d_1d(const Expression& x, const Expression& y, const Expression& b) { return Expression(x.pg, x.pg->add_function<InnerProduct3D_1D>({x.i, y.i, b.i}), "contract3d_1d(const Expression& x, const Expression& y, const Expression& b)"); }
 
-Expression sqrt(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sqrt>({x.i})); }
-Expression erf(const Expression& x) { return Expression(x.pg, x.pg->add_function<Erf>({x.i})); }
-Expression tanh(const Expression& x) { return Expression(x.pg, x.pg->add_function<Tanh>({x.i})); }
-Expression lgamma(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogGamma>({x.i})); }
-Expression log(const Expression& x) { return Expression(x.pg, x.pg->add_function<Log>({x.i})); }
-Expression exp(const Expression& x) { return Expression(x.pg, x.pg->add_function<Exp>({x.i})); }
-Expression square(const Expression& x) { return Expression(x.pg, x.pg->add_function<Square>({x.i})); }
-Expression cube(const Expression& x) { return Expression(x.pg, x.pg->add_function<Cube>({x.i})); }
-Expression logistic(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogisticSigmoid>({x.i})); }
-Expression rectify(const Expression& x) { return Expression(x.pg, x.pg->add_function<Rectify>({x.i})); }
-Expression hinge(const Expression& x, unsigned index, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, index, m)); }
-Expression hinge(const Expression& x, const unsigned* pindex, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, pindex, m)); }
-Expression hinge(const Expression& x, const std::vector<unsigned> & indices, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, indices, m)); }
-Expression hinge(const Expression& x, const std::vector<unsigned> * pindices, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, pindices, m)); }
-Expression log_softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogSoftmax>({x.i})); }
-Expression log_softmax(const Expression& x, const vector<unsigned>& d) { return Expression(x.pg, x.pg->add_function<RestrictedLogSoftmax>({x.i}, d)); }
-Expression sparsemax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sparsemax>({x.i})); }
-Expression sparsemax_loss(const Expression& x, const vector<unsigned>& target_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, target_support)); }
-Expression sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, ptarget_support)); }
-Expression softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i})); }
-Expression softsign(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i})); }
-Expression pow(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Pow>({x.i, y.i})); }
-Expression min(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Min>({x.i, y.i})); }
-Expression max(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Max>({x.i, y.i})); }
-Expression noise(const Expression& x, real stddev) { return Expression(x.pg, x.pg->add_function<GaussianNoise>({x.i}, stddev)); }
-Expression dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<Dropout>({x.i}, p)); }
-Expression block_dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<BlockDropout>({x.i}, p)); }
+Expression sqrt(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sqrt>({x.i}), "sqrt(const Expression& x)"); }
+Expression erf(const Expression& x) { return Expression(x.pg, x.pg->add_function<Erf>({x.i}), "erf(const Expression& x)"); }
+Expression tanh(const Expression& x) { return Expression(x.pg, x.pg->add_function<Tanh>({x.i}), "tanh(const Expression& x)"); }
+Expression lgamma(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogGamma>({x.i}), "lgamma(const Expression& x)"); }
+Expression log(const Expression& x) { return Expression(x.pg, x.pg->add_function<Log>({x.i}), "log(const Expression& x)"); }
+Expression exp(const Expression& x) { return Expression(x.pg, x.pg->add_function<Exp>({x.i}), "exp(const Expression& x)"); }
+Expression square(const Expression& x) { return Expression(x.pg, x.pg->add_function<Square>({x.i}), "square(const Expression& x)"); }
+Expression cube(const Expression& x) { return Expression(x.pg, x.pg->add_function<Cube>({x.i}), "cube(const Expression& x)"); }
+Expression logistic(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogisticSigmoid>({x.i}), "logistic(const Expression& x)"); }
+Expression rectify(const Expression& x) { return Expression(x.pg, x.pg->add_function<Rectify>({x.i}), "rectify(const Expression& x)"); }
+Expression hinge(const Expression& x, unsigned index, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, index, m), "hinge(const Expression& x, unsigned index, float m)"); }
+Expression hinge(const Expression& x, const unsigned* pindex, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, pindex, m), "hinge(const Expression& x, const unsigned* pindex, float m)"); }
+Expression hinge(const Expression& x, const std::vector<unsigned> & indices, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, indices, m), "hinge(const Expression& x, const std::vector<unsigned> & indices, float m)"); }
+Expression hinge(const Expression& x, const std::vector<unsigned> * pindices, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, pindices, m), "hinge(const Expression& x, const std::vector<unsigned> * pindices, float m)"); }
+Expression log_softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogSoftmax>({x.i}), "log_softmax(const Expression& x)"); }
+Expression log_softmax(const Expression& x, const vector<unsigned>& d) { return Expression(x.pg, x.pg->add_function<RestrictedLogSoftmax>({x.i}, d), "log_softmax(const Expression& x, const vector<unsigned>& d)"); }
+Expression sparsemax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sparsemax>({x.i}), "sparsemax(const Expression& x)"); }
+Expression sparsemax_loss(const Expression& x, const vector<unsigned>& target_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, target_support), "sparsemax_loss(const Expression& x, const vector<unsigned>& target_support)"); }
+Expression sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, ptarget_support), "sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support)"); }
+Expression softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i}), "softmax(const Expression& x)"); }
+Expression softsign(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i}), "softsign(const Expression& x)"); }
+Expression pow(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Pow>({x.i, y.i}), "pow(const Expression& x, const Expression& y)"); }
+Expression min(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Min>({x.i, y.i}), "min(const Expression& x, const Expression& y)"); }
+Expression max(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Max>({x.i, y.i}), "max(const Expression& x, const Expression& y)"); }
+Expression noise(const Expression& x, real stddev) { return Expression(x.pg, x.pg->add_function<GaussianNoise>({x.i}, stddev), "noise(const Expression& x, real stddev)"); }
+Expression dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<Dropout>({x.i}, p), "dropout(const Expression& x, real p)"); }
+Expression block_dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<BlockDropout>({x.i}, p), "block_dropout(const Expression& x, real p)"); }
 
-Expression reshape(const Expression& x, const Dim& d) { return Expression(x.pg, x.pg->add_function<Reshape>({x.i}, d)); }
-Expression transpose(const Expression& x) { return Expression(x.pg, x.pg->add_function<Transpose>({x.i})); }
-Expression select_rows(const Expression& x, const vector<unsigned>& rows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, rows)); }
-Expression select_rows(const Expression& x, const vector<unsigned>* prows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, prows)); }
-Expression select_cols(const Expression& x, const vector<unsigned>& cols) { return Expression(x.pg, x.pg->add_function<SelectCols>({x.i}, cols)); }
-Expression select_cols(const Expression& x, const vector<unsigned>* pcols) { return Expression(x.pg, x.pg->add_function<SelectCols>({x.i}, pcols)); }
-Expression inverse(const Expression& x) { return Expression(x.pg, x.pg->add_function<MatrixInverse>({x.i})); }
-Expression logdet(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogDet>({x.i})); }
+Expression reshape(const Expression& x, const Dim& d) { return Expression(x.pg, x.pg->add_function<Reshape>({x.i}, d), "reshape(const Expression& x, const Dim& d)"); }
+Expression transpose(const Expression& x) { return Expression(x.pg, x.pg->add_function<Transpose>({x.i}), "transpose(const Expression& x)"); }
+Expression select_rows(const Expression& x, const vector<unsigned>& rows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, rows), "select_rows(const Expression& x, const vector<unsigned>& rows)"); }
+Expression select_rows(const Expression& x, const vector<unsigned>* prows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, prows), "select_rows(const Expression& x, const vector<unsigned>* prows)"); }
+Expression select_cols(const Expression& x, const vector<unsigned>& cols) { return Expression(x.pg, x.pg->add_function<SelectCols>({x.i}, cols), "select_cols(const Expression& x, const vector<unsigned>& cols)"); }
+Expression select_cols(const Expression& x, const vector<unsigned>* pcols) { return Expression(x.pg, x.pg->add_function<SelectCols>({x.i}, pcols), "select_cols(const Expression& x, const vector<unsigned>* pcols)"); }
+Expression inverse(const Expression& x) { return Expression(x.pg, x.pg->add_function<MatrixInverse>({x.i}), "inverse(const Expression& x)"); }
+Expression logdet(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogDet>({x.i}), "logdet(const Expression& x)"); }
 
-Expression trace_of_product(const Expression& x, const Expression& y) {return Expression(x.pg, x.pg->add_function<TraceOfProduct>({x.i, y.i}));}
+Expression trace_of_product(const Expression& x, const Expression& y) {return Expression(x.pg, x.pg->add_function<TraceOfProduct>({x.i, y.i}), "trace_of_product(const Expression& x, const Expression& y)");}
 
-Expression squared_norm(const Expression& x) { return Expression(x.pg, x.pg->add_function<SquaredNorm>({x.i})); }
+Expression squared_norm(const Expression& x) { return Expression(x.pg, x.pg->add_function<SquaredNorm>({x.i}), "squared_norm(const Expression& x)"); }
 
-Expression dot_product(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<DotProduct>({x.i, y.i})); }
-Expression squared_distance(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<SquaredEuclideanDistance>({x.i, y.i})); }
-Expression huber_distance(const Expression& x, const Expression& y, real c) { return Expression(x.pg, x.pg->add_function<HuberDistance>({x.i, y.i}, c)); }
-Expression l1_distance(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<L1Distance>({x.i, y.i})); }
-Expression binary_log_loss(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<BinaryLogLoss>({x.i,y.i})); }
-Expression pairwise_rank_loss(const Expression& x, const Expression& y, real m) { return Expression(x.pg, x.pg->add_function<PairwiseRankLoss>({x.i, y.i}, m)); }
-Expression poisson_loss(const Expression& x, unsigned y) { return Expression(x.pg, x.pg->add_function<PoissonRegressionLoss>({x.i}, y)); }
-Expression poisson_loss(const Expression& x, const unsigned* py) { return Expression(x.pg, x.pg->add_function<PoissonRegressionLoss>({x.i}, py)); }
+Expression dot_product(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<DotProduct>({x.i, y.i}), "dot_product(const Expression& x, const Expression& y)"); }
+Expression squared_distance(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<SquaredEuclideanDistance>({x.i, y.i}), "squared_distance(const Expression& x, const Expression& y)"); }
+Expression huber_distance(const Expression& x, const Expression& y, real c) { return Expression(x.pg, x.pg->add_function<HuberDistance>({x.i, y.i}, c), "huber_distance(const Expression& x, const Expression& y, real c)"); }
+Expression l1_distance(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<L1Distance>({x.i, y.i}), "l1_distance(const Expression& x, const Expression& y)"); }
+Expression binary_log_loss(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<BinaryLogLoss>({x.i, y.i}), "binary_log_loss(const Expression& x, const Expression& y)"); }
+Expression pairwise_rank_loss(const Expression& x, const Expression& y, real m) { return Expression(x.pg, x.pg->add_function<PairwiseRankLoss>({x.i, y.i}, m), "pairwise_rank_loss(const Expression& x, const Expression& y, real m)"); }
+Expression poisson_loss(const Expression& x, unsigned y) { return Expression(x.pg, x.pg->add_function<PoissonRegressionLoss>({x.i}, y), "poisson_loss(const Expression& x, unsigned y)"); }
+Expression poisson_loss(const Expression& x, const unsigned* py) { return Expression(x.pg, x.pg->add_function<PoissonRegressionLoss>({x.i}, py), "poisson_loss(const Expression& x, const unsigned* py)"); }
 
-Expression conv1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DNarrow>({x.i, f.i})); }
-Expression conv1d_wide(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DWide>({x.i, f.i})); }
-Expression filter1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Filter1DNarrow>({x.i, f.i})); }
-Expression kmax_pooling(const Expression& x, unsigned k) { return Expression(x.pg, x.pg->add_function<KMaxPooling>({x.i}, k)); }
-Expression fold_rows(const Expression& x, unsigned nrows) { return Expression(x.pg, x.pg->add_function<FoldRows>({x.i}, nrows)); }
+Expression conv1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DNarrow>({x.i, f.i}), "conv1d_narrow(const Expression& x, const Expression& f)"); }
+Expression conv1d_wide(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DWide>({x.i, f.i}), "conv1d_wide(const Expression& x, const Expression& f)"); }
+Expression filter1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Filter1DNarrow>({x.i, f.i}), "filter1d_narrow(const Expression& x, const Expression& f)"); }
+Expression kmax_pooling(const Expression& x, unsigned k) { return Expression(x.pg, x.pg->add_function<KMaxPooling>({x.i}, k), "kmax_pooling(const Expression& x, unsigned k)"); }
+Expression fold_rows(const Expression& x, unsigned nrows) { return Expression(x.pg, x.pg->add_function<FoldRows>({x.i}, nrows), "fold_rows(const Expression& x, unsigned nrows)"); }
 
-Expression pick(const Expression& x, unsigned v, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, v, d)); }
-Expression pick(const Expression& x, const vector<unsigned> & v, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, v, d)); }
-Expression pick(const Expression& x, const unsigned* pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
-Expression pick(const Expression& x, const vector<unsigned> * pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
+Expression pick(const Expression& x, unsigned v, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, v, d), "pick(const Expression& x, unsigned v, unsigned d)"); }
+Expression pick(const Expression& x, const vector<unsigned> & v, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, v, d), "pick(const Expression& x, const vector<unsigned> & v, unsigned d)"); }
+Expression pick(const Expression& x, const unsigned* pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d), "pick(const Expression& x, const unsigned* pv, unsigned d)"); }
+Expression pick(const Expression& x, const vector<unsigned> * pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d), "pick(const Expression& x, const vector<unsigned> * pv, unsigned d)"); }
 
-Expression pickrange(const Expression& x, unsigned v, unsigned u) { return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u)); }
+Expression pickrange(const Expression& x, unsigned v, unsigned u) { return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u), "pickrange(const Expression& x, unsigned v, unsigned u)"); }
 
-Expression pickneglogsoftmax(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v)); }
-Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> & v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v)); }
-Expression pickneglogsoftmax(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv)); }
-Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> * pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv)); }
+Expression pickneglogsoftmax(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v), "pickneglogsoftmax(const Expression& x, unsigned v)"); }
+Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> & v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v), "pickneglogsoftmax(const Expression& x, const vector<unsigned> & v)"); }
+Expression pickneglogsoftmax(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv), "pickneglogsoftmax(const Expression& x, const unsigned* pv)"); }
+Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> * pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv), "pickneglogsoftmax(const Expression& x, const vector<unsigned> * pv)"); }
 
-Expression average_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<AverageColumns>({x.i})); }
-Expression sum_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, d)); }
-Expression sum_rows(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 0)); }
-Expression sum_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 1)); }
+Expression average_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<AverageColumns>({x.i}), "average_cols(const Expression& x)"); }
+Expression sum_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, d), "sum_dim(const Expression& x, unsigned d)"); }
+Expression sum_rows(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 0), "sum_rows(const Expression& x)"); }
+Expression sum_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 1), "sum_cols(const Expression& x)"); }
 
-Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumBatches>({x.i})); }
+Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumBatches>({x.i}), "sum_batches(const Expression& x)"); }
 
-Expression kmh_ngram(const Expression& x, unsigned n) { return Expression(x.pg, x.pg->add_function<KMHNGram>({x.i}, n)); }
+Expression kmh_ngram(const Expression& x, unsigned n) { return Expression(x.pg, x.pg->add_function<KMHNGram>({x.i}, n), "kmh_ngram(const Expression& x, unsigned n)"); }
 
 
-} }
+}
+}

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -10,7 +10,7 @@
  * \defgroup tensoroperations tensoroperations
  * \defgroup linalgoperations linalgoperations
  * \brief The various operations that you can use in building a DyNet graph
- * 
+ *
  * \details TODO: **This documentation is incomplete. See expr.h for a full list of expressions.**
  */
 
@@ -20,39 +20,71 @@
 #include "dynet/dynet.h"
 #include "dynet/nodes.h"
 #include "dynet/nodes-contract.h"
+#include <stdexcept>
+#include <sstream>
 
-namespace dynet { namespace expr {
+
+namespace dynet {
+namespace expr {
 /**
  * \ingroup operations
- * \brief Expressions are the building block of a Dynet computation graph 
+ * \brief Expressions are the building block of a Dynet computation graph
  * \details [long description]
  */
 struct Expression {
   ComputationGraph *pg;
   VariableIndex i;
+  unsigned graph_id;
+  std::string name;
 
-  Expression() : pg(nullptr) { }
+  Expression() : pg(nullptr), i(0), graph_id(0), name("Empty expression") { }
+  const bool is_stale() const {return (get_number_of_active_graphs() != 1 || graph_id != get_current_graph_id());}
   /**
    * \brief Base expression constructor
-   * \details [long description]
-   * 
-   * \param pg [description]
-   * \param i [description]
+   * \details Used when creating operations
+   *
+   * \param pg Pointer to the computation graph
+   * \param i Variable index
+   * \param name Name of the expression
    */
-  Expression(ComputationGraph *pg, VariableIndex i) : pg(pg), i(i) { }
-  const Tensor& value() const { return pg->get_value(i); }
-  const Dim& dim() const { return pg->get_dimension(i); }
+  Expression(ComputationGraph *pg, VariableIndex i, std::string name) : pg(pg), i(i), graph_id(pg->get_id()), name(name) { }
+  /**
+   * \brief Get value of the expression
+   * \details Throws a tuntime_error exception if no computation graph is available
+   * \return Value of the expression as a tensor
+   */
+  const Tensor& value() const {
+    if (this->is_stale()) {
+      std::stringstream error_message;
+      error_message << "Expression " << name << " at index " << i << " is stale, cannot get value";
+      throw std::runtime_error(error_message.str());
+    }
+    return pg->get_value(i);
+  }
+  /**
+   * \brief Get dimension of the expression
+   * \details Throws a tuntime_error exception if no computation graph is available
+   * \return Dimension of the expression
+   */
+  const Dim& dim() const {
+    if (this->is_stale()) {
+      std::stringstream error_message;
+      error_message << "Expression " << name << " at index " << i << " is stale, cannot get dimension";
+      throw std::runtime_error(error_message.str());
+    }
+    return pg->get_dimension(i);
+  }
 };
 
 namespace detail {
-  template <typename F, typename T>
-  Expression f(const T& xs) {
-    ComputationGraph *pg = xs.begin()->pg;
-    std::vector<VariableIndex> xis(xs.size());
-    int i = 0;
-    for (auto xi = xs.begin(); xi != xs.end(); ++xi) xis[i++] = xi->i;
-    return Expression(pg, pg->add_function<F>(xis));
-  }
+template <typename F, typename T>
+Expression f(const T& xs, std::string name) {
+  ComputationGraph *pg = xs.begin()->pg;
+  std::vector<VariableIndex> xis(xs.size());
+  int i = 0;
+  for (auto xi = xs.begin(); xi != xs.end(); ++xi) xis[i++] = xi->i;
+  return Expression(pg, pg->add_function<F>(xis), name);
+}
 }
 
 ////////////////////////////////////////////////
@@ -63,10 +95,10 @@ namespace detail {
  * \ingroup inputoperations
  * \brief Scalar input
  * \details Create an expression that represents the scalar value s
- * 
+ *
  * \param g Computation graph
  * \param s Real number
- * 
+ *
  * \return An expression representing s
  */
 Expression input(ComputationGraph& g, real s);
@@ -77,10 +109,10 @@ Expression input(ComputationGraph& g, real s);
  * \details Create an expression that represents the scalar value *ps.
  *          If *ps is changed and the computation graph recalculated, the
  *          next forward pass will reflect the new value.
- * 
+ *
  * \param g Computation graph
  * \param ps Real number pointer
- * 
+ *
  * \return An expression representing *ps
  */
 Expression input(ComputationGraph& g, const real *ps);
@@ -99,11 +131,11 @@ Expression input(ComputationGraph& g, const real *ps);
  *          The data vector "data" will contain the values used to fill the input, in
  *          column-major format. The length must add to the product of all dimensions in
  *          d.
- * 
+ *
  * \param g Computation graph
  * \param d Dimension of the input matrix
  * \param data A vector of data points
- * 
+ *
  * \return An expression representing data
  */
 Expression input(ComputationGraph& g, const Dim& d, const std::vector<float>& data);
@@ -113,11 +145,11 @@ Expression input(ComputationGraph& g, const Dim& d, const std::vector<float>& da
  * \brief Updatable vector/matrix/tensor input
  * \details Similarly to input that takes a vector reference, input a vector, matrix,
  *          or tensor input. Because we pass the pointer, the data can be updated.
- * 
+ *
  * \param g Computation graph
  * \param d Dimension of the input matrix
  * \param pdata A pointer to an (updatable) vector of data points
- * 
+ *
  * \return An expression representing *pdata
  */
 Expression input(ComputationGraph& g, const Dim& d, const std::vector<float>* pdata);
@@ -129,13 +161,13 @@ Expression input(ComputationGraph& g, const Dim& d, const std::vector<float>* pd
  *          exactly the same as the standard input via vector reference, but sets all
  *          non-specified values to "defdata" and resets all others to the appropriate
  *          input values.
- * 
+ *
  * \param g Computation graph
  * \param d Dimension of the input matrix
  * \param ids The indexes of the data points to update
  * \param data The data points corresponding to each index
  * \param defdata The default data with which to set the unspecified data points
- * 
+ *
  * \return An expression representing data
  */
 Expression input(ComputationGraph& g, const Dim& d, const std::vector<unsigned int>& ids, const std::vector<float>& data, float defdata = 0.f);
@@ -144,10 +176,10 @@ Expression input(ComputationGraph& g, const Dim& d, const std::vector<unsigned i
  * \ingroup inputoperations
  * \brief Load parameter
  * \details Load parameters into the computation graph.
- * 
+ *
  * \param g Computation graph
  * \param p Parameter object to load
- * 
+ *
  * \return An expression representing p
  */
 Expression parameter(ComputationGraph& g, Parameter p);
@@ -157,10 +189,10 @@ Expression parameter(ComputationGraph& g, Parameter p);
  * \brief Load constant parameters
  * \details Load parameters into the computation graph, but prevent them from being
  *          updated when performing parameter update.
- * 
+ *
  * \param g Computation graph
  * \param p Parameter object to load
- * 
+ *
  * \return An expression representing the constant p
  */
 Expression const_parameter(ComputationGraph& g, Parameter p);
@@ -168,13 +200,13 @@ Expression const_parameter(ComputationGraph& g, Parameter p);
 /**
  * \ingroup inputoperations
  * \brief Look up parameter
- * \details Look up parameters according to an index, and load them into the 
+ * \details Look up parameters according to an index, and load them into the
  *          computation graph.
- * 
+ *
  * \param g Computation graph
  * \param p LookupParameter object from which to load
  * \param index Index of the parameters within p
- * 
+ *
  * \return An expression representing p[index]
  */
 Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index);
@@ -182,14 +214,14 @@ Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index);
 /**
  * \ingroup inputoperations
  * \brief Look up parameters with modifiable index
- * \details Look up parameters according to the *pindex, and load them into the 
- *          computation graph. When *pindex changes, on the next computation of 
+ * \details Look up parameters according to the *pindex, and load them into the
+ *          computation graph. When *pindex changes, on the next computation of
  *          forward() the values will change.
- * 
+ *
  * \param g Computation graph
  * \param p LookupParameter object from which to load
  * \param pindex Pointer index of the parameters within p
- * 
+ *
  * \return An expression representing p[*pindex]
  */
 Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex);
@@ -197,13 +229,13 @@ Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex
 /**
  * \ingroup inputoperations
  * \brief Look up parameter
- * \details Look up parameters according to an index, and load them into the 
+ * \details Look up parameters according to an index, and load them into the
  *          computation graph. Do not perform gradient update on the parameters.
- * 
+ *
  * \param g Computation graph
  * \param p LookupParameter object from which to load
  * \param index Index of the parameters within p
- * 
+ *
  * \return A constant expression representing p[index]
  */
 Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index);
@@ -211,15 +243,15 @@ Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index);
 /**
  * \ingroup inputoperations
  * \brief Constant lookup parameters with modifiable index
- * \details Look up parameters according to the *pindex, and load them into the 
- *          computation graph. When *pindex changes, on the next computation of 
+ * \details Look up parameters according to the *pindex, and load them into the
+ *          computation graph. When *pindex changes, on the next computation of
  *          forward() the values will change. However, gradient updates will not be
             performend.
- * 
+ *
  * \param g Computation graph
  * \param p LookupParameter object from which to load
  * \param pindex Pointer index of the parameters within p
- * 
+ *
  * \return A constant expression representing p[*pindex]
  */
 Expression const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex);
@@ -233,11 +265,11 @@ Expression const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* 
  *          a mini-batch of parameters, where the "i"th element of the batch corresponds
  *          to the parameters at the position specified by the "i"th element of
  *          "indices"
- * 
+ *
  * \param g Computation graph
  * \param p LookupParameter object from which to load
  * \param indices Index of the parameters at each position in the batch
- * 
+ *
  * \return An expression with the "i"th batch element representing p[indices[i]]
  */
 Expression lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>& indices);
@@ -246,11 +278,11 @@ Expression lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsi
  * \ingroup inputoperations
  * \brief Look up parameters
  * \details The mini-batched version of lookup with modifiable parameter indices.
- * 
+ *
  * \param g Computation graph
  * \param p LookupParameter object from which to load
  * \param pindices Pointer to lookup indices
- * 
+ *
  * \return An expression with the "i"th batch element representing p[*pindices[i]]
  */
 Expression lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>* pindices);
@@ -259,11 +291,11 @@ Expression lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsi
  * \ingroup inputoperations
  * \brief Look up parameters
  * \details Mini-batched lookup that will not update the parameters.
- * 
+ *
  * \param g Computation graph
  * \param p LookupParameter object from which to load
  * \param indices Lookup indices
- * 
+ *
  * \return A constant expression with the "i"th batch element representing p[indices[i]]
  */
 Expression const_lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>& indices);
@@ -273,11 +305,11 @@ Expression const_lookup(ComputationGraph& g, LookupParameter p, const std::vecto
  * \brief Look up parameters
  * \details Mini-batched lookup that will not update the parameters, with modifiable
  *          indices.
- * 
+ *
  * \param g Computation graph
  * \param p LookupParameter object from which to load
  * \param pindices Lookup index pointers.
- * 
+ *
  * \return A constant expression with the "i"th batch element representing
  *         p[*pindices[i]]
  */
@@ -287,10 +319,10 @@ Expression const_lookup(ComputationGraph& g, LookupParameter p, const std::vecto
  * \ingroup inputoperations
  * \brief Create an input full of zeros
  * \details Create an input full of zeros, sized according to dimensions d.
- * 
+ *
  * \param g Computation graph
  * \param d The dimensions of the input
- * 
+ *
  * \return A "d" dimensioned zero vector
  */
 Expression zeroes(ComputationGraph& g, const Dim& d);
@@ -300,10 +332,10 @@ Expression zeroes(ComputationGraph& g, const Dim& d);
  * \brief Create a random normal vector
  * \details Create a vector distributed according to normal distribution with mean
  *          0, variance 1.
- * 
+ *
  * \param g Computation graph
  * \param d The dimensions of the input
- * 
+ *
  * \return A "d" dimensioned normally distributed vector
  */
 Expression random_normal(ComputationGraph& g, const Dim& d);
@@ -312,12 +344,12 @@ Expression random_normal(ComputationGraph& g, const Dim& d);
  * \ingroup inputoperations
  * \brief Create a random bernoulli vector
  * \details Create a vector distributed according to bernoulli distribution with parameter p.
- * 
+ *
  * \param g Computation graph
  * \param d The dimensions of the input
  * \param p The bernoulli p parameter
  * \param scale A scaling factor for the output ("active" elements will receive this value)
- * 
+ *
  * \return A "d" dimensioned bernoulli distributed vector
  */
 Expression random_bernoulli(ComputationGraph& g, const Dim& d, real p, real scale = 1.0f);
@@ -326,12 +358,12 @@ Expression random_bernoulli(ComputationGraph& g, const Dim& d, real p, real scal
  * \ingroup inputoperations
  * \brief Create a random uniform vector
  * \details Create a vector distributed according to uniform distribution with boundaries left and right.
- * 
+ *
  * \param g Computation graph
  * \param d The dimensions of the input
  * \param left The left boundary
  * \param right The right boundary
- * 
+ *
  * \return A "d" dimensioned uniform distributed vector
  */
 Expression random_uniform(ComputationGraph& g, const Dim& d, real left, real right);
@@ -344,9 +376,9 @@ Expression random_uniform(ComputationGraph& g, const Dim& d, real left, real rig
  * \ingroup arithmeticoperations
  * \brief Negation
  * \details Negate the passed argument.
- * 
+ *
  * \param x An input expression
- * 
+ *
  * \return The negation of x
  */
 Expression operator-(const Expression& x);
@@ -355,10 +387,10 @@ Expression operator-(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Expression addition
  * \details Add two expressions of the same dimensions.
- * 
+ *
  * \param x The first input
  * \param y The second input
- * 
+ *
  * \return The sum of x and y
  */
 Expression operator+(const Expression& x, const Expression& y);
@@ -367,10 +399,10 @@ Expression operator+(const Expression& x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Scalar addition
  * \details Add a scalar to an expression
- * 
+ *
  * \param x The expression
  * \param y The scalar
- * 
+ *
  * \return An expression equal to x, with every component increased by y
  */
 Expression operator+(const Expression& x, real y);
@@ -379,10 +411,10 @@ Expression operator+(const Expression& x, real y);
  * \ingroup arithmeticoperations
  * \brief Scalar addition
  * \details Add a scalar to an expression
- * 
+ *
  * \param x The scalar
  * \param y The expression
- * 
+ *
  * \return An expression equal to y, with every component increased by x
  */
 Expression operator+(real x, const Expression& y);
@@ -391,10 +423,10 @@ Expression operator+(real x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Expression subtraction
  * \details Subtract one expression from another.
- * 
+ *
  * \param x The expression from which to subtract
  * \param y The expression to subtract
- * 
+ *
  * \return An expression where the ith element is x_i minus y_i
  */
 Expression operator-(const Expression& x, const Expression& y);
@@ -403,10 +435,10 @@ Expression operator-(const Expression& x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Scalar subtraction
  * \details Subtract an expression from a scalar
- * 
+ *
  * \param x The scalar from which to subtract
  * \param y The expression to subtract
- * 
+ *
  * \return An expression where the ith element is x_i minus y
  */
 Expression operator-(real x, const Expression& y);
@@ -415,10 +447,10 @@ Expression operator-(real x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Scalar subtraction
  * \details Subtract a scalar from an expression
- * 
+ *
  * \param x The expression from which to subtract
  * \param y The scalar to subtract
- * 
+ *
  * \return An expression where the ith element is x_i minus y
  */
 Expression operator-(const Expression& x, real y);
@@ -429,10 +461,10 @@ Expression operator-(const Expression& x, real y);
  * \brief Matrix multiplication
  * \details Multiply two matrices together. Like standard matrix multiplication, the
  *          second dimension of x and the first dimension of y must match.
- * 
+ *
  * \param x The left-hand matrix
  * \param y The right-hand matrix
- * 
+ *
  * \return An expression x times y
  */
 Expression operator*(const Expression& x, const Expression& y);
@@ -441,10 +473,10 @@ Expression operator*(const Expression& x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Matrix-scalar multiplication
  * \details Multiply an expression component-wise by a scalar.
- * 
+ *
  * \param x The matrix
  * \param y The scalar
- * 
+ *
  * \return An expression where the ith element is x_i times y
  */
 Expression operator*(const Expression& x, float y);
@@ -453,10 +485,10 @@ Expression operator*(const Expression& x, float y);
  * \ingroup arithmeticoperations
  * \brief Matrix-scalar multiplication
  * \details Multiply an expression component-wise by a scalar.
- * 
+ *
  * \param x The scalar
  * \param y The matrix
- * 
+ *
  * \return An expression where the ith element is x_i times y
  */
 inline Expression operator*(float y, const Expression& x) { return x * y; }
@@ -465,10 +497,10 @@ inline Expression operator*(float y, const Expression& x) { return x * y; }
  * \ingroup arithmeticoperations
  * \brief Matrix-scalar division
  * \details Divide an expression component-wise by a scalar.
- * 
+ *
  * \param x The matrix
  * \param y The scalar
- * 
+ *
  * \return An expression where the ith element is x_i divided by y
  */
 inline Expression operator/(const Expression& x, float y) { return x * (1.f / y); }
@@ -483,48 +515,48 @@ inline Expression operator/(const Expression& x, float y) { return x * (1.f / y)
  *          A very common usage case is the calculation of the score for a neural network
  *          layer (e.g. b + Wz) where b is the bias, W is the weight matrix, and z is the
  *          input. In this case xs[0] = b, xs[1] = W, and xs[2] = z.
- * 
+ *
  * \param xs An initializer list containing an odd number of expressions
- * 
+ *
  * \return An expression equal to: xs[0] + xs[1]*xs[2] + xs[3]*xs[4] + ...
  */
-inline Expression affine_transform(const std::initializer_list<Expression>& xs) { return detail::f<AffineTransform>(xs); }
+inline Expression affine_transform(const std::initializer_list<Expression>& xs) { return detail::f<AffineTransform>(xs, "affine_transform(const std::initializer_list<Expression>& xs)"); }
 template <typename T>
-inline Expression affine_transform(const T& xs) { return detail::f<AffineTransform>(xs); }
+inline Expression affine_transform(const T& xs) { return detail::f<AffineTransform>(xs, "affine_transform(const T& xs)"); }
 
 /**
  * \ingroup arithmeticoperations
  * \brief Sum
  * \details This performs an elementwise sum over all the expressions in xs
- * 
+ *
  * \param xs An initializer list containing expressions
- * 
+ *
  * \return An expression where the ith element is equal to xs[0][i] + xs[1][i] + ...
  */
-inline Expression sum(const std::initializer_list<Expression>& xs) { return detail::f<Sum>(xs); }
+inline Expression sum(const std::initializer_list<Expression>& xs) { return detail::f<Sum>(xs, "sum(const std::initializer_list<Expression>& xs)"); }
 template <typename T>
-inline Expression sum(const T& xs) { return detail::f<Sum>(xs); }
+inline Expression sum(const T& xs) { return detail::f<Sum>(xs, "sum(const T& xs)"); }
 
 /**
  * \ingroup arithmeticoperations
  * \brief Average
  * \details This performs an elementwise average over all the expressions in xs
- * 
+ *
  * \param xs An initializer list containing expressions
- * 
+ *
  * \return An expression where the ith element is equal to (xs[0][i] + xs[1][i] + ...)/|xs|
  */
-inline Expression average(const std::initializer_list<Expression>& xs) { return detail::f<Average>(xs); }
+inline Expression average(const std::initializer_list<Expression>& xs) { return detail::f<Average>(xs, "average(const std::initializer_list<Expression>& xs)"); }
 template <typename T>
-inline Expression average(const T& xs) { return detail::f<Average>(xs); }
+inline Expression average(const T& xs) { return detail::f<Average>(xs, "average(const T& xs)"); }
 
 /**
  * \ingroup arithmeticoperations
  * \brief Square root
  * \details Elementwise square root.
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to sqrt(x_i)
  */
 Expression sqrt(const Expression& x);
@@ -533,9 +565,9 @@ Expression sqrt(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Gaussian error function
  * \details Elementwise calculation of the Gaussian error function
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to erf(x_i)
  */
 Expression erf(const Expression& x);
@@ -544,9 +576,9 @@ Expression erf(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Hyperbolic tangent
  * \details Elementwise calculation of the hyperbolic tangent
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to tanh(x_i)
  */
 Expression tanh(const Expression& x);
@@ -555,9 +587,9 @@ Expression tanh(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Natural exponent
  * \details Calculate elementwise y_i = e^{x_i}
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to e^{x_i}
  */
 Expression exp(const Expression& x);
@@ -566,9 +598,9 @@ Expression exp(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Square
  * \details Calculate elementwise y_i = x_i^2
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to x_i^2
  */
 Expression square(const Expression& x);
@@ -577,9 +609,9 @@ Expression square(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Cube
  * \details Calculate elementwise y_i = x_i^3
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to x_i^3
  */
 Expression cube(const Expression& x);
@@ -588,9 +620,9 @@ Expression cube(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Log gamma
  * \details Calculate elementwise y_i = ln(gamma(x_i))
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to ln(gamma(x_i))
  */
 Expression lgamma(const Expression& x);
@@ -599,9 +631,9 @@ Expression lgamma(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Logarithm
  * \details Calculate the elementwise natural logarithm y_i = ln(x_i)
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to ln(x_i)
  */
 Expression log(const Expression& x);
@@ -610,9 +642,9 @@ Expression log(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Logistic sigmoid function
  * \details Calculate elementwise y_i = 1/(1+e^{-x_i})
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to y_i = 1/(1+e^{-x_i})
  */
 Expression logistic(const Expression& x);
@@ -621,9 +653,9 @@ Expression logistic(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Rectifier
  * \details Calculate elementwise the recitifer (ReLU) function y_i = max(x_i,0)
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to max(x_i,0)
  */
 Expression rectify(const Expression& x);
@@ -632,9 +664,9 @@ Expression rectify(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Soft Sign
  * \details Calculate elementwise the softsign function y_i = x_i/(1+|x_i|)
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return An expression where the ith element is equal to x_i/(1+|x_i|)
  */
 Expression softsign(const Expression& x);
@@ -643,10 +675,10 @@ Expression softsign(const Expression& x);
  * \ingroup arithmeticoperations
  * \brief Power function
  * \details Calculate an output where the ith element is equal to x_i^y_i
- * 
+ *
  * \param x The input expression
  * \param y The exponent expression
- * 
+ *
  * \return An expression where the ith element is equal to x_i^y_i
  */
 Expression pow(const Expression& x, const Expression& y);
@@ -655,10 +687,10 @@ Expression pow(const Expression& x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Minimum
  * \details Calculate an output where the ith element is min(x_i,y_i)
- * 
+ *
  * \param x The first input expression
  * \param y The second input expression
- * 
+ *
  * \return An expression where the ith element is equal to min(x_i,y_i)
  */
 Expression min(const Expression& x, const Expression& y);
@@ -667,10 +699,10 @@ Expression min(const Expression& x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Maximum
  * \details Calculate an output where the ith element is max(x_i,y_i)
- * 
+ *
  * \param x The first input expression
  * \param y The second input expression
- * 
+ *
  * \return An expression where the ith element is equal to max(x_i,y_i)
  */
 Expression max(const Expression& x, const Expression& y);
@@ -679,23 +711,23 @@ Expression max(const Expression& x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Max
  * \details This performs an elementwise max over all the expressions in xs
- * 
+ *
  * \param xs An initializer list containing expressions
- * 
+ *
  * \return An expression where the ith element is equal to max(xs[0][i], xs[1][i], ...)
  */
-inline Expression max(const std::initializer_list<Expression>& xs) { return detail::f<Max>(xs); }
+inline Expression max(const std::initializer_list<Expression>& xs) { return detail::f<Max>(xs, "max(const std::initializer_list<Expression>& xs)"); }
 template <typename T>
-inline Expression max(const T& xs) { return detail::f<Max>(xs); }
+inline Expression max(const T& xs) { return detail::f<Max>(xs, "max(const T& xs)"); }
 
 /**
  * \ingroup arithmeticoperations
  * \brief Dot Product
  * \details Calculate the dot product sum_i x_i*y_i
- * 
+ *
  * \param x The input expression
  * \param y The input expression
- * 
+ *
  * \return An expression equal to the dot product
  */
 Expression dot_product(const Expression& x, const Expression& y);
@@ -705,10 +737,10 @@ Expression dot_product(const Expression& x, const Expression& y);
  * \brief Componentwise multiply
  * \details Do a componentwise multiply where each value is equal to x_i*y_i.
  *          This function used to be called cwise_multiply.
- * 
+ *
  * \param x The first input expression
  * \param y The second input expression
- * 
+ *
  * \return An expression where the ith element is equal to x_i*y_i
  */
 Expression cmult(const Expression& x, const Expression& y);
@@ -717,10 +749,10 @@ Expression cmult(const Expression& x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Componentwise multiply
  * \details Do a componentwise multiply where each value is equal to x_i/y_i
- * 
+ *
  * \param x The first input expression
  * \param y The second input expression
- * 
+ *
  * \return An expression where the ith element is equal to x_i/y_i
  */
 Expression cdiv(const Expression& x, const Expression& y);
@@ -729,10 +761,10 @@ Expression cdiv(const Expression& x, const Expression& y);
  * \ingroup arithmeticoperations
  * \brief Columnwise addition
  * \details Add vector "bias" to each column of matrix "x"
- * 
+ *
  * \param x An MxN matrix
  * \param bias A length M vector
- * 
+ *
  * \return An expression where bias is added to each column of x
  */
 Expression colwise_add(const Expression& x, const Expression& bias);
@@ -747,9 +779,9 @@ Expression colwise_add(const Expression& x, const Expression& bias);
  * \details The softmax function normalizes each column to ensure that all
  *          values are between 0 and 1 and add to one by applying the
  *          e^{x[i]}/{sum_j e^{x[j]}}.
- * 
+ *
  * \param x A vector or matrix
- * 
+ *
  * \return A vector or matrix after calculating the softmax
  */
 Expression softmax(const Expression& x);
@@ -760,9 +792,9 @@ Expression softmax(const Expression& x);
  * \details The log softmax function normalizes each column to ensure that all
  *          values are between 0 and 1 and add to one by applying the
  *          e^{x[i]}/{sum_j e^{x[j]}}, then takes the log
- * 
+ *
  * \param x A vector or matrix
- * 
+ *
  * \return A vector or matrix after calculating the log softmax
  */
 Expression log_softmax(const Expression& x);
@@ -773,10 +805,10 @@ Expression log_softmax(const Expression& x);
  * \details The log softmax function calculated over only a subset of the vector elements. The
  *          elements to be included are set by the ``restriction`` variable. All elements not
  *          included in ``restriction`` are set to negative infinity.
- * 
+ *
  * \param x A vector over which to calculate the softmax
  * \param restriction The elements over which to calculate the softmax
- * 
+ *
  * \return A vector with the log softmax over the specified elements
  */
 Expression log_softmax(const Expression& x, const std::vector<unsigned>& restriction);
@@ -786,14 +818,14 @@ Expression log_softmax(const Expression& x, const std::vector<unsigned>& restric
  * \brief Log, sum, exp
  * \details The elementwise "logsumexp" function that calculates
  *   \f$ln(\sum_i e^{xs_i})\f$, used in adding probabilities in the log domain.
- * 
+ *
  * \param xs Expressions with respect to which to calculate the logsumexp.
- * 
+ *
  * \return The result.
  */
-inline Expression logsumexp(const std::initializer_list<Expression>& xs) { return detail::f<LogSumExp>(xs); }
+inline Expression logsumexp(const std::initializer_list<Expression>& xs) { return detail::f<LogSumExp>(xs, "logsumexp(const std::initializer_list<Expression>& xs)"); }
 template <typename T>
-inline Expression logsumexp(const T& xs) { return detail::f<LogSumExp>(xs); }
+inline Expression logsumexp(const T& xs) { return detail::f<LogSumExp>(xs, "logsumexp(const T& xs)"); }
 
 /**
  * \ingroup lossoperations
@@ -802,10 +834,10 @@ inline Expression logsumexp(const T& xs) { return detail::f<LogSumExp>(xs); }
  *          the negative, and selects the likelihood corresponding to the element ``v``. This is
  *          perhaps the most standard loss function for training neural networks to predict
  *          one out of a set of elements.
- * 
+ *
  * \param x A vector of scores
  * \param v The element with which to calculate the loss
- * 
+ *
  * \return The negative log likelihood of element ``v`` after taking the softmax
  */
 Expression pickneglogsoftmax(const Expression& x, unsigned v);
@@ -819,10 +851,10 @@ Expression pickneglogsoftmax(const Expression& x, unsigned v);
  *          ``*pv`` can be modified without re-constructing the computation graph. This can be
  *          used in situations where we want to create a computation graph once, then feed it
  *          different data points.
- * 
+ *
  * \param x A vector of scores
  * \param pv A pointer to the index of the correct element
- * 
+ *
  * \return The negative log likelihood of element ``*pv`` after taking the softmax
  */
 Expression pickneglogsoftmax(const Expression& x, const unsigned * pv);
@@ -833,10 +865,10 @@ Expression pickneglogsoftmax(const Expression& x, const unsigned * pv);
  * \details This function is similar to standard pickneglogsoftmax, but calculates loss with
  *          respect to multiple batch elements. The input will be a mini-batch of score vectors
  *          where the number of batch elements is equal to the number of indices in ``v``.
- * 
+ *
  * \param x An expression with vectors of scores over N batch elements
  * \param v A size-N vector indicating the index with respect to all the batch elements
- * 
+ *
  * \return The negative log likelihoods over all the batch elements
  */
 Expression pickneglogsoftmax(const Expression& x, const std::vector<unsigned> & v);
@@ -846,10 +878,10 @@ Expression pickneglogsoftmax(const Expression& x, const std::vector<unsigned> & 
  * \brief Modifiable batched negative softmax log likelihood
  * \details This function is a combination of modifiable pickneglogsoftmax and batched
  *          pickneglogsoftmax: ``pv`` can be modified without re-creating the computation graph.
- * 
+ *
  * \param x An expression with vectors of scores over N batch elements
  * \param pv A pointer to the indexes
- * 
+ *
  * \return The negative log likelihoods over all the batch elements
  */
 Expression pickneglogsoftmax(const Expression& x, const std::vector<unsigned> * pv);
@@ -859,11 +891,11 @@ Expression pickneglogsoftmax(const Expression& x, const std::vector<unsigned> * 
  * \brief Hinge loss
  * \details This expression calculates the hinge loss, formally expressed as:
  *          \f$ \text{hinge}(x,index,m) = \sum_{i \ne index} \max(0, m-x[index]+x[i]). \f$
- * 
+ *
  * \param x A vector of scores
  * \param index The index of the correct candidate
  * \param m The margin
- * 
+ *
  * \return The hinge loss of candidate ``index`` with respect to margin ``m``
  */
 Expression hinge(const Expression& x, unsigned index, float m = 1.0);
@@ -877,11 +909,11 @@ Expression hinge(const Expression& x, unsigned index, float m = 1.0);
  *          ``*pindex`` can be modified without re-constructing the computation graph. This can be
  *          used in situations where we want to create a computation graph once, then feed it
  *          different data points.
- * 
+ *
  * \param x A vector of scores
  * \param pindex A pointer to the index of the correct candidate
  * \param m The margin
- * 
+ *
  * \return The hinge loss of candidate ``*pindex`` with respect to margin ``m``
  */
 Expression hinge(const Expression& x, const unsigned* pindex, float m = 1.0);
@@ -892,11 +924,11 @@ Expression hinge(const Expression& x, const unsigned* pindex, float m = 1.0);
  * \details The same as hinge loss, but for the case where ``x`` is a mini-batched tensor
  *          with ``indices.size()`` batch elements, and ``indices`` is a vector indicating
  *          the index of each of the correct elements for these elements.
- * 
+ *
  * \param x A mini-batch of vectors with ``indices.size()`` batch elements
  * \param indices The indices of the correct candidates for each batch element
  * \param m The margin
- * 
+ *
  * \return The hinge loss of each mini-batch
  */
 Expression hinge(const Expression& x, const std::vector<unsigned> & indices, float m = 1.0);
@@ -906,11 +938,11 @@ Expression hinge(const Expression& x, const std::vector<unsigned> & indices, flo
  * \brief Batched modifiable hinge loss
  * \details A combination of the previous batched and modifiable hinge loss functions, where
  *          vector ``*pindices`` can be modified.
- * 
+ *
  * \param x A mini-batch of vectors with ``indices.size()`` batch elements
  * \param pindices Pointer to the indices of the correct candidates for each batch element
  * \param m The margin
- * 
+ *
  * \return The hinge loss of each mini-batch
  */
 Expression hinge(const Expression& x, const std::vector<unsigned> * pindices, float m = 1.0);
@@ -921,9 +953,9 @@ Expression hinge(const Expression& x, const std::vector<unsigned> * pindices, fl
  * \details The sparsemax function (Martins et al. 2016), which is similar to softmax,
  *          but induces sparse solutions where most of the vector elements are zero.
  *          **Note:** This function is not yet implemented on GPU.
- * 
+ *
  * \param x A vector of scores
- * 
+ *
  * \return The sparsemax of the scores
  */
 Expression sparsemax(const Expression& x);
@@ -937,10 +969,10 @@ Expression sparsemax(const Expression& x);
  *          and thus is useful for optimizing when the sparsemax will be used at
  *          test time.
  *          **Note:** This function is not yet implemented on GPU.
- * 
+ *
  * \param x A vector of scores
  * \param target_support The target correct labels.
- * 
+ *
  * \return The sparsemax loss of the labels
  */
 Expression sparsemax_loss(const Expression& x, const std::vector<unsigned>& target_support);
@@ -952,10 +984,10 @@ Expression sparsemax_loss(const Expression& x, const std::vector<unsigned>& targ
  *          to a vector, allowing it to be modified without re-creating the compuation
  *          graph.
  *          **Note:** This function is not yet implemented on GPU.
- * 
+ *
  * \param x A vector of scores
  * \param ptarget_support A pointer to the target correct labels.
- * 
+ *
  * \return The sparsemax loss of the labels
  */
 Expression sparsemax_loss(const Expression& x, const std::vector<unsigned>* ptarget_support);
@@ -964,9 +996,9 @@ Expression sparsemax_loss(const Expression& x, const std::vector<unsigned>* ptar
  * \ingroup lossoperations
  * \brief Squared norm
  * \details The squared norm of the values of x: \f$\sum_i x_i^2\f$.
- * 
+ *
  * \param x A vector of values
- * 
+ *
  * \return The squared norm
  */
 Expression squared_norm(const Expression& x);
@@ -975,10 +1007,10 @@ Expression squared_norm(const Expression& x);
  * \ingroup lossoperations
  * \brief Squared distance
  * \details The squared distance between values of ``x`` and ``y``: \f$\sum_i (x_i-y_i)^2\f$.
- * 
+ *
  * \param x A vector of values
  * \param y Another vector of values
- * 
+ *
  * \return The squared distance
  */
 Expression squared_distance(const Expression& x, const Expression& y);
@@ -987,10 +1019,10 @@ Expression squared_distance(const Expression& x, const Expression& y);
  * \ingroup lossoperations
  * \brief Squared distance
  * \details The L1 distance between values of ``x`` and ``y``: \f$\sum_i |x_i-y_i|\f$.
- * 
+ *
  * \param x A vector of values
  * \param y Another vector of values
- * 
+ *
  * \return The squared distance
  */
 Expression l1_distance(const Expression& x, const Expression& y);
@@ -1000,7 +1032,7 @@ Expression l1_distance(const Expression& x, const Expression& y);
  * \brief Huber distance
  * \details The huber distance between values of ``x`` and ``y`` parameterized
  *    by ``c,`` \f$\sum_i L_c(x_i, y_i)\f$ where:
- *    
+ *
  *    \f$
  *      L_c(x, y) = \begin{cases}{lr}
  *        \frac{1}{2}(y - x)^2                   & \textrm{for } |y - f(x)| \le c, \\
@@ -1011,7 +1043,7 @@ Expression l1_distance(const Expression& x, const Expression& y);
  * \param x A vector of values
  * \param y Another vector of values
  * \param c The parameter of the huber distance parameterizing the cuttoff
- * 
+ *
  * \return The huber distance
  */
 Expression huber_distance(const Expression& x, const Expression& y, float c = 1.345f);
@@ -1021,10 +1053,10 @@ Expression huber_distance(const Expression& x, const Expression& y, float c = 1.
  * \brief Binary log loss
  * \details The log loss of a binary decision according to the sigmoid
  *          sigmoid function \f$- \sum_i (y_i * ln(x_i) + (1-y_i) * ln(1-x_i)) \f$
- * 
+ *
  * \param x A vector of values
  * \param y A vector of true answers
- * 
+ *
  * \return The log loss of the sigmoid function
  */
 Expression binary_log_loss(const Expression& x, const Expression& y);
@@ -1034,14 +1066,14 @@ Expression binary_log_loss(const Expression& x, const Expression& y);
  * \brief Pairwise rank loss
  * \details A margin-based loss, where every margin violation for each pair of
  *          values is penalized: \f$\sum_i max(x_i-y_i+m, 0)\f$
- * 
+ *
  * \param x A vector of values
  * \param y A vector of true answers
  * \param m The margin
- * 
+ *
  * \return The pairwise rank loss
  */
-Expression pairwise_rank_loss(const Expression& x, const Expression& y, real m=1.0);
+Expression pairwise_rank_loss(const Expression& x, const Expression& y, real m = 1.0);
 
 /**
  * \ingroup lossoperations
@@ -1050,10 +1082,10 @@ Expression pairwise_rank_loss(const Expression& x, const Expression& y, real m=1
  *          distribution with parameter ``x``. Useful in Poisson regression
  *          where, we try to predict the parameters of a Possion distribution
  *          to maximize the probability of data ``y``.
- * 
+ *
  * \param x The parameter of the Poisson distribution.
  * \param y The target value
- * 
+ *
  * \return The Poisson loss
  */
 Expression poisson_loss(const Expression& x, unsigned y);
@@ -1063,10 +1095,10 @@ Expression poisson_loss(const Expression& x, unsigned y);
  * \details Similar to Poisson loss, but with the target value passed by
  *          pointer so that it can be modified without re-constructing the
  *          computation graph.
- * 
+ *
  * \param x The parameter of the Poisson distribution.
  * \param py A pointer to the target value
- * 
+ *
  * \return The Poisson loss
  */
 Expression poisson_loss(const Expression& x, const unsigned* py);
@@ -1081,32 +1113,32 @@ Expression poisson_loss(const Expression& x, const unsigned* py);
  * \details This node has no effect on the forward pass, but prevents gradients from
  *          flowing backward during the backward pass. This is useful when there's
  *          a subgraph for which you don't want loss passed back to the parameters.
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return The new expression
  */
 Expression nobackprop(const Expression& x);
 
 /**
  * \ingroup flowoperations
- * \brief Negative backprop 
- * \details This node has no effect on the forward pass, but takes negative on backprop process. 
+ * \brief Negative backprop
+ * \details This node has no effect on the forward pass, but takes negative on backprop process.
  *          This operation is widely used in adversarial networks.
- *          
+ *
  * \param x The input expression
- * 
+ *
  * \return An output expression containing the same as input (only effects on backprop process)
- */ 
-Expression flip_gradient(const Expression& x);  
-  
+ */
+Expression flip_gradient(const Expression& x);
+
 /**
  * \ingroup flowoperations
  * \brief Reshape to another size
  * \details This node reshapes a tensor to another size, without changing the
  *          underlying layout of the data. The layout of the data in DyNet is
  *          column-major, so if we have a 3x4 matrix
- *    
+ *
  *    \f$
  *      \begin{pmatrix}
  *        x_{1,1} & x_{1,2} & x_{1,3} & x_{1,4} \\
@@ -1125,10 +1157,10 @@ Expression flip_gradient(const Expression& x);
  *    \f$
  *
  *         **Note:** This is O(1) for forward, and O(n) for backward.
- * 
+ *
  * \param x The input expression
  * \param d The new dimensions
- * 
+ *
  * \return The reshaped expression
  */
 Expression reshape(const Expression& x, const Dim& d);
@@ -1139,9 +1171,9 @@ Expression reshape(const Expression& x, const Dim& d);
  * \details Get the transpose of the matrix.
  *          **Note:** This is O(1) if either the row or column dimension is 1,
  *          and O(n) otherwise.
- * 
+ *
  * \param x The input expression
- * 
+ *
  * \return The transposed expression
  */
 Expression transpose(const Expression& x);
@@ -1150,10 +1182,10 @@ Expression transpose(const Expression& x);
  * \ingroup flowoperations
  * \brief Select rows
  * \details Select a subset of rows of a matrix.
- * 
+ *
  * \param x The input expression
  * \param rows The rows to extract
- * 
+ *
  * \return An expression containing the selected rows
  */
 Expression select_rows(const Expression& x, const std::vector<unsigned>& rows);
@@ -1163,10 +1195,10 @@ Expression select_rows(const Expression& x, const std::vector<unsigned>& rows);
  * \brief Modifiable select rows
  * \details Select a subset of rows of a matrix, where the elements of prows
  *          can be modified without re-creating the computation graph.
- * 
+ *
  * \param x The input expression
  * \param prows The rows to extract
- * 
+ *
  * \return An expression containing the selected rows
  */
 Expression select_rows(const Expression& x, const std::vector<unsigned>* prows);
@@ -1174,12 +1206,12 @@ Expression select_rows(const Expression& x, const std::vector<unsigned>* prows);
 /**
  * \ingroup flowoperations
  * \brief Select columns
- * \details Select a subset of columns of a matrix. select_cols is more 
+ * \details Select a subset of columns of a matrix. select_cols is more
  *          efficient than select_rows since DyNet uses column-major order.
- * 
+ *
  * \param x The input expression
  * \param columns The columns to extract
- * 
+ *
  * \return An expression containing the selected columns
  */
 Expression select_cols(const Expression& x, const std::vector<unsigned>& cols);
@@ -1189,10 +1221,10 @@ Expression select_cols(const Expression& x, const std::vector<unsigned>& cols);
  * \brief Modifiable select columns
  * \details Select a subset of columns of a matrix, where the elements of pcols
  *          can be modified without re-creating the computation graph.
- * 
+ *
  * \param x The input expression
  * \param pcolumns The columns to extract
- * 
+ *
  * \return An expression containing the selected columns
  */
 Expression select_cols(const Expression& x, const std::vector<unsigned>* pcols);
@@ -1203,9 +1235,9 @@ Expression select_cols(const Expression& x, const std::vector<unsigned>* pcols);
  * \details Sum an expression that consists of multiple minibatches into one of
  *          equal dimension but with only a single minibatch. This is useful
  *          for summing loss functions at the end of minibatch training.
- * 
+ *
  * \param x The input mini-batched expression
- * 
+ *
  * \return An expression with a single batch
  */
 Expression sum_batches(const Expression& x);
@@ -1216,11 +1248,11 @@ Expression sum_batches(const Expression& x);
  * \details Pick a single element/row/column/sub-tensor from an expression.
  *          This will result in the dimension of the tensor being reduced
  *          by 1.
- * 
+ *
  * \param x The input expression
  * \param v The index of the element to select
  * \param d The dimension along which to choose the element
- * 
+ *
  * \return The value of x[v] along dimension d
  */
 Expression pick(const Expression& x, unsigned v, unsigned d = 0);
@@ -1229,12 +1261,12 @@ Expression pick(const Expression& x, unsigned v, unsigned d = 0);
  * \ingroup flowoperations
  * \brief Batched pick
  * \details Pick elements from multiple batches.
- * 
+ *
  * \param x The input expression
  * \param v A vector of indicies to choose, one for each batch in the
  *          input expression.
  * \param d The dimension along which to choose the elements
- * 
+ *
  * \return A mini-batched expression containing the picked elements
  */
 Expression pick(const Expression& x, const std::vector<unsigned> & v, unsigned d = 0);
@@ -1245,11 +1277,11 @@ Expression pick(const Expression& x, const std::vector<unsigned> & v, unsigned d
  * \details Pick a single element from an expression, where the index is
  *          passed by pointer so we do not need to re-create the computation
  *          graph every time.
- * 
+ *
  * \param x The input expression
  * \param pv Pointer to the index of the element to select
  * \param d The dimension along which to choose the elements
- * 
+ *
  * \return The value of x[*pv]
  */
 Expression pick(const Expression& x, const unsigned * pv, unsigned d = 0);
@@ -1260,11 +1292,11 @@ Expression pick(const Expression& x, const unsigned * pv, unsigned d = 0);
  * \details Pick multiple elements from an input expression, where the indices
  *          are passed by pointer so we do not need to re-create the computation
  *          graph every time.
- * 
+ *
  * \param x The input expression
  * \param pv A pointer to vector of indicies to choose
  * \param d The dimension along which to choose the elements
- * 
+ *
  * \return A mini-batched expression containing the picked elements
  */
 Expression pick(const Expression& x, const std::vector<unsigned> * pv, unsigned d = 0);
@@ -1273,11 +1305,11 @@ Expression pick(const Expression& x, const std::vector<unsigned> * pv, unsigned 
  * \ingroup flowoperations
  * \brief Pick range of elements
  * \details Pick a range of elements from an expression.
- * 
+ *
  * \param x The input expression
  * \param v The beginning index
  * \param u The end index
- * 
+ *
  * \return The value of {x[v],...,x[u]}
  */
 Expression pickrange(const Expression& x, unsigned v, unsigned u);
@@ -1287,28 +1319,28 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u);
  * \brief Concatenate columns
  * \details Perform a concatenation of the columns in multiple expressions.
  *          All expressions must have the same number of rows.
- * 
+ *
  * \param xs The input expressions
- * 
+ *
  * \return The expression with the columns concatenated
  */
-inline Expression concatenate_cols(const std::initializer_list<Expression>& xs) { return detail::f<ConcatenateColumns>(xs); }
+inline Expression concatenate_cols(const std::initializer_list<Expression>& xs) { return detail::f<ConcatenateColumns>(xs, "concatenate_cols(const std::initializer_list<Expression>& xs)"); }
 template <typename T>
-inline Expression concatenate_cols(const T& xs) { return detail::f<ConcatenateColumns>(xs); }
+inline Expression concatenate_cols(const T& xs) { return detail::f<ConcatenateColumns>(xs, "concatenate_cols(const T& xs)"); }
 
 /**
  * \ingroup flowoperations
  * \brief Concatenate rows
  * \details Perform a concatenation of the rows in multiple expressions.
  *          All expressions must have the same number of columns.
- * 
+ *
  * \param xs The input expressions
- * 
+ *
  * \return The expression with the rows concatenated
  */
-inline Expression concatenate(const std::initializer_list<Expression>& xs) { return detail::f<Concatenate>(xs); }
+inline Expression concatenate(const std::initializer_list<Expression>& xs) { return detail::f<Concatenate>(xs, "concatenate(const std::initializer_list<Expression>& xs)"); }
 template <typename T>
-inline Expression concatenate(const T& xs) { return detail::f<Concatenate>(xs); }
+inline Expression concatenate(const T& xs) { return detail::f<Concatenate>(xs, "concatenate(const T& xs)"); }
 
 ////////////////////////////////////////////////
 // Noise operations                           //
@@ -1318,10 +1350,10 @@ inline Expression concatenate(const T& xs) { return detail::f<Concatenate>(xs); 
  * \ingroup noiseoperations
  * \brief Gaussian noise
  * \details Add gaussian noise to an expression.
- * 
+ *
  * \param x The input expression
  * \param stddev The standard deviation of the gaussian
- * 
+ *
  * \return The noised expression
  */
 Expression noise(const Expression& x, real stddev);
@@ -1339,10 +1371,10 @@ Expression noise(const Expression& x, real stddev);
  *     time, and do not need to do anything at test time.
  *   DyNet implements the latter, so you only need to apply dropout at training
  *   time, and do not need to perform scaling and test time.
- * 
+ *
  * \param x The input expression
  * \param p The dropout probability
- * 
+ *
  * \return The dropped out expression
  */
 Expression dropout(const Expression& x, real p);
@@ -1353,10 +1385,10 @@ Expression dropout(const Expression& x, real p);
  * \details Identical to the dropout operation, but either drops out *all*
  *          or *no* values in the expression, as opposed to making a decision
  *          about each value individually.
- * 
+ *
  * \param x The input expression
  * \param p The block dropout probability
- * 
+ *
  * \return The block dropout expression
  */
 Expression block_dropout(const Expression& x, real p);
@@ -1369,7 +1401,7 @@ Expression conv1d_narrow(const Expression& x, const Expression& f);
 Expression conv1d_wide(const Expression& x, const Expression& f);
 Expression filter1d_narrow(const Expression& x, const Expression& f);
 Expression kmax_pooling(const Expression& x, unsigned k);
-Expression fold_rows(const Expression& x, unsigned nrows=2);
+Expression fold_rows(const Expression& x, unsigned nrows = 2);
 Expression sum_dim(const Expression& x, unsigned d);
 Expression sum_cols(const Expression& x);
 Expression sum_rows(const Expression& x);
@@ -1400,9 +1432,9 @@ Expression contract3d_1d(const Expression& x, const Expression& y, const Express
  *          contributions are welcome: https://github.com/clab/dynet/issues/158).
  *          Note that back-propagating through an inverted matrix can also be the
  *          source of stability problems sometimes.
- * 
+ *
  * \param x A square matrix
- * 
+ *
  * \return The inverse of the matrix
  */
 Expression inverse(const Expression& x);
@@ -1413,9 +1445,9 @@ Expression inverse(const Expression& x);
  * \details Takes the log of the determinant of a matrix.
  *          (not implemented on GPU yet, although
  *          contributions are welcome: https://github.com/clab/dynet/issues/158).
- * 
+ *
  * \param x A square matrix
- * 
+ *
  * \return The log of its determinant
  */
 Expression logdet(const Expression& x);
@@ -1426,10 +1458,10 @@ Expression logdet(const Expression& x);
  * \details Takes the trace of the product of matrices.
  *          (not implemented on GPU yet, although
  *          contributions are welcome: https://github.com/clab/dynet/issues/158).
- * 
+ *
  * \param x1 A matrix
  * \param x2 Another matrix
- * 
+ *
  * \return trace(x1 * x2)
  */
 Expression trace_of_product(const Expression& x, const Expression& y);

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -21,7 +21,6 @@
 #include "dynet/nodes.h"
 #include "dynet/nodes-contract.h"
 #include <stdexcept>
-#include <sstream>
 
 
 namespace dynet {

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -136,9 +136,9 @@ cdef extern from "dynet/dynet.h" namespace "dynet":
         VariableIndex add_const_lookup(CLookupParameters* p, const unsigned* pindex)
         VariableIndex add_const_lookup(CLookupParameters* p, unsigned index)
         
-        const CTensor& forward(VariableIndex index)
-        const CTensor& incremental_forward(VariableIndex index)
-        const CTensor& get_value(VariableIndex i)
+        const CTensor& forward(VariableIndex index) except +
+        const CTensor& incremental_forward(VariableIndex index) except +
+        const CTensor& get_value(VariableIndex i) except +
         void invalidate()
         void backward(VariableIndex i)
 
@@ -203,10 +203,11 @@ cdef extern from "dynet/training.h" namespace "dynet":
 cdef extern from "dynet/expr.h" namespace "dynet::expr":
     cdef cppclass CExpression "dynet::expr::Expression":
         CExpression()
-        CExpression(CComputationGraph *pg, VariableIndex i)
+        CExpression(CComputationGraph *pg, VariableIndex i,string name)
         CComputationGraph *pg
         long i
-        CDim dim()
+        string name
+        CDim dim() except +
     #CExpression c_input "dynet::expr::input" (CComputationGraph& g, float s)   #
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, float *ps) #
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, CDim& d, vector[float]* pdata)

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -203,10 +203,9 @@ cdef extern from "dynet/training.h" namespace "dynet":
 cdef extern from "dynet/expr.h" namespace "dynet::expr":
     cdef cppclass CExpression "dynet::expr::Expression":
         CExpression()
-        CExpression(CComputationGraph *pg, VariableIndex i,string name)
+        CExpression(CComputationGraph *pg, VariableIndex i)
         CComputationGraph *pg
         long i
-        string name
         CDim dim() except +
     #CExpression c_input "dynet::expr::input" (CComputationGraph& g, float s)   #
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, float *ps) #

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -691,7 +691,6 @@ cdef class Expression: #{{{
 
     cdef VariableIndex vindex
     cdef int cg_version
-    cdef string name
     def __cinit__(self):
         #self.cg = NULL
         self.vindex = 0
@@ -702,10 +701,9 @@ cdef class Expression: #{{{
         #self.cg = cexpr.pg
         self.vindex = cexpr.i
         self.cg_version = cgv
-        self.name = cexpr.name
         return self
     cdef CExpression c(self):
-        return CExpression(self.cgp(), self.vindex, self.name)
+        return CExpression(self.cgp(), self.vindex)
 
     cpdef dim(self):
         """
@@ -1714,4 +1712,3 @@ cdef class AdamTrainer:
         return self.thisptr.clip_threshold
 
 #}}}
-

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -691,6 +691,7 @@ cdef class Expression: #{{{
 
     cdef VariableIndex vindex
     cdef int cg_version
+    cdef string name
     def __cinit__(self):
         #self.cg = NULL
         self.vindex = 0
@@ -701,9 +702,10 @@ cdef class Expression: #{{{
         #self.cg = cexpr.pg
         self.vindex = cexpr.i
         self.cg_version = cgv
+        self.name = cexpr.name
         return self
     cdef CExpression c(self):
-        return CExpression(self.cgp(), self.vindex)
+        return CExpression(self.cgp(), self.vindex, self.name)
 
     cpdef dim(self):
         """

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -14,7 +14,7 @@ using namespace std;
 struct NodeTest {
   NodeTest() {
     // initialize if necessary
-    if(default_device == nullptr) {
+    if (default_device == nullptr) {
       for (auto x : {"NodeTest", "--dynet-mem", "10"}) {
         av.push_back(strdup(x));
       }
@@ -23,46 +23,48 @@ struct NodeTest {
       dynet::initialize(argc, argv);
     }
 
-    ones3_vals = {1.f,1.f,1.f};
-    first_one_vals = {1.f,0.f,0.f};
-    ones2_vals = {1.f,1.f};
-    batch_vals = {1.f,2.f,3.f,4.f,5.f,6.f};
+    ones3_vals = {1.f, 1.f, 1.f};
+    first_one_vals = {1.f, 0.f, 0.f};
+    ones2_vals = {1.f, 1.f};
+    batch_vals = {1.f, 2.f, 3.f, 4.f, 5.f, 6.f};
     // Create parameters
-    std::vector<float> param1_vals = {1.1f,-2.2f,3.3f};
-    std::vector<float> param2_vals = {2.2f,3.4f,-1.2f};
-    std::vector<float> param3_vals = {1.1f,2.2f,3.3f};
-    std::vector<float> param4_vals = {1.1f,2.2f,3.3f,-1.2f,2.1f,3.4f};
+    std::vector<float> param1_vals = {1.1f, -2.2f, 3.3f};
+    std::vector<float> param2_vals = {2.2f, 3.4f, -1.2f};
+    std::vector<float> param3_vals = {1.1f, 2.2f, 3.3f};
+    std::vector<float> param4_vals = {1.1f, 2.2f, 3.3f, -1.2f, 2.1f, 3.4f};
     std::vector<float> param_scalar1_vals = {2.2f};
     std::vector<float> param_scalar2_vals = {1.1f};
-    std::vector<float> param_kernel1_vals = {1.1f,2.2f,-1.0f,1.2f,-3.4f,-0.2f};
-    std::vector<float> param_filter1_vals = {1.1f,2.2f,-1.0f,1.2f,-3.4f,-0.2f,
-                                             11.1f,12.2f,13.3f,11.2f,12.2f,13.2f};
-    std::vector<float> param_square1_vals = {1.1f,2.2f,3.4f,1.2f,2.5f,3.2f,5.3f,2.3f,3.3f};
-    std::vector<float> param_cube1_vals = {.011f,.022f,.033f,.012f,.022f,.032f,.013f,.023f,.033f,
-                                           .111f,-.122f,-.033f,-.112f,-.022f,-.132f,-.113f,-.123f,-.133f,
-                                           .211f,.222f,.233f,.212f,.222f,.232f,.213f,.223f,.233f};
+    std::vector<float> param_kernel1_vals = {1.1f, 2.2f, -1.0f, 1.2f, -3.4f, -0.2f};
+    std::vector<float> param_filter1_vals = {1.1f, 2.2f, -1.0f, 1.2f, -3.4f, -0.2f,
+                                             11.1f, 12.2f, 13.3f, 11.2f, 12.2f, 13.2f
+                                            };
+    std::vector<float> param_square1_vals = {1.1f, 2.2f, 3.4f, 1.2f, 2.5f, 3.2f, 5.3f, 2.3f, 3.3f};
+    std::vector<float> param_cube1_vals = {.011f, .022f, .033f, .012f, .022f, .032f, .013f, .023f, .033f,
+                                           .111f, -.122f, -.033f, -.112f, -.022f, -.132f, -.113f, -.123f, -.133f,
+                                           .211f, .222f, .233f, .212f, .222f, .232f, .213f, .223f, .233f
+                                          };
     param1 = mod.add_parameters({3});
-    TensorTools::SetElements(param1.get()->values,param1_vals);
+    TensorTools::SetElements(param1.get()->values, param1_vals);
     param2 = mod.add_parameters({3});
-    TensorTools::SetElements(param2.get()->values,param2_vals);
+    TensorTools::SetElements(param2.get()->values, param2_vals);
     param3 = mod.add_parameters({3});
-    TensorTools::SetElements(param3.get()->values,param3_vals);
+    TensorTools::SetElements(param3.get()->values, param3_vals);
     param4 = mod.add_parameters({6});
-    TensorTools::SetElements(param4.get()->values,param4_vals);
+    TensorTools::SetElements(param4.get()->values, param4_vals);
     param_scalar1 = mod.add_parameters({1});
-    TensorTools::SetElements(param_scalar1.get()->values,param_scalar1_vals);
+    TensorTools::SetElements(param_scalar1.get()->values, param_scalar1_vals);
     param_scalar2 = mod.add_parameters({1});
-    TensorTools::SetElements(param_scalar2.get()->values,param_scalar2_vals);
-    param_kernel1 = mod.add_parameters({3,2});
-    TensorTools::SetElements(param_kernel1.get()->values,param_kernel1_vals);
-    param_filter1 = mod.add_parameters({3,2,2});
-    TensorTools::SetElements(param_filter1.get()->values,param_filter1_vals);
-    param_square1 = mod.add_parameters({3,3});
-    TensorTools::SetElements(param_square1.get()->values,param_square1_vals);
-    param_cube1 = mod.add_parameters({3,3,3});
-    TensorTools::SetElements(param_cube1.get()->values,param_cube1_vals);
+    TensorTools::SetElements(param_scalar2.get()->values, param_scalar2_vals);
+    param_kernel1 = mod.add_parameters({3, 2});
+    TensorTools::SetElements(param_kernel1.get()->values, param_kernel1_vals);
+    param_filter1 = mod.add_parameters({3, 2, 2});
+    TensorTools::SetElements(param_filter1.get()->values, param_filter1_vals);
+    param_square1 = mod.add_parameters({3, 3});
+    TensorTools::SetElements(param_square1.get()->values, param_square1_vals);
+    param_cube1 = mod.add_parameters({3, 3, 3});
+    TensorTools::SetElements(param_cube1.get()->values, param_cube1_vals);
     lookup1 = mod.add_lookup_parameters(3, {3});
-    TensorTools::SetElements(lookup1.get()->all_values,param_square1_vals);
+    TensorTools::SetElements(lookup1.get()->all_values, param_square1_vals);
   }
   ~NodeTest() {
     for (auto x : av) free(x);
@@ -71,8 +73,8 @@ struct NodeTest {
   template <class T>
   std::string print_vec(const std::vector<T> vec) {
     ostringstream oss;
-    if(vec.size()) oss << vec[0];
-    for(size_t i = 1; i < vec.size(); i++)
+    if (vec.size()) oss << vec[0];
+    for (size_t i = 1; i < vec.size(); i++)
       oss << ' ' << vec[i];
     return oss.str();
   }
@@ -93,7 +95,7 @@ BOOST_AUTO_TEST_CASE( negate_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = -x1;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -102,8 +104,8 @@ BOOST_AUTO_TEST_CASE( add_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
-  Expression y = x1+x2;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = x1 + x2;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -112,8 +114,8 @@ BOOST_AUTO_TEST_CASE( sum_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
-  Expression y = sum({x2,x1,x2});
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = sum({x2, x1, x2});
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -122,9 +124,9 @@ BOOST_AUTO_TEST_CASE( sum_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
-  Expression x3 = input(cg, Dim({3},2), batch_vals);
-  Expression y = sum({x3,x1,cmult(x2,x3)});
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression x3 = input(cg, Dim({3}, 2), batch_vals);
+  Expression y = sum({x3, x1, cmult(x2, x3)});
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = sum_batches(ones3 * y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -142,8 +144,8 @@ BOOST_AUTO_TEST_CASE( logsumexp_gradient ) {
 BOOST_AUTO_TEST_CASE( addscalar_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression y = x1+2.0;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = x1 + 2.0;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -151,8 +153,8 @@ BOOST_AUTO_TEST_CASE( addscalar_gradient ) {
 BOOST_AUTO_TEST_CASE( scalaradd_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression y = 2.0+x1;
-  Expression z =input(cg, {1,3}, ones3_vals) * y;
+  Expression y = 2.0 + x1;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -161,8 +163,8 @@ BOOST_AUTO_TEST_CASE( subtract_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
-  Expression y = x1+x2;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = x1 + x2;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -170,8 +172,8 @@ BOOST_AUTO_TEST_CASE( subtract_gradient ) {
 BOOST_AUTO_TEST_CASE( scalarsubtract_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression y = 2.0-x1;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = 2.0 - x1;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -179,8 +181,8 @@ BOOST_AUTO_TEST_CASE( scalarsubtract_gradient ) {
 BOOST_AUTO_TEST_CASE( subtractscalar_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression y = x1-2.0;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = x1 - 2.0;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -189,8 +191,8 @@ BOOST_AUTO_TEST_CASE( multiply_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
-  Expression y = x1*transpose(x2);
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression y = x1 * transpose(x2);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = ones3 * y * transpose(ones3);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -199,9 +201,9 @@ BOOST_AUTO_TEST_CASE( multiply_gradient ) {
 BOOST_AUTO_TEST_CASE( multiply_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
-  Expression y = x1*transpose(x2);
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression y = x1 * transpose(x2);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = sum_batches(ones3 * y * transpose(ones3));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -213,7 +215,7 @@ BOOST_AUTO_TEST_CASE( affine_gradient ) {
   Expression scalar = parameter(cg, param_scalar1);
   Expression x2 = parameter(cg, param2);
   Expression y = affine_transform({x1, x2, scalar});
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = ones3 * sqrt(y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -223,9 +225,9 @@ BOOST_AUTO_TEST_CASE( affine_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression scalar = parameter(cg, param_scalar1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
   Expression y = affine_transform({x1, x2, scalar});
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = sum_batches(ones3 * sqrt(y));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -235,9 +237,9 @@ BOOST_AUTO_TEST_CASE( affine_batch_col_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression scalar = parameter(cg, param_scalar1);
-  Expression x2 = input(cg, Dim({1,3},2), batch_vals);
+  Expression x2 = input(cg, Dim({1, 3}, 2), batch_vals);
   Expression y = affine_transform({transpose(x1), scalar, x2});
-  Expression ones3 = input(cg, {3,1}, ones3_vals);
+  Expression ones3 = input(cg, {3, 1}, ones3_vals);
   Expression z = sum_batches(sqrt(y) * ones3);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -245,11 +247,11 @@ BOOST_AUTO_TEST_CASE( affine_batch_col_gradient ) {
 // Expression operator*(const Expression& x, const Expression& y);
 BOOST_AUTO_TEST_CASE( affine_batch2_gradient ) {
   dynet::ComputationGraph cg;
-  Expression x1 = input(cg, Dim({1,3},2), batch_vals);
+  Expression x1 = input(cg, Dim({1, 3}, 2), batch_vals);
   Expression scalar = parameter(cg, param_scalar1);
   Expression x2 = parameter(cg, param2);
   Expression y = affine_transform({x1, scalar, transpose(x2) });
-  Expression ones3 = input(cg, {3,1}, ones3_vals);
+  Expression ones3 = input(cg, {3, 1}, ones3_vals);
   Expression z = sum_batches(sqrt(y) * ones3);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -259,9 +261,9 @@ BOOST_AUTO_TEST_CASE( affine_batch3_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param_square1);
-  Expression inp = input(cg, Dim({3},2), batch_vals);
+  Expression inp = input(cg, Dim({3}, 2), batch_vals);
   Expression y = affine_transform({x1, x2, inp });
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = sum_batches(ones3 * sqrt(y));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -270,8 +272,8 @@ BOOST_AUTO_TEST_CASE( affine_batch3_gradient ) {
 BOOST_AUTO_TEST_CASE( multiplyscalar_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression y = x1*2.0;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = x1 * 2.0;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -279,8 +281,8 @@ BOOST_AUTO_TEST_CASE( multiplyscalar_gradient ) {
 BOOST_AUTO_TEST_CASE( scalarmultiply_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression y = 2.0*x1;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = 2.0 * x1;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -288,8 +290,8 @@ BOOST_AUTO_TEST_CASE( scalarmultiply_gradient ) {
 BOOST_AUTO_TEST_CASE( dividescalar_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression y = x1/2.0;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = x1 / 2.0;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -299,7 +301,7 @@ BOOST_AUTO_TEST_CASE( cdiv_gradient ) {
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
   Expression y = cdiv(x1, x2);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -307,9 +309,9 @@ BOOST_AUTO_TEST_CASE( cdiv_gradient ) {
 BOOST_AUTO_TEST_CASE( cdiv_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
   Expression y = cdiv(x1, x2) + cdiv(x2, x1);
-  Expression z = sum_batches(input(cg, {1,3}, ones3_vals) * y);
+  Expression z = sum_batches(input(cg, {1, 3}, ones3_vals) * y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -319,7 +321,7 @@ BOOST_AUTO_TEST_CASE( colwise_add_gradient ) {
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
   Expression y = colwise_add(x1 * transpose(x2), x2);
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = ones3 * y * transpose(ones3);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -329,9 +331,9 @@ BOOST_AUTO_TEST_CASE( colwise_add_batch1_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
-  Expression x3 = input(cg, Dim({1,3},2), batch_vals);
+  Expression x3 = input(cg, Dim({1, 3}, 2), batch_vals);
   Expression y = colwise_add(x1 * x3, x2);
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = sum_batches(ones3 * y * transpose(ones3));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -341,9 +343,9 @@ BOOST_AUTO_TEST_CASE( colwise_add_batch2_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
-  Expression x3 = input(cg, Dim({3,1},2), batch_vals);
+  Expression x3 = input(cg, Dim({3, 1}, 2), batch_vals);
   Expression y = colwise_add(x1 * transpose(x2), cmult(x2, x3));
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = sum_batches(ones3 * y * transpose(ones3));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -354,7 +356,7 @@ BOOST_AUTO_TEST_CASE( concatenate_cols_gradient ) {
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
   Expression y = concatenate_cols({x1, x2, x1});
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = ones3 * y * transpose(ones3);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -365,7 +367,7 @@ BOOST_AUTO_TEST_CASE( concatenate_gradient ) {
   Expression x1 = transpose(parameter(cg, param1));
   Expression x2 = transpose(parameter(cg, param2));
   Expression y = concatenate({x1, x2, x1});
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = ones3 * y * transpose(ones3);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -375,9 +377,9 @@ BOOST_AUTO_TEST_CASE( concatenate_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = transpose(parameter(cg, param1));
   Expression x2 = transpose(parameter(cg, param2));
-  Expression x3 = input(cg, Dim({1,3},2), batch_vals);
+  Expression x3 = input(cg, Dim({1, 3}, 2), batch_vals);
   Expression y = concatenate({x1, x2, cmult(x2, x3)});
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = sum_batches(ones3 * y * transpose(ones3));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -389,7 +391,7 @@ BOOST_AUTO_TEST_CASE( contract3d_1d_gradient ) {
   Expression square1 = parameter(cg, param_square1);
   Expression cube1 = parameter(cg, param_cube1);
   Expression y = contract3d_1d(cube1, x1, square1);
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = ones3 * y * transpose(ones3);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -402,7 +404,7 @@ BOOST_AUTO_TEST_CASE( contract3d_1d_1d_gradient ) {
   Expression x3 = parameter(cg, param3);
   Expression cube1 = parameter(cg, param_cube1);
   Expression y = contract3d_1d_1d(cube1, x1, x2, x3);
-  Expression ones3 = input(cg, {1,3}, ones3_vals);
+  Expression ones3 = input(cg, {1, 3}, ones3_vals);
   Expression z = ones3 * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -412,7 +414,7 @@ BOOST_AUTO_TEST_CASE( sqrt_gradient ) {
   dynet::ComputationGraph cg;
   Expression x3 = parameter(cg, param3);
   Expression y = sqrt(x3);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -421,7 +423,7 @@ BOOST_AUTO_TEST_CASE( erf_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = erf(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -430,7 +432,7 @@ BOOST_AUTO_TEST_CASE( tanh_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = tanh(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -439,7 +441,7 @@ BOOST_AUTO_TEST_CASE( exp_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = exp(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -448,7 +450,7 @@ BOOST_AUTO_TEST_CASE( square_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = square(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -457,7 +459,7 @@ BOOST_AUTO_TEST_CASE( cube_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = cube(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -466,7 +468,7 @@ BOOST_AUTO_TEST_CASE( lgamma_gradient ) {
   dynet::ComputationGraph cg;
   Expression x2 = parameter(cg, param2);
   Expression y = lgamma(x2);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -475,7 +477,7 @@ BOOST_AUTO_TEST_CASE( log_gradient ) {
   dynet::ComputationGraph cg;
   Expression x3 = parameter(cg, param3);
   Expression y = log(x3);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -484,7 +486,7 @@ BOOST_AUTO_TEST_CASE( logistic_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = logistic(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -493,7 +495,7 @@ BOOST_AUTO_TEST_CASE( rectify_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = rectify(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -508,11 +510,11 @@ BOOST_AUTO_TEST_CASE( hinge_gradient ) {
 
 // Expression hinge(const Expression& x, unsigned index, float m = 1.0);
 BOOST_AUTO_TEST_CASE( hinge_batch_gradient ) {
-  std::vector<unsigned> idx = {1,2};
+  std::vector<unsigned> idx = {1, 2};
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
-  Expression z = sum_batches(hinge(x1+x2, idx, 2.f));
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression z = sum_batches(hinge(x1 + x2, idx, 2.f));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -530,7 +532,7 @@ BOOST_AUTO_TEST_CASE( log_softmax_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = log_softmax(x1);
-  Expression z = input(cg, {1,3}, first_one_vals) * y;
+  Expression z = input(cg, {1, 3}, first_one_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -538,28 +540,28 @@ BOOST_AUTO_TEST_CASE( log_softmax_gradient ) {
 BOOST_AUTO_TEST_CASE( log_softmax_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
-  Expression y = log_softmax(x1+x2);
-  Expression z = sum_batches(input(cg, {1,3}, first_one_vals) * y);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression y = log_softmax(x1 + x2);
+  Expression z = sum_batches(input(cg, {1, 3}, first_one_vals) * y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression log_softmax(const Expression& x, unsigned v);
 BOOST_AUTO_TEST_CASE( log_softmax_colbatch_gradient ) {
   dynet::ComputationGraph cg;
-  Expression x = reshape(parameter(cg, param_cube1), Dim({3,3},3));
+  Expression x = reshape(parameter(cg, param_cube1), Dim({3, 3}, 3));
   Expression y = log_softmax(x);
-  Expression z = sum_batches(input(cg, {1,3}, first_one_vals) * y * input(cg, {3}, first_one_vals));
+  Expression z = sum_batches(input(cg, {1, 3}, first_one_vals) * y * input(cg, {3}, first_one_vals));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression log_softmax(const Expression& x, const std::vector<unsigned>& restriction);
 BOOST_AUTO_TEST_CASE( restricted_log_softmax_gradient ) {
-  vector<unsigned> restriction = {0,1};
+  vector<unsigned> restriction = {0, 1};
   dynet::ComputationGraph cg;
   Expression x3 = parameter(cg, param3);
   Expression y = exp( log_softmax(x3, restriction) );
-  Expression z = input(cg, {1,3}, first_one_vals) * y;
+  Expression z = input(cg, {1, 3}, first_one_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -568,7 +570,7 @@ BOOST_AUTO_TEST_CASE( softmax_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = log(softmax(x1));
-  Expression z = input(cg, {1,3}, first_one_vals) * y;
+  Expression z = input(cg, {1, 3}, first_one_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -576,18 +578,18 @@ BOOST_AUTO_TEST_CASE( softmax_gradient ) {
 BOOST_AUTO_TEST_CASE( softmax_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
-  Expression y = log(softmax(x1+x2));
-  Expression z = sum_batches(input(cg, {1,3}, first_one_vals) * y);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression y = log(softmax(x1 + x2));
+  Expression z = sum_batches(input(cg, {1, 3}, first_one_vals) * y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression softmax(const Expression& x, unsigned v);
 BOOST_AUTO_TEST_CASE( softmax_colbatch_gradient ) {
   dynet::ComputationGraph cg;
-  Expression x = reshape(parameter(cg, param_cube1), Dim({3,3},3));
+  Expression x = reshape(parameter(cg, param_cube1), Dim({3, 3}, 3));
   Expression y = softmax(x);
-  Expression z = sum_batches(input(cg, {1,3}, first_one_vals) * y * input(cg, {3}, first_one_vals));
+  Expression z = sum_batches(input(cg, {1, 3}, first_one_vals) * y * input(cg, {3}, first_one_vals));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -596,7 +598,7 @@ BOOST_AUTO_TEST_CASE( sparsemax_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = sparsemax(x1);
-  Expression z = input(cg, {1,3}, first_one_vals) * y;
+  Expression z = input(cg, {1, 3}, first_one_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -614,7 +616,7 @@ BOOST_AUTO_TEST_CASE( softsign_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = softsign(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -624,7 +626,7 @@ BOOST_AUTO_TEST_CASE( pow_gradient ) {
   Expression x3 = parameter(cg, param3);
   Expression x_scalar1 = parameter(cg, param_scalar1);
   Expression y = pow(x3, x_scalar1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -634,7 +636,7 @@ BOOST_AUTO_TEST_CASE( min_gradient ) {
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
   Expression y = min(x1, x2);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -644,7 +646,7 @@ BOOST_AUTO_TEST_CASE( max_gradient ) {
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
   Expression y = max(x1, x2);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -675,7 +677,7 @@ BOOST_AUTO_TEST_CASE( max_gradient ) {
 BOOST_AUTO_TEST_CASE( reshape_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression y = reshape(x1, {1,3});
+  Expression y = reshape(x1, {1, 3});
   Expression z = y * input(cg, {3}, ones3_vals);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -684,10 +686,10 @@ BOOST_AUTO_TEST_CASE( reshape_gradient ) {
 BOOST_AUTO_TEST_CASE( reshape_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
-  Expression y1 = x1*transpose(x2);
-  Expression y2 = reshape(y1, Dim({3,3}, 2));
-  Expression z = sum_batches(input(cg, {1,3}, ones3_vals) * y2 * input(cg, {3,1}, ones3_vals));
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression y1 = x1 * transpose(x2);
+  Expression y2 = reshape(y1, Dim({3, 3}, 2));
+  Expression z = sum_batches(input(cg, {1, 3}, ones3_vals) * y2 * input(cg, {3, 1}, ones3_vals));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -696,7 +698,7 @@ BOOST_AUTO_TEST_CASE( transpose_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = softsign(x1);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -725,7 +727,7 @@ BOOST_AUTO_TEST_CASE( cmult_gradient ) {
   Expression x1 = parameter(cg, param1);
   Expression x2 = parameter(cg, param2);
   Expression y = cmult(x1, x2);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -733,9 +735,9 @@ BOOST_AUTO_TEST_CASE( cmult_gradient ) {
 BOOST_AUTO_TEST_CASE( cmult_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
   Expression y = cmult(x1, x2) + cmult(x2, x1);
-  Expression z = sum_batches(input(cg, {1,3}, ones3_vals) * y);
+  Expression z = sum_batches(input(cg, {1, 3}, ones3_vals) * y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -752,7 +754,7 @@ BOOST_AUTO_TEST_CASE( dot_product_gradient ) {
 BOOST_AUTO_TEST_CASE( dot_product_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
   Expression z = sum_batches(dot_product(x1, x2) + dot_product(x2, x1) * 2);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
@@ -816,7 +818,7 @@ BOOST_AUTO_TEST_CASE( conv1d_narrow_gradient ) {
   Expression xsquare = parameter(cg, param_square1);
   Expression xkernel = parameter(cg, param_kernel1);
   Expression y = conv1d_narrow(xsquare, xkernel);
-  Expression z = input(cg, {1,3}, ones3_vals) * y * input(cg, {2,1}, ones2_vals);
+  Expression z = input(cg, {1, 3}, ones3_vals) * y * input(cg, {2, 1}, ones2_vals);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -825,7 +827,7 @@ BOOST_AUTO_TEST_CASE( conv1d_wide_gradient ) {
   dynet::ComputationGraph cg;
   Expression xkernel = parameter(cg, param_kernel1);
   Expression y = conv1d_wide(xkernel, xkernel);
-  Expression z = input(cg, {1,3}, ones3_vals) * y * input(cg, {3,1}, ones3_vals);
+  Expression z = input(cg, {1, 3}, ones3_vals) * y * input(cg, {3, 1}, ones3_vals);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -835,7 +837,7 @@ BOOST_AUTO_TEST_CASE( filter1d_narrow_gradient ) {
   Expression xsquare = parameter(cg, param_square1);
   Expression xfilter = parameter(cg, param_filter1);
   Expression y = filter1d_narrow(xsquare, xfilter);
-  Expression z = input(cg, {1,2}, ones3_vals) * y * input(cg, {2,1}, ones2_vals);
+  Expression z = input(cg, {1, 2}, ones3_vals) * y * input(cg, {2, 1}, ones2_vals);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -844,7 +846,7 @@ BOOST_AUTO_TEST_CASE( kmax_pooling_keq1_gradient ) {
   dynet::ComputationGraph cg;
   Expression xsquare = parameter(cg, param_square1);
   Expression y = tanh(kmax_pooling(xsquare, 1));
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -853,7 +855,7 @@ BOOST_AUTO_TEST_CASE( kmax_pooling_keq2_gradient ) {
   dynet::ComputationGraph cg;
   Expression xsquare = parameter(cg, param_square1);
   Expression y = tanh(kmax_pooling(xsquare, 2));
-  Expression z = input(cg, {1,3}, ones3_vals) * y * input(cg, {2,1}, ones2_vals);
+  Expression z = input(cg, {1, 3}, ones3_vals) * y * input(cg, {2, 1}, ones2_vals);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -862,7 +864,7 @@ BOOST_AUTO_TEST_CASE( fold_rows_gradient ) {
   dynet::ComputationGraph cg;
   Expression x4 = parameter(cg, param4);
   Expression y = fold_rows(x4, 2);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -871,7 +873,7 @@ BOOST_AUTO_TEST_CASE( average_cols_gradient ) {
   dynet::ComputationGraph cg;
   Expression xsquare = parameter(cg, param_square1);
   Expression y = tanh(average_cols(xsquare));
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -880,7 +882,7 @@ BOOST_AUTO_TEST_CASE( sum_cols_gradient ) {
   dynet::ComputationGraph cg;
   Expression xsquare = parameter(cg, param_square1);
   Expression y = tanh(sum_cols(xsquare));
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -908,11 +910,11 @@ BOOST_AUTO_TEST_CASE( pickptr_gradient ) {
 
 // Expression pick(const Expression& x, unsigned v);
 BOOST_AUTO_TEST_CASE( pick_batch_gradient ) {
-  std::vector<unsigned> idx = {1,2};
+  std::vector<unsigned> idx = {1, 2};
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
-  Expression z = sum_batches(pick(x1+x2, idx));
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression z = sum_batches(pick(x1 + x2, idx));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -921,7 +923,7 @@ BOOST_AUTO_TEST_CASE( pickrange_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression y = pickrange(x1, 0, 2);
-  Expression z = input(cg, {1,2}, ones2_vals) * y;
+  Expression z = input(cg, {1, 2}, ones2_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -950,7 +952,7 @@ BOOST_AUTO_TEST_CASE( select_cols_gradient ) {
   vector<unsigned> cols = {1};
   Expression x1 = parameter(cg, param_square1);
   Expression y = select_cols(x1, cols);
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -974,11 +976,11 @@ BOOST_AUTO_TEST_CASE( pickneglogsoftmax_gradient ) {
 
 // Expression pickneglogsoftmax(const Expression& x, unsigned v);
 BOOST_AUTO_TEST_CASE( pickneglogsoftmax_batch_gradient ) {
-  std::vector<unsigned> idx = {1,2};
+  std::vector<unsigned> idx = {1, 2};
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3},2), batch_vals);
-  Expression z = sum_batches(pickneglogsoftmax(x1+x2, idx));
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression z = sum_batches(pickneglogsoftmax(x1 + x2, idx));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -986,11 +988,11 @@ BOOST_AUTO_TEST_CASE( pickneglogsoftmax_batch_gradient ) {
 BOOST_AUTO_TEST_CASE( sparse_input_test ) {
   dynet::ComputationGraph cg;
   std::vector<unsigned int> ids = {0, 4};
-  Expression z = input(cg, Dim({3},2), ids, ones2_vals, 0.5);
+  Expression z = input(cg, Dim({3}, 2), ids, ones2_vals, 0.5);
   std::vector<float> exp = {1.0f, 0.5f, 0.5f, 0.5f, 1.0f, 0.5f};
   std::vector<float> act = as_vector(cg.forward(z));
   assert(exp.size() == act.size());
-  for(size_t i = 0; i < exp.size(); ++i)
+  for (size_t i = 0; i < exp.size(); ++i)
     BOOST_CHECK_CLOSE(exp[i], act[i], 0.001);
 }
 
@@ -999,8 +1001,8 @@ BOOST_AUTO_TEST_CASE( lookup_test ) {
   dynet::ComputationGraph cg;
   Expression x1 = lookup(cg, lookup1, (unsigned)0);
   Expression x2 = lookup(cg, lookup1, (unsigned)2);
-  Expression y = x1+x2;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = x1 + x2;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
@@ -1008,9 +1010,18 @@ BOOST_AUTO_TEST_CASE( backward_test ) {
   dynet::ComputationGraph cg;
   Expression x1 = lookup(cg, lookup1, (unsigned)0);
   Expression x2 = lookup(cg, lookup1, (unsigned)2);
-  Expression y = x1+x2;
-  Expression z = input(cg, {1,3}, ones3_vals) * y;
+  Expression y = x1 + x2;
+  Expression z = input(cg, {1, 3}, ones3_vals) * y;
   cg.backward(z);
+}
+
+BOOST_AUTO_TEST_CASE( sanity_test ) {
+  Expression x;
+  {
+    dynet::ComputationGraph cg;
+    x = input(cg, {3}, ones3_vals);
+  }
+  BOOST_CHECK_THROW(x.value() , std::runtime_error);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This fixes a bug in C++ where if you tried to access an expression value after the deletion of the underlying graph, you would get an error like `SIGSEGV, si_code: 0 (memory access violation at address: 0x00000080)` .

Highlights :

- This does more or less the same thing as python : keeps an id for each graph and checks whether the id of the graph with which the expression was created matches.
- Add a `name` field in expression for more explicit error messages
- Also added `except +` to forward functions in the computation graph in `_dynet.pyx`.

The last points means that now the following snippet :

    import dynet as dy
    x=dy.inputTensor(np.ones(10))
    y=dy.select_rows(x,[11])
    y.value()

raises a python `ValueError` instead of crashing python with `abort (core dumped)` and the c++ exception.

Now there is a concurrent sanity checking system for expressions in c++ and python, this could probably be fixed since python can now catch c++ exceptions so there's no need for double checking.

I'll leave that to a future pull request though. 


