### PR TITLE
Code to allow expression for entirety of lookup params

### DIFF
--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -195,7 +195,24 @@ VariableIndex ComputationGraph::add_parameters(Parameter p) {
   return new_node_index;
 }
 
+VariableIndex ComputationGraph::add_parameters(LookupParameter p) {
+  VariableIndex new_node_index(nodes.size());
+  ParameterNode* new_node = new ParameterNode(p);
+  nodes.push_back(new_node);
+  parameter_nodes.push_back(new_node_index);
+  set_dim_for_new_node(new_node_index);
+  return new_node_index;
+}
+
 VariableIndex ComputationGraph::add_const_parameters(Parameter p) {
+  VariableIndex new_node_index(nodes.size());
+  ConstParameterNode* new_node = new ConstParameterNode(p);
+  nodes.push_back(new_node);
+  set_dim_for_new_node(new_node_index);
+  return new_node_index;
+}
+
+VariableIndex ComputationGraph::add_const_parameters(LookupParameter p) {
   VariableIndex new_node_index(nodes.size());
   ConstParameterNode* new_node = new ConstParameterNode(p);
   nodes.push_back(new_node);

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -142,12 +142,26 @@ struct ComputationGraph {
    */
   VariableIndex add_parameters(Parameter p);
   /**
+   * \brief Add a full matrix of lookup parameters to the computation graph
+   *
+   * \param p LookupParameter to be added
+   * \return The index of the created variable
+   */
+  VariableIndex add_parameters(LookupParameter p);
+  /**
    * \brief Add a parameter to the computation graph (but don't update)
    *
    * \param p Parameter to be added
    * \return The index of the created variable
    */
   VariableIndex add_const_parameters(Parameter p);
+  /**
+   * \brief Add a full matrix of lookup parameter to the computation graph (but don't update)
+   *
+   * \param p LookupParameter to be added
+   * \return The index of the created variable
+   */
+  VariableIndex add_const_parameters(LookupParameter p);
   // use pindex to point to a memory location where the index will live
   // that the caller owns
   /**

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -16,7 +16,9 @@ Expression input(ComputationGraph& g, const Dim& d, const vector<float>& data) {
 Expression input(ComputationGraph& g, const Dim& d, const vector<float>* pdata) { return Expression(&g, g.add_input(d, pdata)); }
 Expression input(ComputationGraph& g, const Dim& d, const vector<unsigned int>& ids, const vector<float>& data, float defdata) { return Expression(&g, g.add_input(d, ids, data, defdata)); }
 Expression const_parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_const_parameters(p)); }
+Expression const_parameter(ComputationGraph& g, LookupParameter p) { return Expression(&g, g.add_const_parameters(p)); }
 Expression parameter(ComputationGraph& g, Parameter p) { return Expression(&g, g.add_parameters(p)); }
+Expression parameter(ComputationGraph& g, LookupParameter p) { return Expression(&g, g.add_parameters(p)); }
 Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index) { return Expression(&g, g.add_lookup(p, index)); }
 Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex) { return Expression(&g, g.add_lookup(p, pindex)); }
 Expression lookup(ComputationGraph& g, LookupParameter p, const vector<unsigned>& indices) { return Expression(&g, g.add_lookup(p, indices)); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -180,6 +180,26 @@ Expression parameter(ComputationGraph& g, Parameter p);
 
 /**
  * \ingroup inputoperations
+ * \brief Load lookup parameter
+ * \details Load a full tensor of lookup parameters into the computation graph.
+ *          Normally lookup parameters are accessed by using the lookup() function
+ *          to grab a single element. However, in some cases we'll want to access
+ *          all of the parameters in the entire set of lookup parameters for some
+ *          reason. In this case you can use this function. In this case, the
+ *          first dimensions in the returned tensor will be equivalent to the
+ *          dimensions that we would get if we get calling the lookup() function,
+ *          and the size of the final dimension will be equal to the size of the
+ *          vocabulary.
+ *
+ * \param g Computation graph
+ * \param lp LookupParameter object to load
+ *
+ * \return An expression representing lp
+ */
+Expression parameter(ComputationGraph& g, LookupParameter lp);
+
+/**
+ * \ingroup inputoperations
  * \brief Load constant parameters
  * \details Load parameters into the computation graph, but prevent them from being
  *          updated when performing parameter update.
@@ -190,6 +210,19 @@ Expression parameter(ComputationGraph& g, Parameter p);
  * \return An expression representing the constant p
  */
 Expression const_parameter(ComputationGraph& g, Parameter p);
+
+/**
+ * \ingroup inputoperations
+ * \brief Load constant lookup parameters
+ * \details Load lookup parameters into the computation graph, but prevent them from being
+ *          updated when performing parameter update.
+ *
+ * \param g Computation graph
+ * \param lp LookupParameter object to load
+ *
+ * \return An expression representing the constant lp
+ */
+Expression const_parameter(ComputationGraph& g, LookupParameter lp);
 
 /**
  * \ingroup inputoperations

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -152,10 +152,21 @@ struct LookupParameterStorage : public ParameterStorageBase {
    * @param val Other LookupParameterStorage to copy from
    */
   void copy(const LookupParameterStorage & val);
+
+  template <class MyDevice>
+  void accumulate_grad_dev(MyDevice & dev, const Tensor& g);
+  /**
+   * @brief Add a Tensor to the gradient of the whole lookup matrix
+   * @details after this `grads<-grads + g`
+   * 
+   * @param g [description]
+   */
+  void accumulate_grad(const Tensor& g);
+
   template <class MyDevice>
   void accumulate_grad_dev(MyDevice & dev, unsigned index, const Tensor& g);
   /**
-   * @brief Add a Tensor to the gradient f one of the lookups
+   * @brief Add a Tensor to the gradient of one of the lookups
    * @details after this `grads[index]<-grads[index] + g`
    * 
    * @param index [description]
@@ -189,8 +200,9 @@ struct LookupParameterStorage : public ParameterStorageBase {
   std::vector<Tensor> grads; /**< List of gradient values for each lookup */
   // gradients are sparse, so track which components are nonzero
   std::unordered_set<unsigned> non_zero_grads; /**< Gradients are sparse, so track which components are nonzero */
+  bool all_updated; /** Whether all of the gradients have been updated. */
 private:
-  LookupParameterStorage() {}
+  LookupParameterStorage() : all_updated(false) {}
   LookupParameterStorage(unsigned n, const Dim& d);
   LookupParameterStorage(unsigned n, const Dim& d, const ParameterInit & init);
   DYNET_SERIALIZE_SPLIT_DECLARE()

--- a/dynet/param-nodes.h
+++ b/dynet/param-nodes.h
@@ -13,19 +13,23 @@ struct ParameterNodeBase : public Node {
 
 // represents optimizable parameters
 struct ParameterNode : public ParameterNodeBase {
-  explicit ParameterNode(Parameter p) : dim(p.get()->dim), params(p) {}
+  explicit ParameterNode(const Parameter & p) : dim(p.get()->dim), params(p) {}
+  explicit ParameterNode(const LookupParameter & lp) : dim(lp.get()->all_dim), lparams(lp) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
   void accumulate_grad(const Tensor& g) override;
   Dim dim;
   Parameter params;
+  LookupParameter lparams;
 };
 
 // represents optimizable parameters that are being held constant
 struct ConstParameterNode : public Node {
-  explicit ConstParameterNode(Parameter p) : dim(p.get()->dim), params(p) {}
+  explicit ConstParameterNode(const Parameter & p) : dim(p.get()->dim), params(p) {}
+  explicit ConstParameterNode(const LookupParameter & lp) : dim(lp.get()->all_dim), lparams(lp) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
   Dim dim;
   Parameter params;
+  LookupParameter lparams;
 };
 
 // represents specified (not learned) inputs to the network

--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -100,7 +100,7 @@ void Trainer::update(const std::vector<unsigned> & upd_params, const std::vector
   }
   const auto & lookup_params = model->lookup_parameters_list();
   for(auto i : upd_lookup_params) {
-    if(sparse_updates_enabled) {
+    if(sparse_updates_enabled && !lookup_params[i]->all_updated) {
       for (auto j : lookup_params[i]->non_zero_grads)
         update_lookup_params(scale, gscale, i, j);
     } else {

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -218,6 +218,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, float *ps) #
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, CDim& d, vector[float]* pdata)
     CExpression c_parameter "dynet::expr::parameter" (CComputationGraph& g, CParameters p) #
+    CExpression c_parameter "dynet::expr::parameter" (CComputationGraph& g, CLookupParameters p) #
     #CExpression c_lookup "dynet::expr::lookup" (CComputationGraph& g, CLookupParameters* p, unsigned index)   #
     CExpression c_lookup "dynet::expr::lookup" (CComputationGraph& g, CLookupParameters p, unsigned* pindex) #
     CExpression c_lookup "dynet::expr::lookup" (CComputationGraph& g, CLookupParameters p, vector[unsigned]* pindices) #

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -148,9 +148,7 @@ cdef class Parameters:
     cdef int _version
     cdef Expression _expr
     def __cinit__(self):
-        #self.thisptr = p
         self._version = -1
-        pass
     @staticmethod
     cdef wrap_ptr(CParameters ptr):
         self = Parameters()
@@ -207,8 +205,10 @@ cdef class Parameters:
 
 cdef class LookupParameters:
     cdef CLookupParameters thisptr # TODO -- no longer pointer
+    cdef int _version
+    cdef Expression _expr
     def __cinit__(self):
-        pass
+        self._version = -1
     @staticmethod
     cdef wrap_ptr(CLookupParameters ptr):
         self = LookupParameters()
@@ -837,8 +837,11 @@ cdef class Expression: #{{{
 #cdef Expression _parameter(ComputationGraph g, Parameters p):
 #    return Expression.from_cexpr(g.version(), c_parameter(g.thisptr[0], p.thisptr))
 
-def parameter(Parameters p): return p.expr()
-def parameter(LookupParameters p): return p.expr()
+def parameter(p):
+    if isinstance(p,Parameters) or isinstance(p,LookupParameters):
+        return p.expr()
+    else:
+        raise NotImplementedError("Cannot call parameter() on anything other than Parameters or LookupParameters")
 
 # {{{ Mutable Expressions
 #     These depend values that can be set by the caller

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -252,6 +252,11 @@ cdef class LookupParameters:
         grads = self.thisptr.get().grads
         return np.vstack([c_tensor_as_np(t).reshape(1,-1,order='F') for t in grads])
 
+    cpdef Expression expr(self):
+        if cg_version() != self._version:
+            self._version = cg_version()
+            self._expr = Expression.from_cexpr(_cg.version(), c_parameter(_cg.thisptr[0], self.thisptr))
+        return self._expr
 
     cpdef zero(self): self.thisptr.zero()
 
@@ -833,6 +838,7 @@ cdef class Expression: #{{{
 #    return Expression.from_cexpr(g.version(), c_parameter(g.thisptr[0], p.thisptr))
 
 def parameter(Parameters p): return p.expr()
+def parameter(LookupParameters p): return p.expr()
 
 # {{{ Mutable Expressions
 #     These depend values that can be set by the caller

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1006,6 +1006,14 @@ BOOST_AUTO_TEST_CASE( lookup_test ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression parameter() with lookup parameter input;
+BOOST_AUTO_TEST_CASE( lookup_matrix_test ) {
+  dynet::ComputationGraph cg;
+  Expression x = parameter(cg, lookup1);
+  Expression z = input(cg, {1, 3}, ones3_vals) * x * input(cg, {3}, ones3_vals);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 BOOST_AUTO_TEST_CASE( backward_test ) {
   dynet::ComputationGraph cg;
   Expression x1 = lookup(cg, lookup1, (unsigned)0);


### PR DESCRIPTION
This code makes it possible to import the entirety of a lookup parameter matrix in the same way we do for standard parameters, addressing https://github.com/clab/dynet/issues/352

This is not yet tested completely, and not compiled on GPU, hence the WIP.