### PR TITLE
Steps towards unifying error catching/reporting

### DIFF
--- a/doc/source/code_style.rst
+++ b/doc/source/code_style.rst
@@ -48,7 +48,16 @@ computation graph construction.
   or small enough (memory-wise) or in other ways cheap enough (time-wise) to
   copy.
 
-**Throwing Exceptions:** When the user does something illegal, throw an
-exception. "assert" should never be used for something that might be triggered
-by a user. (As `noted <https://github.com/clab/dynet/issues/139>`_)
+**Error handling:** The C++ core of DyNet provides a mechanism for error handling that
+should be used in all code. It consists of 3 macros as follows (included in ``globals.h``):
 
+* ``DYNET_INVALID_ARG(msg)``: This is used to throw an error that is triggered when
+  a user passes an invalid argument to one of the functions.
+* ``DYNET_RUNTIME_ERR(msg)``: This is used to throw an error that could be triggered
+  by a user, but is not the result of an invalid argument. For example, it could be
+  used when something is not implemented yet, or when the program dies due to lack
+  of memory, etc.
+* ``DYNET_ASSERT(expr,msg)``: This is to be used to check things that should only
+  happen due to a programming error within DyNet itself, and should never be
+  triggered by a user. ``expr`` is a condition, and ``msg`` is a message explaining
+  the exception, with ``ostream``-style formatting.

--- a/dynet/cuda.h
+++ b/dynet/cuda.h
@@ -3,7 +3,6 @@
 #if HAVE_CUDA
 
 #include <vector>
-#include <cassert>
 #include <utility>
 #include <stdexcept>
 #include <cuda.h>
@@ -43,7 +42,7 @@ struct DynetParams;
 class Device;
 
 inline std::pair<int, int> SizeToBlockThreadPair(int n) {
-  assert(n > 0);
+  DYNET_ASSERT(n > 0, "Bad thread size in GPU code " << n);
   int logn;
 #if defined(_MSC_VER)
   logn = 0;

--- a/dynet/deep-lstm.cc
+++ b/dynet/deep-lstm.cc
@@ -1,7 +1,6 @@
 #include "dynet/deep-lstm.h"
 
 #include <string>
-#include <cassert>
 #include <vector>
 #include <iostream>
 
@@ -75,7 +74,8 @@ void DeepLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    assert(layers*2 == hinit.size());
+    if(layers * 2 != hinit.size())
+      DYNET_INVALID_ARG("DeepLSTMBuilder must be initialized with 2 times as many expressions as layers (hidden state and cell for each layer). However, for " << layers << " layers, " << hinit.size() << " expressions were passed in");
     h0.resize(layers);
     c0.resize(layers);
     for (unsigned i = 0; i < layers; ++i) {

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -38,8 +38,7 @@ DeviceMempoolSizes::DeviceMempoolSizes(const std::string & descriptor) {
     used[1] = stoi(strs[1]);
     used[2] = stoi(strs[2]);
   } else {
-    ostringstream s; s << "the format of --dynet-mem is invalid:" << descriptor;
-    throw std::invalid_argument(s.str());
+    DYNET_INVALID_ARG("the format of --dynet-mem is invalid: " << descriptor);
   }
 }
 
@@ -52,17 +51,20 @@ DeviceMempoolSizes Device::mark(ComputationGraph *cg) {
 }
 
 void Device::revert(const DeviceMempoolSizes & cp) {
-  assert(cp.used[0] <= pools[0]->used);
+  if(cp.used[0] > pools[0]->used)
+    DYNET_INVALID_ARG("Saved value greater than original value in Device::revert (" << cp.used[0] << " > " << pools[0]->used << ")");
   pools[0]->used = cp.used[0];
-  assert(cp.used[1] <= pools[1]->used);
+  if(cp.used[1] > pools[1]->used)
+    DYNET_INVALID_ARG("Saved value greater than original value in Device::revert (" << cp.used[1] << " > " << pools[1]->used << ")");
   pools[1]->used = cp.used[1];
-  assert(cp.used[2] <= pools[2]->used);
+  if(cp.used[2] > pools[2]->used)
+    DYNET_INVALID_ARG("Saved value greater than original value in Device::revert (" << cp.used[2] << " > " << pools[2]->used << ")");
   pools[2]->used = cp.used[2];
 }
 
 void Device::allocate_tensor(DeviceMempool mp, Tensor & tens) {
-  assert(mp != DeviceMempool::NONE);
-  assert(pools[(int)mp] != nullptr);
+  DYNET_ASSERT(mp != DeviceMempool::NONE, "Attempt to allocate tensor for NONE DeviceMempool");
+  DYNET_ASSERT(pools[(int)mp] != nullptr, "Attempt to allocate tensor for null DeviceMempool");
   tens.v = (float*)pools[(int)mp]->allocate(tens.d.size() * sizeof(float));
   tens.mem_pool = mp;
 }

--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -8,7 +8,6 @@
 #ifndef DYNET_DIM_H
 #define DYNET_DIM_H
 
-#include <cassert>
 #include <initializer_list>
 #include <type_traits>
 #include <stdexcept>
@@ -17,6 +16,7 @@
 #include <vector>
 
 #include "dynet/io-macros.h"
+#include "dynet/globals.h"
 
 /**
  * \ingroup dim
@@ -160,7 +160,13 @@ struct Dim {
    * \param i Dimension index
    * \param s Dimension size
    */
-  inline void set(unsigned int i, unsigned int s) { assert(i < nd); assert(s > 0); d[i] = s; }
+  inline void set(unsigned int i, unsigned int s) {
+    if(i >= nd)
+      DYNET_INVALID_ARG("Out of bounds exception in Dim::set("<<i<<","<<s<<") for node of size " << d);
+    if(s == 0)
+      DYNET_INVALID_ARG("Attempt to set dimension size to zero in Dim::set("<<i<<","<<s<<") for node of size " << d);
+    d[i] = s;
+  }
   /**
    * \brief Access a specific dimension as you would access an array element
    *
@@ -180,7 +186,8 @@ struct Dim {
    * \param i index of the dimension to be removed
    */
   inline void delete_dim(unsigned int i) {
-    assert(i < nd);
+    if(i >= nd)
+      DYNET_INVALID_ARG("Out of bounds exception in Dim::delete_dim("<<i<<") for node of size " << d);
     if (nd == 1) {
       d[0] = 1;
     } else {
@@ -197,7 +204,7 @@ struct Dim {
   inline Dim transpose() const {
     if (nd == 1) { return Dim({1, d[0]}, bd); }
     else if (nd == 2) { return Dim({d[1], d[0]}, bd); }
-    throw std::invalid_argument("Cannot transpose Dim object with more than 2 dimensions");
+    DYNET_INVALID_ARG("Cannot transpose Dim object with more than 2 dimensions");
   }
 
   unsigned int d[DYNET_MAX_TENSOR_DIM]; /**< Array of dimension */
@@ -206,8 +213,6 @@ struct Dim {
 private:
   DYNET_SERIALIZE_DECLARE()
 };
-
-//static_assert(std::is_trivially_copyable<Dim>::value, "Dim must be trivially copyable");
 
 /**
  * \brief Check for equality between two Dim

--- a/dynet/globals.h
+++ b/dynet/globals.h
@@ -1,8 +1,22 @@
-#ifndef DYNET_EIGEN_RANDOM_H
-#define DYNET_EIGEN_RANDOM_H
+#ifndef DYNET_GLOBALS_H
+#define DYNET_GLOBALS_H
 
 #include <random>
 #include <vector>
+#include <sstream>
+#include <stdexcept>
+
+#define DYNET_INVALID_ARG(msg) do {             \
+    std::ostringstream oss;                     \
+    oss << msg;                                 \
+    throw std::invalid_argument(oss.str()); }   \
+  while (0);
+
+#define DYNET_RUNTIME_ERR(msg) do {             \
+    std::ostringstream oss;                     \
+    oss << msg;                                 \
+    throw std::runtime_error(oss.str()); }   \
+  while (0);
 
 namespace dynet {
 

--- a/dynet/globals.h
+++ b/dynet/globals.h
@@ -12,10 +12,17 @@
     throw std::invalid_argument(oss.str()); }   \
   while (0);
 
+#define DYNET_ASSERT(expr, msg) do {            \
+  if(!(expr)) {                                  \
+    std::ostringstream oss;                     \
+    oss << msg;                                 \
+    throw std::runtime_error(oss.str()); }      \
+  } while (0);
+
 #define DYNET_RUNTIME_ERR(msg) do {             \
     std::ostringstream oss;                     \
     oss << msg;                                 \
-    throw std::runtime_error(oss.str()); }   \
+    throw std::runtime_error(oss.str()); }      \
   while (0);
 
 namespace dynet {

--- a/dynet/grad-check.cc
+++ b/dynet/grad-check.cc
@@ -1,6 +1,5 @@
 #include "dynet/grad-check.h"
 
-#include <cassert>
 #include <iostream>
 #include <algorithm>
 

--- a/dynet/gru.cc
+++ b/dynet/gru.cc
@@ -1,7 +1,6 @@
 #include "dynet/gru.h"
 
 #include <string>
-#include <cassert>
 #include <vector>
 #include <iostream>
 
@@ -70,17 +69,15 @@ void GRUBuilder::new_graph_impl(ComputationGraph& cg) {
 void GRUBuilder::start_new_sequence_impl(const std::vector<Expression>& h_0) {
   h.clear();
   h0 = h_0;
-  if (!h0.empty()) {
-    assert (h0.size() == layers);
-  }
+  if (!h0.empty() && h0.size() != layers)
+    DYNET_INVALID_ARG("Number of inputs passed to initialize GRUBuilder (" << h0.size() <<
+                      ") is not equal to the number of layers (" << layers << ")");
 }
 
-// TO DO - Make this correct
-// Copied c from the previous step (otherwise c.size()< h.size())
-// Also is creating a new step something we want?
-// wouldn't overwriting the current one be better?
 Expression GRUBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  if (h_new.size()) { assert(h_new.size() == layers); }
+  if (h_new.size() && h_new.size() != layers)
+  DYNET_INVALID_ARG("Number of inputs passed to RNNBuilder::set_h() (" << h_new.size() <<
+                    ") is not equal to the number of layers (" << layers << ")");
   const unsigned t = h.size();
   h.push_back(vector<Expression>(layers));
   for (unsigned i = 0; i < layers; ++i) {
@@ -150,7 +147,8 @@ Expression GRUBuilder::add_input_impl(int prev, const Expression& x) {
 
 void GRUBuilder::copy(const RNNBuilder & rnn) {
   const GRUBuilder & rnn_gru = (const GRUBuilder&)rnn;
-  assert(params.size() == rnn_gru.params.size());
+  if(params.size() != rnn_gru.params.size())
+    DYNET_INVALID_ARG("Attempt to copy between two GRUBuilders that are not the same size");
   for (size_t i = 0; i < params.size(); ++i)
     for (size_t j = 0; j < params[i].size(); ++j)
       params[i][j] = rnn_gru.params[i][j];

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -35,7 +35,7 @@ static void remove_args(int& argc, char**& argv, int& argi, int n) {
   for (int i = argi + n; i < argc; ++i)
     argv[i - n] = argv[i];
   argc -= n;
-  assert(argc >= 0);
+  DYNET_ASSERT(argc >= 0, "remove_args less than 0");
 }
 
 DynetParams extract_dynet_params(int& argc, char**& argv, bool shared_parameters) {

--- a/dynet/mp.cc
+++ b/dynet/mp.cc
@@ -44,7 +44,6 @@ namespace dynet {
 
     unsigned spawn_children(std::vector<Workload>& workloads) {
       const unsigned num_children = workloads.size();
-      assert (workloads.size() == num_children);
       pid_t pid;
       unsigned cid;
       for (cid = 0; cid < num_children; ++cid) {
@@ -67,9 +66,9 @@ namespace dynet {
       std::vector<Workload> workloads(num_children);
       for (unsigned cid = 0; cid < num_children; cid++) { 
         err = pipe(workloads[cid].p2c);
-        assert (err == 0);
+        if(err != 0) DYNET_RUNTIME_ERR("Problem writing to p2c pipe " << cid << " in create_workloads");
         err = pipe(workloads[cid].c2p);
-        assert (err == 0);
+        if(err != 0) DYNET_RUNTIME_ERR("Problem writing to c2p pipe " << cid << " in create_workloads");
       }
       return workloads;
     }

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 
 #include "dynet/nodes-macros.h"
+#include "dynet/globals.h"
 
 using namespace std;
 
@@ -12,15 +13,13 @@ namespace dynet {
 
 string AddVectorToAllColumns::as_string(const vector<string>& arg_names) const {
   ostringstream os;
-  os << "fold_rows(" << arg_names[0] << ", " << arg_names[1] << ')';
+  os << "colwise_add(" << arg_names[0] << ", " << arg_names[1] << ')';
   return os.str();
 }
 
 Dim AddVectorToAllColumns::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 || xs[0].rows() != xs[1].rows() || xs[0].ndims() != 2 || (xs[1].ndims() != 1 && (xs[1].ndims() != 2 || xs[1].cols() != 1))) {
-    cerr << "Bad input dimensions in AddVectorToAllColumns: " << xs << endl;
-    throw std::invalid_argument("bad input dimensions in AddVectorToAllColumns");
-  }
+  if (xs.size() != 2 || xs[0].rows() != xs[1].rows() || xs[0].ndims() != 2 || (xs[1].ndims() != 1 && (xs[1].ndims() != 2 || xs[1].cols() != 1)))
+    DYNET_INVALID_ARG("Bad input dimensions in AddVectorToAllColumns: " << xs);
   return Dim({xs[0][0], xs[0][1]}, max(xs[0].bd,xs[1].bd));
 }
 
@@ -31,10 +30,8 @@ string SparsemaxLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SparsemaxLoss::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || !LooksLikeVector(xs[0])) {
-    ostringstream s; s << "Bad input dimensions in SparsemaxLoss: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs.size() != 1 || !LooksLikeVector(xs[0]))
+    DYNET_INVALID_ARG("Bad input dimensions in SparsemaxLoss: " << xs);
   return Dim({1});
 }
 
@@ -45,10 +42,8 @@ string Sparsemax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Sparsemax::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || !LooksLikeVector(xs[0])) {
-    ostringstream s; s << "Bad input dimensions in Sparsemax: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs.size() != 1 || !LooksLikeVector(xs[0]))
+    DYNET_INVALID_ARG("Bad input dimensions in Sparsemax: " << xs);
   return xs[0];
 }
 
@@ -62,18 +57,16 @@ Dim MatrixInverse::dim_forward(const vector<Dim>& xs) const {
   return xs[0];
 }
 
-Dim LogDet::dim_forward(const vector<Dim>& xs) const {
-    if (xs[0].ndims() > 2 || (xs[0].rows() != xs[0].cols())) {
-        cerr << "Bad arguments in LogDet: " << xs << endl;
-        throw std::invalid_argument("invalid arguments to LogDet");
-    }
-    return Dim({1});
-}
-
 string LogDet::as_string(const vector<string>& arg_names) const {
   ostringstream s;
   s << "logdet(" << arg_names[0] << ")";
   return s.str();
+}
+
+Dim LogDet::dim_forward(const vector<Dim>& xs) const {
+  if (xs[0].ndims() > 2 || (xs[0].rows() != xs[0].cols()))
+    DYNET_INVALID_ARG("Bad arguments in LogDet: " << xs);
+  return Dim({1});
 }
 
 string SelectRows::as_string(const vector<string>& arg_names) const {
@@ -83,10 +76,8 @@ string SelectRows::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SelectRows::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || xs[0].ndims() > 2) {
-    cerr << "Bad arguments in SelectRows: " << xs << endl;
-    throw std::invalid_argument("invalid arguments to SelectRows");
-  }
+  if (xs.size() != 1 || xs[0].ndims() > 2)
+    DYNET_INVALID_ARG("Bad arguments in SelectRows: " << xs);
   unsigned nrows = prows->size();
   if (xs[0].ndims() == 1) return Dim({nrows});
   return Dim({nrows, xs[0].cols()});
@@ -99,10 +90,8 @@ string SelectCols::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SelectCols::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || xs[0].ndims() != 2) {
-    cerr << "Bad arguments in SelectCols: " << xs << endl;
-    throw std::invalid_argument("invalid arguments to SelectCols");
-  }
+  if (xs.size() != 1 || xs[0].ndims() != 2)
+    DYNET_INVALID_ARG("Bad arguments in SelectCols: " << xs);
   unsigned ncols = pcols->size();
   return Dim({xs[0].rows(), ncols});
 }
@@ -114,10 +103,8 @@ string Min::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Min::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 || xs[0] != xs[1]) {
-    cerr << "Bad arguments in Min: " << xs << endl;
-    throw std::invalid_argument("invalid arguments to Min");
-  }
+  if (xs.size() != 2 || xs[0] != xs[1])
+    DYNET_INVALID_ARG("Bad arguments in Min: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
 
@@ -128,10 +115,8 @@ string Max::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Max::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 || xs[0] != xs[1]) {
-    cerr << "Bad arguments in Max: " << xs << endl;
-    throw std::invalid_argument("invalid arguments to Max");
-  }
+  if (xs.size() != 2 || xs[0] != xs[1])
+    DYNET_INVALID_ARG("Bad arguments in Max: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
 
@@ -142,10 +127,8 @@ string TraceOfProduct::as_string(const vector<string>& arg_names) const {
 }
 
 Dim TraceOfProduct::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 || xs[0] != xs[1]) {
-    cerr << "Bad arguments in TraceOfProduct: " << xs << endl;
-    throw std::invalid_argument("invalid arguments to TraceOfProduct");
-  }
+  if (xs.size() != 2 || xs[0] != xs[1])
+    DYNET_INVALID_ARG("Bad arguments in TraceOfProduct: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -156,10 +139,8 @@ string ConstScalarMultiply::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConstScalarMultiply::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1) {
-    cerr << "ConstScalarMultiply expects one argument: " << xs << endl;
-    throw std::invalid_argument("ConstScalarMultiply expects one argument");
-  }
+  if (xs.size() != 1)
+    DYNET_INVALID_ARG("ConstScalarMultiply expects one argument: " << xs);
   return xs[0];
 }
 
@@ -173,10 +154,8 @@ Dim DotProduct::dim_forward(const vector<Dim>& xs) const {
   if (xs.size() != 2 ||
       !LooksLikeVector(xs[0]) ||
       !LooksLikeVector(xs[1]) ||
-      xs[0].rows() != xs[1].rows()) {
-    cerr << "Bad arguments to DotProduct: " << xs << endl;
-    throw std::invalid_argument("Bad arguments to DotProduct");
-  }
+      xs[0].rows() != xs[1].rows())
+    DYNET_INVALID_ARG("Bad arguments to DotProduct: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -187,10 +166,8 @@ string Transpose::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Transpose::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1) {
-    cerr << "Bad arguments to Transpose: " << xs << endl;
-    throw std::invalid_argument("Bad arguments to Transpose");
-  }
+  if (xs.size() != 1)
+    DYNET_INVALID_ARG("Bad arguments to Transpose: " << xs);
   return xs[0].transpose();
 }
 
@@ -209,8 +186,7 @@ Dim Reshape::dim_forward(const vector<Dim>& xs) const {
     ret.bd = xs[0].batch_elems();
     return ret;
   } else {
-    cerr << "Bad arguments to Reshape: " << to << ", " << xs[0] << endl;
-    throw std::invalid_argument("Bad arguments to Reshape");
+    DYNET_INVALID_ARG("Bad arguments to Reshape: " << to << ", " << xs[0]);
   }
 }
 
@@ -221,12 +197,11 @@ string KMHNGram::as_string(const vector<string>& arg_names) const {
 }
 
 Dim KMHNGram::dim_forward(const vector<Dim>& xs) const {
-  assert(xs[0].ndims() == 2);
+  if (xs[0].ndims() != 2)
+    DYNET_INVALID_ARG("Bad input dimensions in KMHNGram: " << xs);
   const unsigned new_cols = xs[0].cols() - n + 1;
-  if (new_cols < 1) {
-    ostringstream s; s << "Bad input dimensions in KMHNGram: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (new_cols < 1)
+    DYNET_INVALID_ARG("Bad input dimensions in KMHNGram: " << xs);
   return Dim({xs[0][0], new_cols});
 }
 
@@ -297,10 +272,8 @@ string LogSumExp::as_string(const vector<string>& arg_names) const {
 Dim LogSumExp::dim_forward(const vector<Dim>& xs) const {
   Dim d = xs[0].truncate();
   for (unsigned i = 1; i < xs.size(); ++i) {
-    if (d.single_batch() != xs[i].truncate().single_batch()) {
-      ostringstream s; s << "Mismatched input dimensions in LogSumExp: " << xs;
-      throw std::invalid_argument(s.str());
-    }
+    if (d.single_batch() != xs[i].truncate().single_batch())
+      DYNET_INVALID_ARG("Mismatched input dimensions in LogSumExp: " << xs);
     d.bd = max(xs[i].bd, d.bd);
   }
   return d;
@@ -317,10 +290,8 @@ Dim Sum::dim_forward(const vector<Dim>& xs) const {
   Dim d = xs[0].truncate();
   unsigned int batch = d.bd;
   for (unsigned i = 1; i < xs.size(); ++i) {
-    if (d.single_batch() != xs[i].truncate().single_batch()) {
-      ostringstream s; s << "Mismatched input dimensions in Sum: " << xs;
-      throw std::invalid_argument(s.str());
-    }
+    if (d.single_batch() != xs[i].truncate().single_batch())
+      DYNET_INVALID_ARG("Mismatched input dimensions in Sum: " << xs);
     batch = max(xs[i].bd, batch);
   }
   d = xs[0]; d.bd = batch;
@@ -350,10 +321,8 @@ string Average::as_string(const vector<string>& arg_names) const {
 Dim Average::dim_forward(const vector<Dim>& xs) const {
   Dim d(xs[0]);
   for (unsigned i = 1; i < xs.size(); ++i) {
-    if (xs[0].single_batch() != xs[1].single_batch()) {
-      ostringstream s; s << "Mismatched input dimensions in Average: " << xs;
-      throw std::invalid_argument(s.str());
-    }
+    if (xs[0].single_batch() != xs[1].single_batch())
+      DYNET_INVALID_ARG("Mismatched input dimensions in Average: " << xs);
     d.bd = max(xs[i].bd, d.bd);
   }
   return d;
@@ -465,10 +434,8 @@ Dim Concatenate::dim_forward(const vector<Dim>& xs) const {
     if (LooksLikeVector(c)) c.resize(1);
     new_rows += c[0];
     dr.set(0, c[0]);
-    if (dr.single_batch() != c.single_batch()) {
-      ostringstream s; s << "Bad input dimensions in Concatenate: " << xs;
-      throw std::invalid_argument(s.str());
-    }
+    if (dr.single_batch() != c.single_batch())
+      DYNET_INVALID_ARG("Bad input dimensions in Concatenate: " << xs);
     dr.bd = max(dr.bd, c.bd);
   }
   dr.set(0, new_rows);
@@ -491,10 +458,8 @@ Dim ConcatenateColumns::dim_forward(const vector<Dim>& xs) const {
   unsigned new_cols = 0;
   unsigned bd = 1;
   for (auto& d : xs) {
-    if (d[0] != rows) {
-      ostringstream s; s << "Bad input dimensions in ConcatenateColumns: " << xs;
-      throw std::invalid_argument(s.str());
-    }
+    if (d[0] != rows)
+      DYNET_INVALID_ARG("Bad input dimensions in ConcatenateColumns: " << xs);
     new_cols += d[1];
     bd = max(bd, d.bd);
   }
@@ -511,10 +476,8 @@ Dim PairwiseRankLoss::dim_forward(const vector<Dim>& xs) const {
   if (xs.size() != 2 ||
       xs[0] != xs[1] ||
       xs[0].rows() != 1 ||
-      (xs[0].ndims() != 1 && xs[0].ndims() != 2)) {
-    ostringstream s; s << "Bad input dimensions in PairwiseRankLoss: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+      (xs[0].ndims() != 1 && xs[0].ndims() != 2))
+    DYNET_INVALID_ARG("Bad input dimensions in PairwiseRankLoss: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
 
@@ -525,10 +488,8 @@ string Hinge::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Hinge::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || !LooksLikeVector(xs[0])) {
-    ostringstream s; s << "Bad input dimensions in Hinge: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs.size() != 1 || !LooksLikeVector(xs[0]))
+    DYNET_INVALID_ARG("Bad input dimensions in Hinge: " << xs);
   return Dim({1}, xs[0].bd);
 }
 
@@ -571,10 +532,8 @@ string Softmax::as_string(const vector<string>& arg_names) const {
 
 Dim Softmax::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 1);
-  if (xs[0].nd > 2) {
-    ostringstream s; s << "Bad input dimensions in Softmax, must be 2 or fewer: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs[0].nd > 2)
+    DYNET_INVALID_ARG("Bad input dimensions in Softmax, must be 2 or fewer: " << xs);
   return xs[0];
 }
 
@@ -586,10 +545,8 @@ string SoftSign::as_string(const vector<string>& arg_names) const {
 
 Dim SoftSign::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 1);
-  if (!LooksLikeVector(xs[0])) {
-    ostringstream s; s << "Bad input dimensions in SoftSign: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (!LooksLikeVector(xs[0]))
+    DYNET_INVALID_ARG("Bad input dimensions in SoftSign: " << xs);
   return xs[0];
 }
 
@@ -608,16 +565,16 @@ string PickNegLogSoftmax::as_string(const vector<string>& arg_names) const {
 
 Dim PickNegLogSoftmax::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 1);
-  if (!LooksLikeVector(xs[0])) {
-    ostringstream s; s << "Bad input dimensions in PickNegLogSoftmax: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (!LooksLikeVector(xs[0]))
+    DYNET_INVALID_ARG("Bad input dimensions in PickNegLogSoftmax: " << xs);
   if (pval && xs[0].bd != 1) {
-    ostringstream s; s << "PickNegLogSoftmax was called with a single ID (" << *pval << "), but the expression under consideration had multiple mini-batch elements (" << xs[0].bd << "). A vector of IDs of size " << xs[0].bd << " must be passed instead.";
-    throw std::invalid_argument(s.str());
+    DYNET_INVALID_ARG("PickNegLogSoftmax was called with a single ID (" << *pval <<
+      "), but the expression under consideration had multiple mini-batch elements (" <<
+      xs[0].bd << "). A vector of IDs of size " << xs[0].bd << " must be passed instead.");
   } else if (pvals && xs[0].bd != pvals->size()) {
-    ostringstream s; s << "The number of IDs passed to PickNegLogSoftmax (" << pvals->size() << "), did not match the number of mini-batch elements in the expression under consideration (" << xs[0].bd << "). These numbers must match.";
-    throw std::invalid_argument(s.str());
+    DYNET_INVALID_ARG("The number of IDs passed to PickNegLogSoftmax (" << pvals->size() <<
+    "), did not match the number of mini-batch elements in the expression under consideration (" <<
+    xs[0].bd << "). These numbers must match.");
   }
   return Dim({1}, xs[0].bd);
 }
@@ -630,10 +587,8 @@ string LogSoftmax::as_string(const vector<string>& arg_names) const {
 
 Dim LogSoftmax::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 1);
-  if (xs[0].nd > 2) {
-    ostringstream s; s << "Bad input dimensions in LogSoftmax, must be 2 or fewer: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs[0].nd > 2)
+    DYNET_INVALID_ARG("Bad input dimensions in LogSoftmax, must be 2 or fewer: " << xs);
   return xs[0];
 }
 
@@ -645,10 +600,8 @@ string RestrictedLogSoftmax::as_string(const vector<string>& arg_names) const {
 
 Dim RestrictedLogSoftmax::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 1);
-  if (!LooksLikeVector(xs[0])) {
-    ostringstream s; s << "Bad input dimensions in RestrictedLogSoftmax: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (!LooksLikeVector(xs[0]))
+    DYNET_INVALID_ARG("Bad input dimensions in RestrictedLogSoftmax: " << xs);
   return xs[0];
 }
 
@@ -673,12 +626,10 @@ string PickElement::as_string(const vector<string>& arg_names) const {
 
 Dim PickElement::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 1);
-  if(dimension >= xs[0].nd) {
-    ostringstream s; s << "Tried to PickElement on dimension " << dimension << " bigger than input " << xs[0];
-    throw std::invalid_argument(s.str());
-  }
+  if(dimension >= xs[0].nd)
+    DYNET_INVALID_ARG("Tried to PickElement on dimension " << dimension << " bigger than input " << xs[0]);
   if(xs[0].nd >= 4)
-    throw std::invalid_argument("PickElement not currently supported for tensors of 4 or more dimensions.");
+    DYNET_INVALID_ARG("PickElement not currently supported for tensors of 4 or more dimensions.");
   Dim ret(xs[0]);
   ret.delete_dim(dimension);
   return ret;
@@ -694,11 +645,8 @@ string PickRange::as_string(const vector<string>& arg_names) const {
 
 Dim PickRange::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 1);
-  if (!LooksLikeVector(xs[0])) {
-    ostringstream s; s << "Bad input dimensions in PickRange: " << xs;
-    throw std::invalid_argument(s.str());
-  }
-  assert(end <= xs[0][0]);
+  if (!LooksLikeVector(xs[0]) || end > xs[0][0])
+    DYNET_INVALID_ARG("Bad input dimensions or range in PickRange: " << xs << " range(" << start << ", " << end << ")");
   return Dim({end - start}, xs[0].bd);
 }
 
@@ -710,10 +658,8 @@ string MatrixMultiply::as_string(const vector<string>& arg_names) const {
 
 Dim MatrixMultiply::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 2);
-  if (xs[0].cols() != xs[1].rows()) {
-    ostringstream s; s << "Mismatched input dimensions in MatrixMultiply: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs[0].cols() != xs[1].rows())
+    DYNET_INVALID_ARG("Mismatched input dimensions in MatrixMultiply: " << xs);
   if (xs[1].ndims() == 1) return Dim({xs[0].rows()}, max(xs[0].bd, xs[1].bd));
   return Dim({xs[0].rows(), xs[1].cols()}, max(xs[0].bd, xs[1].bd));
 }
@@ -727,10 +673,8 @@ string CwiseMultiply::as_string(const vector<string>& arg_names) const {
 Dim CwiseMultiply::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 2);
   Dim d = xs[0].truncate();
-  if (d.single_batch() != xs[1].truncate().single_batch()) {
-    ostringstream s; s << "Mismatched input dimensions in CwiseMultiply: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (d.single_batch() != xs[1].truncate().single_batch())
+    DYNET_INVALID_ARG("Mismatched input dimensions in CwiseMultiply: " << xs);
   d.bd = max(xs[1].bd, d.bd);
   return d;
 }
@@ -744,10 +688,8 @@ string Pow::as_string(const vector<string>& arg_names) const {
 Dim Pow::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 2);
   Dim d = xs[0].truncate();
-  if (xs[1].truncate().single_batch().size() != 1) {
-    ostringstream s; s << "Bad input dimensions in Pow: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs[1].truncate().single_batch().size() != 1)
+    DYNET_INVALID_ARG("Bad input dimensions in Pow: " << xs);
   return d;
 }
 
@@ -760,10 +702,8 @@ string CwiseQuotient::as_string(const vector<string>& arg_names) const {
 Dim CwiseQuotient::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 2);
   Dim d = xs[0].truncate();
-  if (d.single_batch() != xs[1].truncate().single_batch()) {
-    ostringstream s; s << "Bad input dimensions in CwiseQuotient: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (d.single_batch() != xs[1].truncate().single_batch())
+    DYNET_INVALID_ARG("Bad input dimensions in CwiseQuotient: " << xs);
   d.bd = max(xs[1].bd, d.bd);
   return d;
 }
@@ -777,24 +717,18 @@ string AffineTransform::as_string(const vector<string>& arg_names) const {
 }
 
 Dim AffineTransform::dim_forward(const vector<Dim>& xs) const {
-  if ((xs.size() - 1) % 2 != 0) {
-    ostringstream s; s << "Bad number of inputs in AffineTransform: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if ((xs.size() - 1) % 2 != 0)
+    DYNET_INVALID_ARG("Bad number of inputs in AffineTransform: " << xs);
   if(xs.size() == 1) return xs[0];
   if (xs[0].rows() != xs[1].rows() ||
-      xs[1].cols() != xs[2].rows()) {
-    ostringstream s; s << "Bad dimensions for AffineTransform: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+      xs[1].cols() != xs[2].rows())
+    DYNET_INVALID_ARG("Bad dimensions for AffineTransform: " << xs);
   Dim d({xs[0].rows(), xs[2].cols()}, max(max(xs[0].bd, xs[1].bd), xs[2].bd));
   for (unsigned i = 3; i < xs.size(); i += 2) {
     if (xs[i].cols() != xs[i+1].rows() ||
         d.rows() != xs[i].rows() ||
-        d.cols() != xs[i+1].cols()) {
-      ostringstream s; s << "Bad dimensions for AffineTransform: " << xs;
-      throw std::invalid_argument(s.str());
-    }
+        d.cols() != xs[i+1].cols())
+      DYNET_INVALID_ARG("Bad dimensions for AffineTransform: " << xs);
     d.bd = max(max(d.bd, xs[i].bd), xs[i+1].bd);
   }
   return d;
@@ -830,10 +764,8 @@ string HuberDistance::as_string(const vector<string>& arg_names) const {
 
 Dim HuberDistance::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 2);
-  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size())) {
-    ostringstream s; s << "Mismatched input dimensions in HuberDistance: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
+    DYNET_INVALID_ARG("Mismatched input dimensions in HuberDistance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -845,10 +777,8 @@ string L1Distance::as_string(const vector<string>& arg_names) const {
 
 Dim L1Distance::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 2);
-  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size())) {
-    ostringstream s; s << "Mismatched input dimensions in L1Distance: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
+    DYNET_INVALID_ARG("Mismatched input dimensions in L1Distance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -859,10 +789,8 @@ string PoissonRegressionLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PoissonRegressionLoss::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || xs[0].size() != 1) {
-    ostringstream s; s << "Bad input dimensions in PoissonRegressionLoss: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs.size() != 1 || xs[0].size() != 1)
+    DYNET_INVALID_ARG("Bad input dimensions in PoissonRegressionLoss: " << xs);
   return xs[0];
 }
 
@@ -885,10 +813,8 @@ string SquaredEuclideanDistance::as_string(const vector<string>& arg_names) cons
 
 Dim SquaredEuclideanDistance::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 2);
-  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size())) {
-    ostringstream s; s << "Bad input dimensions in SquaredEuclideanDistance: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
+    DYNET_INVALID_ARG("Bad input dimensions in SquaredEuclideanDistance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -911,14 +837,10 @@ string BinaryLogLoss::as_string(const vector<string>& arg_names) const {
 
 Dim BinaryLogLoss::dim_forward(const vector<Dim>& xs) const {
   assert(xs.size() == 2);
-  if (xs[0].rows() != 2 && xs[0].ndims() != 1) {
-    ostringstream s; s << "Bad input dimensions in BinaryLogLoss: " << xs;
-    throw std::invalid_argument(s.str());
-  }
-  if (xs[1].rows() != 2 && xs[1].ndims() != 1) {
-    ostringstream s; s << "Bad input dimensions in BinaryLogLoss: " << xs;
-    throw std::invalid_argument(s.str());
-  }
+  if (xs[0].rows() != 2 && xs[0].ndims() != 1)
+    DYNET_INVALID_ARG("Bad input dimensions in BinaryLogLoss: " << xs);
+  if (xs[1].rows() != 2 && xs[1].ndims() != 1)
+    DYNET_INVALID_ARG("Bad input dimensions in BinaryLogLoss: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -178,7 +178,7 @@ string Reshape::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Reshape::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Reshape")
   if(to.size() == xs[0].size()) {
     return to;
   } else if(to.batch_elems() == 1 && to.batch_size() == xs[0].batch_size()) {
@@ -212,7 +212,7 @@ string GaussianNoise::as_string(const vector<string>& arg_names) const {
 }
 
 Dim GaussianNoise::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in GaussianNoise")
   return xs[0];
 }
 
@@ -223,7 +223,7 @@ string Dropout::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Dropout::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Dropout")
   return xs[0];
 }
 
@@ -234,7 +234,7 @@ string BlockDropout::as_string(const vector<string>& arg_names) const {
 }
 
 Dim BlockDropout::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in BlockDropout")
   return xs[0];
 }
 
@@ -245,7 +245,7 @@ string ConstantPlusX::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConstantPlusX::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in ConstantPlusX")
   return xs[0];
 }
 
@@ -256,7 +256,7 @@ string ConstantMinusX::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConstantMinusX::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in ConstantMinusX")
   return xs[0];
 }
 
@@ -305,7 +305,7 @@ string SumBatches::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SumBatches::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in SumBatches")
   return xs[0].single_batch();
 }
 
@@ -335,7 +335,7 @@ string Sqrt::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Sqrt::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Sqrt")
   return xs[0];
 }
 
@@ -346,7 +346,7 @@ string Erf::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Erf::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Erf")
   return xs[0];
 }
 
@@ -357,7 +357,7 @@ string Tanh::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Tanh::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Tanh")
   return xs[0];
 }
 
@@ -368,7 +368,7 @@ string Square::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Square::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Square")
   return xs[0];
 }
 
@@ -379,7 +379,7 @@ string Cube::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Cube::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Cube")
   return xs[0];
 }
 
@@ -390,7 +390,7 @@ string Exp::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Exp::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Exp")
   return xs[0];
 }
 
@@ -401,7 +401,7 @@ string LogGamma::as_string(const vector<string>& arg_names) const {
 }
 
 Dim LogGamma::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in LogGamma")
   return xs[0];
 }
 
@@ -412,7 +412,7 @@ string Log::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Log::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Log")
   return xs[0];
 }
 
@@ -453,7 +453,7 @@ string ConcatenateColumns::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConcatenateColumns::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() > 0);
+  DYNET_ASSERT(xs.size() > 0, "Failed input count check in ConcatenateColumns")
   unsigned rows = xs[0][0];
   unsigned new_cols = 0;
   unsigned bd = 1;
@@ -498,7 +498,7 @@ string Identity::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Identity::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Identity")
   return xs[0];
 }
 
@@ -509,7 +509,7 @@ string NoBackprop::as_string(const vector<string>& arg_names) const {
 }
 
 Dim NoBackprop::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in NoBackprop")
   return xs[0];
 }
 
@@ -520,7 +520,7 @@ string FlipGradient::as_string(const vector<string>& arg_names) const {
 }
 
 Dim FlipGradient::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in FlipGradient")
   return xs[0];
 }  
   
@@ -531,7 +531,7 @@ string Softmax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Softmax::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Softmax")
   if (xs[0].nd > 2)
     DYNET_INVALID_ARG("Bad input dimensions in Softmax, must be 2 or fewer: " << xs);
   return xs[0];
@@ -544,7 +544,7 @@ string SoftSign::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SoftSign::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in SoftSign")
   if (!LooksLikeVector(xs[0]))
     DYNET_INVALID_ARG("Bad input dimensions in SoftSign: " << xs);
   return xs[0];
@@ -564,7 +564,7 @@ string PickNegLogSoftmax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PickNegLogSoftmax::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickNegLogSoftmax")
   if (!LooksLikeVector(xs[0]))
     DYNET_INVALID_ARG("Bad input dimensions in PickNegLogSoftmax: " << xs);
   if (pval && xs[0].bd != 1) {
@@ -586,7 +586,7 @@ string LogSoftmax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim LogSoftmax::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in LogSoftmax")
   if (xs[0].nd > 2)
     DYNET_INVALID_ARG("Bad input dimensions in LogSoftmax, must be 2 or fewer: " << xs);
   return xs[0];
@@ -599,7 +599,7 @@ string RestrictedLogSoftmax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim RestrictedLogSoftmax::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in RestrictedLogSoftmax")
   if (!LooksLikeVector(xs[0]))
     DYNET_INVALID_ARG("Bad input dimensions in RestrictedLogSoftmax: " << xs);
   return xs[0];
@@ -611,7 +611,7 @@ string PickElement::as_string(const vector<string>& arg_names) const {
   if(pval) { 
     s << *pval;
   } else {
-    assert(pvals);
+    DYNET_ASSERT(pvals, "Have neither index nor index vector in PickElement");
     s << '[';
     if(pvals->size()) {
       s << (*pvals)[0];
@@ -625,7 +625,7 @@ string PickElement::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PickElement::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickElement")
   if(dimension >= xs[0].nd)
     DYNET_INVALID_ARG("Tried to PickElement on dimension " << dimension << " bigger than input " << xs[0]);
   if(xs[0].nd >= 4)
@@ -644,7 +644,7 @@ string PickRange::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PickRange::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickRange")
   if (!LooksLikeVector(xs[0]) || end > xs[0][0])
     DYNET_INVALID_ARG("Bad input dimensions or range in PickRange: " << xs << " range(" << start << ", " << end << ")");
   return Dim({end - start}, xs[0].bd);
@@ -657,7 +657,7 @@ string MatrixMultiply::as_string(const vector<string>& arg_names) const {
 }
 
 Dim MatrixMultiply::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed input count check in MatrixMultiply")
   if (xs[0].cols() != xs[1].rows())
     DYNET_INVALID_ARG("Mismatched input dimensions in MatrixMultiply: " << xs);
   if (xs[1].ndims() == 1) return Dim({xs[0].rows()}, max(xs[0].bd, xs[1].bd));
@@ -671,7 +671,7 @@ string CwiseMultiply::as_string(const vector<string>& arg_names) const {
 }
 
 Dim CwiseMultiply::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed input count check in CwiseMultiply")
   Dim d = xs[0].truncate();
   if (d.single_batch() != xs[1].truncate().single_batch())
     DYNET_INVALID_ARG("Mismatched input dimensions in CwiseMultiply: " << xs);
@@ -686,7 +686,7 @@ string Pow::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Pow::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed input count check in Pow")
   Dim d = xs[0].truncate();
   if (xs[1].truncate().single_batch().size() != 1)
     DYNET_INVALID_ARG("Bad input dimensions in Pow: " << xs);
@@ -700,7 +700,7 @@ string CwiseQuotient::as_string(const vector<string>& arg_names) const {
 }
 
 Dim CwiseQuotient::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed input count check in CwiseQuotient")
   Dim d = xs[0].truncate();
   if (d.single_batch() != xs[1].truncate().single_batch())
     DYNET_INVALID_ARG("Bad input dimensions in CwiseQuotient: " << xs);
@@ -741,7 +741,7 @@ string Negate::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Negate::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Negate")
   return xs[0];
 }
 
@@ -752,7 +752,7 @@ string Rectify::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Rectify::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Rectify")
   return xs[0];
 }
 
@@ -763,7 +763,7 @@ string HuberDistance::as_string(const vector<string>& arg_names) const {
 }
 
 Dim HuberDistance::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed input count check in HuberDistance")
   if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
     DYNET_INVALID_ARG("Mismatched input dimensions in HuberDistance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
@@ -776,7 +776,7 @@ string L1Distance::as_string(const vector<string>& arg_names) const {
 }
 
 Dim L1Distance::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed input count check in L1Distance")
   if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
     DYNET_INVALID_ARG("Mismatched input dimensions in L1Distance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
@@ -801,7 +801,7 @@ string SquaredNorm::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SquaredNorm::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in SquaredNorm")
   return Dim({1}, xs[0].bd);
 }
 
@@ -812,7 +812,7 @@ string SquaredEuclideanDistance::as_string(const vector<string>& arg_names) cons
 }
 
 Dim SquaredEuclideanDistance::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed input count check in SquaredEuclideanDistance")
   if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
     DYNET_INVALID_ARG("Bad input dimensions in SquaredEuclideanDistance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
@@ -825,7 +825,7 @@ string LogisticSigmoid::as_string(const vector<string>& arg_names) const {
 }
 
 Dim LogisticSigmoid::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in LogisticSigmoid")
   return xs[0];
 }
 
@@ -836,7 +836,7 @@ string BinaryLogLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim BinaryLogLoss::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed input count check in BinaryLogLoss")
   if (xs[0].rows() != 2 && xs[0].ndims() != 1)
     DYNET_INVALID_ARG("Bad input dimensions in BinaryLogLoss: " << xs);
   if (xs[1].rows() != 2 && xs[1].ndims() != 1)

--- a/dynet/nodes-macros.h
+++ b/dynet/nodes-macros.h
@@ -71,7 +71,7 @@ inline bool LooksLikeVector(const Dim& d) {
                                            unsigned i, \
                                            Tensor& dEdxi) const; \
   void MyNode::forward_impl(const std::vector<const Tensor*>& xs, Tensor& fx) const { \
-    assert(fx.device); \
+    DYNET_ASSERT(fx.device, "Device not allocated for expression"); \
     if(fx.device->type == DeviceType::CPU) { forward_dev_impl<dynet::Device_CPU>(*(dynet::Device_CPU*)fx.device,xs,fx); } \
     else if(fx.device->type == DeviceType::GPU) { forward_dev_impl<dynet::Device_GPU>(*(dynet::Device_GPU*)fx.device,xs,fx); } \
     else { throw std::runtime_error("Invalid device in MyNode::forward_impl"); } \
@@ -81,7 +81,7 @@ inline bool LooksLikeVector(const Dim& d) {
                 const Tensor& dEdf, \
                 unsigned i, \
                 Tensor& dEdxi) const { \
-    assert(fx.device); \
+    DYNET_ASSERT(fx.device, "Device not allocated for expression"); \
     if(fx.device->type == DeviceType::CPU) { backward_dev_impl<dynet::Device_CPU>(*(dynet::Device_CPU*)fx.device,xs,fx,dEdf,i,dEdxi); } \
     else if(fx.device->type == DeviceType::GPU) { backward_dev_impl<dynet::Device_GPU>(*(dynet::Device_GPU*)fx.device,xs,fx,dEdf,i,dEdxi); } \
     else { throw std::runtime_error("Invalid device in MyNode::backward_impl"); } \
@@ -96,7 +96,7 @@ inline bool LooksLikeVector(const Dim& d) {
                                            unsigned i, \
                                            Tensor& dEdxi) const; \
   void MyNode::forward_impl(const std::vector<const Tensor*>& xs, Tensor& fx) const { \
-    assert(fx.device); \
+    DYNET_ASSERT(fx.device, "Device not allocated for expression"); \
     if(fx.device->type == DeviceType::CPU) { forward_dev_impl<dynet::Device_CPU>(*(dynet::Device_CPU*)fx.device,xs,fx); } \
     else { throw std::runtime_error("Invalid device in MyNode::forward_impl"); } \
   } \
@@ -105,7 +105,7 @@ inline bool LooksLikeVector(const Dim& d) {
                 const Tensor& dEdf, \
                 unsigned i, \
                 Tensor& dEdxi) const { \
-    assert(fx.device); \
+    DYNET_ASSERT(fx.device, "Device not allocated for expression"); \
     if(fx.device->type == DeviceType::CPU) { backward_dev_impl<dynet::Device_CPU>(*(dynet::Device_CPU*)fx.device,xs,fx,dEdf,i,dEdxi); } \
     else { throw std::runtime_error("Invalid device in MyNode::backward_impl"); } \
   }

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -209,7 +209,8 @@ inline void CUDAMatrixMultiply(const Device_GPU & dev, const Tensor& l, const Te
           acc_scalar, y.v, y.d.rows()));
   } else {
     // Otherwise, loop over the batches
-    assert(r.d.bd == 1 || r.d.bd == l.d.bd);
+    DYNET_ASSERT(r.d.bd != 1 || r.d.bd != l.d.bd,
+                 "Number of batch elements in matrix multiply must match, but got: " << r.d.bd << ", " << l.d.bd);
     for(unsigned b = 0; b < y.d.bd; ++b) {
       CUBLAS_CHECK(cublasSgemm(dev.cublas_handle, CUBLAS_OP_N, CUBLAS_OP_N,
             y.d.rows(), y.d.cols(), l.d.cols(),
@@ -229,7 +230,8 @@ void AddVectorToAllColumns::forward_dev_impl(const MyDevice & dev, const vector<
     Eigen::array<int, 3> bcasts = {1, (int)xs[0]->d[1], (int)(xs[0]->d.bd/xs[1]->d.bd)};
     fx.tb<2>().device(*dev.edevice) = xs[0]->tb<2>() + xs[1]->tb<2>().broadcast(bcasts);
   } else {
-    assert(xs[0]->d.bd == 1);
+    DYNET_ASSERT(xs[0]->d.bd == 1,
+                 "Bad dimensions in AddVectorToAllColumns::forward: " << xs[0]->d << ", " << xs[1]->d);
     Eigen::array<int, 3> bcasts0 = {1, 1, (int)xs[1]->d.bd};
     Eigen::array<int, 3> bcasts1 = {1, (int)xs[0]->d[1], 1};
     fx.tb<2>().device(*dev.edevice) = xs[0]->tb<2>().broadcast(bcasts0) + xs[1]->tb<2>().broadcast(bcasts1);
@@ -243,7 +245,7 @@ void AddVectorToAllColumns::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in AddVetorToAllColumns::backward");
   // TODO: profile on CPU and see whether the chip version is better
   if (i == 0) { // x
     if(dEdf.d.bd == dEdxi.d.bd) {
@@ -257,7 +259,8 @@ void AddVectorToAllColumns::backward_dev_impl(const MyDevice & dev,
       Eigen::array<int, 1> red_axis = {1};
       dEdxi.tb<1>().device(*dev.edevice) += dEdf.tb<2>().sum(red_axis);
     } else {
-      assert(dEdxi.d.bd == 1);
+      DYNET_ASSERT(dEdxi.d.bd == 1,
+                   "Bad dimensions in AddVectorToAllColumns::backward: " << xs[0]->d << ", " << xs[1]->d);
       Eigen::array<int, 2> red_axis = {1,2};
       dEdxi.t<1>().device(*dev.edevice) += dEdf.tb<2>().sum(red_axis);
     }
@@ -269,7 +272,7 @@ DYNET_NODE_INST_DEV_IMPL(AddVectorToAllColumns)
 // much faster than using Eigen's tensor contractions (as of the writing)
 template<class MyDevice>
 void AffineTransform::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() % 2 == 1);
+  DYNET_ASSERT(xs.size() % 2 == 1, "Failed dimension check in AffineTransform::forward");
   if (xs.size() == 1) {
     fx.v = xs[0]->v;
     return;
@@ -284,7 +287,7 @@ void AffineTransform::forward_dev_impl(const MyDevice & dev, const vector<const 
       fx.tb<2>().device(*dev.edevice) = xs[0]->tb<2>().broadcast(bcast);
 #else
       if(xs[0]->d.bd != 1)
-        throw std::invalid_argument("In AffineTransform, broadcasting over columns with mini-batched inputs is not implemented yet");
+        DYNET_INVALID_ARG("In AffineTransform, broadcasting over columns with mini-batched inputs is not implemented yet");
       float *curr_ptr = fx.v, *end_ptr = curr_ptr + fx.d.size(), *in_ptr = xs[0]->v;
       do {
         memcpy(curr_ptr, in_ptr, sizeof(float)*b_size);
@@ -304,7 +307,7 @@ void AffineTransform::forward_dev_impl(const MyDevice & dev, const vector<const 
       if(xs[i]->d.bd == 1 && xs[i+1]->d.bd == fx.d.bd) {
         fx.colbatch_matrix().noalias() += **xs[i] * xs[i+1]->colbatch_matrix();
       } else {
-        assert(xs[i+1]->d.bd == 1 || xs[i+1]->d.bd == xs[i]->d.bd);
+        DYNET_ASSERT(xs[i+1]->d.bd == 1 || xs[i+1]->d.bd == xs[i]->d.bd, "Failed dimension check in AffineTransform::forward");
         for(unsigned b = 0; b < fx.d.bd; ++b) {
           fx.batch_matrix(b).noalias() += xs[i]->batch_matrix(b) * xs[i+1]->batch_matrix(b);
         }
@@ -321,7 +324,7 @@ void AffineTransform::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < xs.size());
+  DYNET_ASSERT(i < xs.size(), "Failed boundary check in AffineTransform::backward");
   // Bias term
   if (i == 0) { // bias term
     size_t dx_size = dEdxi.d.size(), df_size = dEdf.d.size();
@@ -329,7 +332,7 @@ void AffineTransform::backward_dev_impl(const MyDevice & dev,
       dEdxi.tvec().device(*dev.edevice) += dEdf.tvec();
     } else {
       if(dEdxi.d.bd != 1)
-        throw std::invalid_argument("In AffineTransform, broadcasting over columns with mini-batched inputs is not implemented yet");
+        DYNET_INVALID_ARG("In AffineTransform, broadcasting over columns with mini-batched inputs is not implemented yet");
 #ifdef __CUDACC__
       if(dEdxi.d[1] == dEdf.d[1]) {
         Eigen::array<int, 1> red_axis; red_axis[0] = 2;
@@ -471,7 +474,7 @@ void Concatenate::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < src_row_indices.size());
+  DYNET_ASSERT(i < src_row_indices.size(), "Failed boundary check in Concatenate::backward: " << i << " >= " << src_row_indices.size());
   Eigen::DSizes<ptrdiff_t, 3> indices(static_cast<ptrdiff_t>(src_row_indices[i]),0,0);
   Eigen::DSizes<ptrdiff_t, 3> sizes(static_cast<ptrdiff_t>(dEdxi.d.rows()), static_cast<ptrdiff_t>(fx.d.cols()),
                                     static_cast<ptrdiff_t>(fx.d.bd));
@@ -542,9 +545,8 @@ void BlockDropout::forward_dev_impl(const MyDevice & dev, const vector<const Ten
   float block_multiplier = distribution(*rndeng)? 1.0 : 0.0;
   block_multiplier = 
     dropout_probability == 1.0? 0.0 : block_multiplier / (1.0 - dropout_probability);
-  if (dropout_probability > 1.0 || dropout_probability < 0.0) {
-    throw std::runtime_error("Dropout probability must be in the range [0, 1]");
-  }
+  if (dropout_probability > 1.0 || dropout_probability < 0.0)
+    DYNET_INVALID_ARG("Dropout probability must be in the range [0, 1]");
   *(static_cast<float*>(aux_mem)) = block_multiplier;
   fx.tvec().device(*dev.edevice) = xs[0]->tvec() * block_multiplier;
 }
@@ -605,7 +607,7 @@ void ConstScalarMultiply::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i == 0);
+  DYNET_ASSERT(i == 0, "Failed dimension check in ConstScalarMultiply");
   dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * alpha;
 }
 DYNET_NODE_INST_DEV_IMPL(ConstScalarMultiply)
@@ -628,7 +630,7 @@ DYNET_NODE_INST_DEV_IMPL(Cube)
 
 template<class MyDevice>
 void CwiseQuotient::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in CwiseQuotient::forward (cdiv)");
   if(xs[0]->d.bd == xs[1]->d.bd) {
     fx.tvec().device(*dev.edevice) = xs[0]->tvec() / xs[1]->tvec();
   } else if(xs[0]->d.bd == 1) {
@@ -647,7 +649,7 @@ void CwiseQuotient::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in CwiseQuotient::backward (cdiv)");
   if (i == 0) {
     if(xs[0]->d.bd == xs[1]->d.bd) {
       dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() / xs[1]->tvec();
@@ -675,7 +677,7 @@ DYNET_NODE_INST_DEV_IMPL(CwiseQuotient)
 
 template<class MyDevice>
 void CwiseMultiply::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in CwiseMultiply::forward (cmult)");
   if(xs[0]->d.bd == xs[1]->d.bd) {
     fx.tvec().device(*dev.edevice) = xs[0]->tvec() * xs[1]->tvec();
   } else {
@@ -694,7 +696,7 @@ void CwiseMultiply::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in CwiseMultiply::backward (cmult)");
   if(xs[0]->d.bd == xs[1]->d.bd) {
     dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * xs[1-i]->tvec();
   } else if(xs[1-i]->d.bd == 1) {
@@ -819,17 +821,22 @@ DYNET_NODE_INST_DEV_IMPL(GaussianNoise)
 
 template<class MyDevice>
 void Hinge::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in Hinge::forward");
   Tensor eloss(xs[0]->d, static_cast<float*>(aux_mem), fx.device, DeviceMempool::FXS);
   // TODO: Can we do this on device?
+  size_t batch_size = fx.d.batch_size();
   if(pelement != nullptr) {
+    if(batch_size != 1)
+      DYNET_INVALID_ARG("Hinge was passed a single index but the corresponding expression has multiple mini-batch elements (" << batch_size << ")");
     const real mlystar = margin - TensorTools::AccessElement(*xs[0], *pelement);
     eloss.tvec().device(*dev.edevice) = (xs[0]->tvec() + mlystar).cwiseMax(0.f);
     TensorTools::SetElement(eloss, *pelement, 0.f);
     fx.t<0>().device(*dev.edevice) = eloss.tvec().sum();
   } else {
-    assert(pelements != nullptr); 
-    size_t batch_size = fx.d.batch_size();
+    DYNET_ASSERT(pelements != nullptr, "Hinge::forward has neither pointer to single element nor vector");
+    if(batch_size != pelements->size())
+      DYNET_INVALID_ARG("The list of indexes passed to Hinge has a length (" << pelements->size() <<
+                        ") that doesn't match that of the corresponding expression (" << batch_size << ")");
     for(size_t b = 0; b < fx.d.bd; b++) {
       const real mlystar = margin - TensorTools::AccessElement(*xs[0], b*batch_size + (*pelements)[b]);
       eloss.tb<1>().chip<1>(b).device(*dev.edevice) = (xs[0]->tb<1>().chip<1>(b) + mlystar).cwiseMax(0.f);
@@ -846,7 +853,7 @@ void Hinge::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i == 0);
+  DYNET_ASSERT(i == 0, "Failed dimension check in Hinge::backward");
   if(pelement != nullptr) {
     if(as_scalar(fx)) { // there was some loss
       const float d = as_scalar(dEdf);
@@ -854,12 +861,12 @@ void Hinge::backward_dev_impl(const MyDevice & dev,
       // TODO: The > comparison should not be calculated twice. Keep it in auxiliary memory?
       dEdxi.tvec().device(*dev.edevice) += (eloss.tvec() > 0.f).cast<float>() * d;
 #if defined(__CUDACC__) && defined(EIGEN_NO_MALLOC)
-      throw std::runtime_error("CUDA memory allocation in hinge");
+      DYNET_RUNTIME_ERR("CUDA memory allocation in hinge");
 #endif
       dEdxi.tvec().chip<0>(*pelement).device(*dev.edevice) -= (eloss.tvec() > 0.f).template cast<float>().sum() * d;
     }
   } else {
-    assert(pelements != nullptr); 
+    DYNET_ASSERT(pelements != nullptr, "Hinge::backward has neither pointer to single element nor vector");
     vector<float> fx_vec = as_vector(fx);
     vector<float> d_vec = as_vector(dEdf);
     Tensor eloss(xs[0]->d, static_cast<float*>(aux_mem), fx.device, DeviceMempool::FXS);
@@ -868,7 +875,7 @@ void Hinge::backward_dev_impl(const MyDevice & dev,
         // TODO: The > comparison should not be calculated twice. Keep it in auxiliary memory?
         dEdxi.tb<1>().chip<1>(b).device(*dev.edevice) += (eloss.tb<1>().chip<1>(b) > 0.f).cast<float>() * d_vec[b];
 #if defined(__CUDACC__) && defined(EIGEN_NO_MALLOC)
-        throw std::runtime_error("CUDA memory allocation in hinge");
+        DYNET_RUNTIME_ERR("CUDA memory allocation in hinge");
 #endif
         dEdxi.tb<1>().chip<1>(b).chip<0>((*pelements)[b]).device(*dev.edevice) -= (eloss.tb<1>().chip<1>(b) > 0.f).template cast<float>().sum() * d_vec[b];
       }
@@ -879,7 +886,7 @@ DYNET_NODE_INST_DEV_IMPL(Hinge)
 
 template<class MyDevice>
 void HuberDistance::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "HuberDistance::forward dimension check failed");
   fx.t<0>().device(*dev.edevice) = (xs[0]->tvec() - xs[1]->tvec()).unaryExpr(FHuberForward(d)).sum();
 }
 
@@ -890,7 +897,7 @@ void HuberDistance::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "HuberDistance::backward dimension check failed");
   dEdxi.tvec().device(*dev.edevice) += (xs[i]->tvec() - xs[1-i]->tvec()).unaryExpr(FHuberBackward(d, as_scalar(dEdf)));
 }
 DYNET_NODE_INST_DEV_IMPL(HuberDistance)
@@ -915,11 +922,11 @@ DYNET_NODE_INST_DEV_IMPL(Identity)
 template<class MyDevice>
 void KMHNGram::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
 #ifdef __CUDACC__
-  throw std::runtime_error("KMHNGram not implemented for CUDA");
+  DYNET_RUNTIME_ERR("KMHNGram not implemented for CUDA");
 #else
   auto x = **xs[0];
   const int new_cols = x.cols() - n + 1;
-  assert(new_cols > 0);
+  DYNET_ASSERT(new_cols > 0, "Failed dimension check in KMHNGram");
   auto res = *fx;
   res.setZero();
   for (int j = 0; j < new_cols; ++j) {
@@ -938,7 +945,7 @@ void KMHNGram::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
 #ifdef __CUDACC__
-  throw std::runtime_error("KMHNGram not implemented for CUDA");
+  DYNET_RUNTIME_ERR("KMHNGram not implemented for CUDA");
 #else
   const int c = dEdf.d.cols();
   for (int j = 0; j < c; ++j)
@@ -950,7 +957,7 @@ DYNET_NODE_INST_DEV_IMPL(KMHNGram)
 
 template<class MyDevice>
 void L1Distance::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in L1Distance::forward");
   fx.t<0>().device(*dev.edevice) = (xs[0]->tvec() - xs[1]->tvec()).abs().sum();
 }
 
@@ -961,7 +968,7 @@ void L1Distance::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in L1Distance::backward");
   dEdxi.tvec().device(*dev.edevice) += (xs[i]->tvec() - xs[1-i]->tvec()).unaryExpr(FL1Backward(as_scalar(dEdf)));
 }
 DYNET_NODE_INST_DEV_IMPL(L1Distance)
@@ -985,7 +992,7 @@ DYNET_NODE_INST_DEV_IMPL(Log)
 template<class MyDevice>
 void LogDet::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
 #ifdef __CUDACC__
-  throw std::runtime_error("LogDet not implemented for CUDA");
+  DYNET_RUNTIME_ERR("LogDet not implemented for CUDA");
 #else
   fx.v[0] = logdet(**xs[0], false);
 #endif
@@ -999,7 +1006,7 @@ void LogDet::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
 #ifdef __CUDACC__
-  throw std::runtime_error("KMHNGram not implemented for CUDA");
+  DYNET_RUNTIME_ERR("KMHNGram not implemented for CUDA");
 #else
   auto trans = (**xs[0]).transpose();
   (*dEdxi) += (dEdf.v[0]) * trans.inverse();
@@ -1026,7 +1033,7 @@ DYNET_NODE_INST_DEV_IMPL(LogGamma)
 
 template<class MyDevice>
 void LogisticSigmoid::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in LogisticSigmoid::forward");
   fx.tvec().device(*dev.edevice) = xs[0]->tvec().unaryExpr(scalar_logistic_sigmoid_op<float>());
 }
 
@@ -1043,7 +1050,7 @@ DYNET_NODE_INST_DEV_IMPL(LogisticSigmoid)
 
 template<class MyDevice>
 void LogSoftmax::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in LogSoftmax::forward");
   Tensor z(Dim({xs[0]->d.cols()},fx.d.bd), (float*)aux_mem, fx.device, DeviceMempool::FXS);
   Tensor m(Dim({xs[0]->d.cols()},fx.d.bd), (float*)aux_mem + z.d.size(), fx.device, DeviceMempool::FXS);
   logsumexp(dev, *xs[0], m, z);
@@ -1114,9 +1121,9 @@ DYNET_NODE_INST_DEV_IMPL(LogSumExp)
 
 template<class MyDevice>
 void MatrixInverse::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in MatrixInverse::forward");
 #ifdef __CUDACC__
-  throw std::runtime_error("MatrixInverse not yet implemented for CUDA");
+  DYNET_RUNTIME_ERR("MatrixInverse not yet implemented for CUDA");
 #else
   auto x = **xs[0];
   auto y = *fx;
@@ -1133,9 +1140,9 @@ void MatrixInverse::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in MatrixInverse::backward");
 #ifdef __CUDACC__
-  throw std::runtime_error("MatrixInverse not yet implemented for CUDA");
+  DYNET_RUNTIME_ERR("MatrixInverse not yet implemented for CUDA");
 #else
   auto d = *dEdf;
   auto y = *fx;
@@ -1146,12 +1153,12 @@ DYNET_NODE_INST_DEV_IMPL(MatrixInverse)
 
 template<class MyDevice>
 void MatrixMultiply::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in MatrixMultiply::forward");
 #ifdef __CUDACC__
   // fx = 0*fx + xs[0] * xs[1]
   CUDAMatrixMultiply(dev, *xs[0], *xs[1], fx, kSCALAR_ZERO);
 #else
-  assert(fx.d.bd == max(xs[0]->d.bd, xs[1]->d.bd));
+  DYNET_ASSERT(fx.d.bd == max(xs[0]->d.bd, xs[1]->d.bd), "Failed dimension check in MatrixMultiply::forward");
   if(xs[0]->d.bd == 1) {
     // If the left side has one batch, multiply by columns
     // [x, z, b] = [x, y] * [y, z, b]
@@ -1159,7 +1166,7 @@ void MatrixMultiply::forward_dev_impl(const MyDevice & dev, const vector<const T
     fx.colbatch_matrix().noalias() = **xs[0] * xs[1]->colbatch_matrix();
   } else {
     // Otherwise, loop over the batches
-    assert(xs[1]->d.bd == 1 || xs[1]->d.bd == xs[0]->d.bd);
+    DYNET_ASSERT(xs[1]->d.bd == 1 || xs[1]->d.bd == xs[0]->d.bd, "Failed dimension check in MatrixMultiply::forward");
     for(unsigned b = 0; b < xs[0]->d.bd; ++b)
       fx.batch_matrix(b).noalias() = xs[0]->batch_matrix(b) * xs[1]->batch_matrix(b);
   }
@@ -1173,7 +1180,7 @@ void MatrixMultiply::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in MatrixMultiply::backward");
   int max_b = max(xs[0]->d.bd, xs[1]->d.bd);
 #if __CUDACC__
   if (i == 0) {
@@ -1247,7 +1254,7 @@ void Max::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in Max::backward");
   const Tensor t(dEdxi.d, static_cast<float*>(aux_mem), fx.device, DeviceMempool::FXS);
   if (i == 0) {
     dEdxi.tvec().device(*dev.edevice) += t.tvec() * dEdf.tvec();
@@ -1293,12 +1300,12 @@ DYNET_NODE_INST_DEV_IMPL(FlipGradient)
   
 template<class MyDevice>
 void MaxPooling1D::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  throw std::runtime_error("MaxPooling1D::forward_dev_impl not implemented yet");
+  DYNET_RUNTIME_ERR("MaxPooling1D::forward_dev_impl not implemented yet");
 #if 0
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in MaxPooling1D::forward");
   const Tensor& x = *xs.front();
   const unsigned x_rows = x.rows();
-  assert(x.cols() == 1);
+  DYNET_ASSERT(x.cols() == 1, "Failed dimension check in MaxPooling1D::forward");
   const unsigned fx_rows = x_rows / width;
   ind.resize(fx_rows);
   Tensor fx = Zero(Dim(fx_rows, 1));
@@ -1328,14 +1335,14 @@ void MaxPooling1D::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  throw std::runtime_error("MaxPooling1D::backward_dev_impl not implemented yet");
+  DYNET_RUNTIME_ERR("MaxPooling1D::backward_dev_impl not implemented yet");
 #if 0
   const Tensor& x = *xs.front();
   const unsigned x_rows = x.rows();
   Tensor dEdx = Zero(Dim(x_rows, 1));
   const unsigned fx_rows = x_rows / width;
-  assert(fx_rows == ind.size());
-  assert(fx_rows == dEdf.rows());
+  DYNET_ASSERT(fx_rows == ind.size(), "Failed dimension check in MaxPooling1D::backward");
+  DYNET_ASSERT(fx_rows == dEdf.rows(), "Failed dimension check in MaxPooling1D::backward");
   for (unsigned i = 0; i < fx_rows; ++i)
     dEdx(ind[i], 0) = dEdf(i, 0);
   return dEdx;
@@ -1357,7 +1364,7 @@ void Min::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in Min::backward");
   const Tensor t(dEdxi.d, static_cast<float*>(aux_mem), fx.device, DeviceMempool::FXS);
   if (i == 0) {
     dEdxi.tvec().device(*dev.edevice) += t.tvec() * dEdf.tvec();
@@ -1369,7 +1376,7 @@ DYNET_NODE_INST_DEV_IMPL(Min)
 
 template<class MyDevice>
 void Negate::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in Negate::forward");
   fx.tvec().device(*dev.edevice) = -xs[0]->tvec();
 }
 
@@ -1380,7 +1387,7 @@ void Negate::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i == 0);
+  DYNET_ASSERT(i == 0, "Failed dimension check in Negate::backward");
   dEdxi.tvec().device(*dev.edevice) -= dEdf.tvec();
 }
 DYNET_NODE_INST_DEV_IMPL(Negate)
@@ -1410,23 +1417,21 @@ DYNET_NODE_INST_DEV_IMPL(PairwiseRankLoss)
 template<class MyDevice>
 void PickElement::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   if(pval) {
-    if (*pval >= xs[0]->d[dimension]) {
-      ostringstream s; s << "PickElement::forward_impl requested element " << *pval
-                         << " from a dimension of length " << xs[0]->d[dimension] << endl;
-      throw std::invalid_argument(s.str());
-    }
-    // TODO: This limit of up to 3 is somewhat arbitrary. We need to decide how to handle
+    if (*pval >= xs[0]->d[dimension])
+      DYNET_INVALID_ARG("PickElement::forward_impl requested element " << *pval
+                         << " from a dimension of length " << xs[0]->d[dimension]);
+    // TODO: This limit of up to 4 is somewhat arbitrary. We need to decide how to handle
     //       things with "maximum tensor size".
-    fx.tb<2>().device(*dev.edevice) = xs[0]->tb<3>().chip(*pval, dimension); 
+    fx.tb<3>().device(*dev.edevice) = xs[0]->tb<4>().chip(*pval, dimension); 
   } else {
-    assert(pvals);
-    assert(pvals->size() == fx.d.batch_elems());
+    DYNET_ASSERT(pvals != nullptr, "Neither single nor vector of elements available in PickElement::forward");
+    if(pvals->size() != fx.d.batch_elems())
+      DYNET_INVALID_ARG("In PickElement::forward, number of elements in the passed-in index vector (" << pvals->size() <<
+                        ") did not match number of elements in mini-batch elements in expression (of dimension" << fx.d << ")");
     for(unsigned b = 0; b < pvals->size(); ++b) {
-      if ((*pvals)[b] >= xs[0]->d[dimension]) {
-        ostringstream s; s << "PickElement::forward_impl requested element " << (*pvals)[b]
-                           << " from a dimension of length " << xs[0]->d[dimension] << endl;
-        throw std::invalid_argument(s.str());
-      }
+      if ((*pvals)[b] >= xs[0]->d[dimension])
+        DYNET_INVALID_ARG("PickElement::forward_impl requested element " << (*pvals)[b]
+                           << " from a dimension of length " << xs[0]->d[dimension]);
       fx.tb<2>().chip<2>(b).device(*dev.edevice) = xs[0]->tb<3>().chip<3>(b).chip((*pvals)[b], dimension); 
     }
   }
@@ -1440,11 +1445,11 @@ void PickElement::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i == 0);
+  DYNET_ASSERT(i == 0, "Failed dimension check in PickElement::backward");
   if(pval) {
     dEdxi.tb<3>().chip(*pval, dimension).device(*dev.edevice) += dEdf.tb<2>();
   } else {
-    assert(pvals);
+    DYNET_ASSERT(pvals, "Neither single nor vector of elements available in PickElement::forward");
     for(unsigned b = 0; b < pvals->size(); ++b)
       dEdxi.tb<3>().chip<3>(b).chip((*pvals)[b], dimension).device(*dev.edevice) += dEdf.tb<2>().chip<2>(b);
   }
@@ -1465,8 +1470,10 @@ void PickNegLogSoftmax::forward_dev_impl(const MyDevice & dev, const vector<cons
     if(pval) {
       *ids_host = *pval;
     } else {
-      assert(pvals);
-      assert(pvals->size() == fx.d.bd);
+      DYNET_ASSERT(pvals, "Neither single nor vector of elements available in PickNegLogSoftmax::forward");
+      if(pvals->size() != fx.d.batch_elems())
+        DYNET_INVALID_ARG("In PickNegLogSoftmax::forward, number of elements in the passed-in index vector (" << pvals->size() <<
+                          ") did not match number of elements in mini-batch elements in expression (of dimension" << fx.d << ")");
       size_t batch_size = xs[0]->d.batch_size();
       for(unsigned b = 0; b < fx.d.bd; ++b)
         ids_host[b] = batch_size * b + (*pvals)[b];
@@ -1483,7 +1490,7 @@ void PickNegLogSoftmax::forward_dev_impl(const MyDevice & dev, const vector<cons
 #endif
     fx.tvec().device(*dev.edevice) = z.tvec() - fx.tvec();
   } else {
-    throw std::runtime_error("PickNegLogSoftmax::forward not yet implemented for multiple columns");
+    DYNET_RUNTIME_ERR("PickNegLogSoftmax::forward not yet implemented for multiple columns");
   }
 }
 
@@ -1509,7 +1516,7 @@ void PickNegLogSoftmax::backward_dev_impl(const MyDevice & dev,
     }
 #endif
   } else {
-    throw std::runtime_error("PickNegLogSoftmax::backward not yet implemented for multiple columns");
+    DYNET_RUNTIME_ERR("PickNegLogSoftmax::backward not yet implemented for multiple columns");
   }
 }
 DYNET_NODE_INST_DEV_IMPL(PickNegLogSoftmax)
@@ -1562,7 +1569,7 @@ DYNET_NODE_INST_DEV_IMPL(PoissonRegressionLoss)
 
 template<class MyDevice>
 void Pow::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in Pow::forward");
   fx.tvec().device(*dev.edevice) = xs[0]->tvec().pow(as_scalar(*xs[1]));
 }
 
@@ -1573,13 +1580,13 @@ void Pow::backward_dev_impl(const MyDevice & dev,
                             const Tensor& dEdf,
                             unsigned i,
                             Tensor& dEdxi) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in Pow::backward");
   real x2 = as_scalar(*xs[1]);
   if (i == 0) {
     dEdxi.tvec().device(*dev.edevice) += xs[0]->tvec().pow(x2 - 1) * dEdf.tvec() * x2;
   } else {
 #if defined(__CUDACC__) && defined(EIGEN_NO_MALLOC)
-    throw std::runtime_error("CUDA memory allocation in Pow");
+    DYNET_RUNTIME_ERR("CUDA memory allocation in Pow");
 #endif
     // y = a^x
     // dy/dx = a^x * log(a)
@@ -1590,7 +1597,7 @@ DYNET_NODE_INST_DEV_IMPL(Pow)
 
 template<class MyDevice>
 void Rectify::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in Rectify::forward");
   fx.tvec().device(*dev.edevice) = xs[0]->tvec().cwiseMax(0.f);
 }
 
@@ -1626,15 +1633,17 @@ DYNET_NODE_INST_DEV_IMPL(Reshape)
 
 template<class MyDevice>
 void RestrictedLogSoftmax::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in RestrictedLogSoftmax");
 #ifdef __CUDACC__
-  throw std::runtime_error("RestrictedLogSoftmax not yet implemented for CUDA");
+  DYNET_RUNTIME_ERR("RestrictedLogSoftmax not yet implemented for CUDA (contributions welcome!)");
 #else
   // TODO create auxiliary mask with -infty's
   // and do usual LogSoftmax stuff
-  assert(xs.size() == 1);
-  assert(denom.size() > 0);
+  if(denom.size() == 0)
+    DYNET_INVALID_ARG("Number of elements in denominator of RestrictedLogSoftmax::forward must be zero");
   auto x = **xs[0];
-  assert(x.cols() == 1);
+  if(denom.size() == 0)
+    DYNET_RUNTIME_ERR("RestrictedLogSoftmax currently only supports single column expressions (contributions expanding support to multiple columns welcome!)");
   const real logz = logsumexp(x, denom);
   TensorTools::Constant(fx, -numeric_limits<real>::infinity());
   for (auto i : denom)
@@ -1650,9 +1659,9 @@ void RestrictedLogSoftmax::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i == 0);
+  DYNET_ASSERT(i == 0, "Failed dimension check in RestrictedLogSoftmax");
 #ifdef __CUDACC__
-  throw std::runtime_error("RestrictedLogSoftmax not yet implemented for CUDA");
+  DYNET_RUNTIME_ERR("RestrictedLogSoftmax not yet implemented for CUDA (contributions welcome!)");
 #else
   float z = 0;
   for (auto ind : denom)
@@ -1665,13 +1674,11 @@ DYNET_NODE_INST_DEV_IMPL(RestrictedLogSoftmax)
 
 template<class MyDevice>
 void SelectCols::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SelectCols::forward");
   auto& rm = *pcols;
   for (unsigned i = 0; i < rm.size(); ++i) {
-    if(rm[i] >= xs[0]->d.cols()) {
-      ostringstream oss; oss << "Out-of-bounds index " << rm[i] << " in SelectCols over expression of dimensions " << xs[0]->d;
-      throw std::invalid_argument(oss.str());
-    }
+    if(rm[i] >= xs[0]->d.cols())
+      DYNET_INVALID_ARG("Out-of-bounds index " << rm[i] << " in SelectCols over expression of dimensions " << xs[0]->d);
     fx.t<2>().chip<1>(i).device(*dev.edevice) = xs[0]->t<2>().chip<1>(rm[i]);
   }
 }
@@ -1683,7 +1690,7 @@ void SelectCols::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SelectCols::backward");
   auto& rm = *pcols;
   for (unsigned i = 0; i < rm.size(); ++i)
     dEdxi.t<2>().chip<1>(rm[i]).device(*dev.edevice) = dEdf.t<2>().chip<1>(i);
@@ -1692,13 +1699,11 @@ DYNET_NODE_INST_DEV_IMPL(SelectCols)
 
 template<class MyDevice>
 void SelectRows::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SelectRows::forward");
   auto& rm = *prows;
   for (unsigned i = 0; i < rm.size(); ++i) {
-    if(rm[i] >= xs[0]->d.rows()) {
-      ostringstream oss; oss << "Out-of-bounds index " << rm[i] << " in SelectRows over expression of dimensions " << xs[0]->d;
-      throw std::invalid_argument(oss.str());
-    }
+    if(rm[i] >= xs[0]->d.rows())
+      DYNET_INVALID_ARG("Out-of-bounds index " << rm[i] << " in SelectRows over expression of dimensions " << xs[0]->d);
     fx.t<2>().chip<0>(i).device(*dev.edevice) = xs[0]->t<2>().chip<0>(rm[i]);
   }
 }
@@ -1710,7 +1715,7 @@ void SelectRows::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SelectRows::backward");
   auto& rm = *prows;
   for (unsigned i = 0; i < rm.size(); ++i)
     dEdxi.t<2>().chip<0>(rm[i]).device(*dev.edevice) = dEdf.t<2>().chip<0>(i);
@@ -1719,7 +1724,7 @@ DYNET_NODE_INST_DEV_IMPL(SelectRows)
 
 template<class MyDevice>
 void Softmax::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in Softmax::forward");
   Tensor z(Dim({xs[0]->d.cols()},fx.d.bd), (float*)aux_mem, fx.device, DeviceMempool::FXS);
   Tensor m(Dim({xs[0]->d.cols()},fx.d.bd), (float*)aux_mem + z.d.size(), fx.device, DeviceMempool::FXS);
   logsumexp(dev, *xs[0], m, z);
@@ -1748,7 +1753,7 @@ DYNET_NODE_INST_DEV_IMPL(Softmax)
 
 template<class MyDevice>
 void SoftSign::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SoftSign::forward");
   fx.tvec().device(*dev.edevice) = xs[0]->tvec().unaryExpr(FSoftSign());
 }
 
@@ -1767,7 +1772,7 @@ template<class MyDevice>
 void Sparsemax::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   if (xs[0]->d.cols() == 1) {
 #ifdef __CUDACC__
-    throw std::runtime_error("Sparsemax not implemented for CUDA");
+    DYNET_RUNTIME_ERR("Sparsemax not implemented for CUDA");
 #else
     const unsigned rows = xs[0]->d.rows();
     float *zs = static_cast<float*>(aux_mem);
@@ -1790,7 +1795,7 @@ void Sparsemax::forward_dev_impl(const MyDevice & dev, const vector<const Tensor
     cc[0] = c - 1;
 #endif
   } else {
-    throw std::runtime_error("Sparsemax not yet implemented for multiple columns");
+    DYNET_RUNTIME_ERR("Sparsemax not yet implemented for multiple columns");
   }
 }
 
@@ -1802,7 +1807,7 @@ void Sparsemax::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
 #ifdef __CUDACC__
-  throw std::runtime_error("Sparsemax not implemented for CUDA");
+  DYNET_RUNTIME_ERR("Sparsemax not implemented for CUDA");
 #else
   const int ssize = static_cast<int*>(aux_mem)[0];
   int *support = static_cast<int*>(aux_mem) + 1;
@@ -1821,11 +1826,11 @@ template<class MyDevice>
 void SparsemaxLoss::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   if (xs[0]->d.cols() == 1) {
 #ifdef __CUDACC__
-    throw std::runtime_error("SparsemaxLoss not implemented for CUDA");
+    DYNET_RUNTIME_ERR("SparsemaxLoss not implemented for CUDA");
 #else
     const int rows = xs[0]->d.rows();
     if (rows > MAX_SPARSEMAX_LOSS_ROWS)
-      throw std::runtime_error("MAX_SPARSEMAX_LOSS_ROWS is not sufficient. Recompile with larger value.");
+      DYNET_RUNTIME_ERR("MAX_SPARSEMAX_LOSS_ROWS is not sufficient. Recompile with larger value.");
     const unsigned qsupport_size = pq->size();
     const float qprop = 1.f / qsupport_size;
 
@@ -1849,7 +1854,7 @@ void SparsemaxLoss::forward_dev_impl(const MyDevice & dev, const vector<const Te
     fx.t<0>() = fx.t<0>().cwiseMax(0.f);
 #endif
   } else {
-    throw std::runtime_error("SparsemaxLoss not yet implemented for multiple columns");
+    DYNET_RUNTIME_ERR("SparsemaxLoss not yet implemented for multiple columns");
   }
 }
 
@@ -1861,7 +1866,7 @@ void SparsemaxLoss::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
 #ifdef __CUDACC__
-  throw std::runtime_error("SparsemaxLoss not implemented for CUDA");
+  DYNET_RUNTIME_ERR("SparsemaxLoss not implemented for CUDA");
 #else
   const float d = dEdf.v[0];
   float* psm = static_cast<float*>(aux_mem);
@@ -1893,7 +1898,7 @@ DYNET_NODE_INST_DEV_IMPL(Square)
 
 template<class MyDevice>
 void SquaredEuclideanDistance::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 2);
+  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in SquaredEuclideanDistance::forward");
   fx.t<0>().device(*dev.edevice) = (xs[0]->tvec() - xs[1]->tvec()).square().sum();
 }
 
@@ -1904,7 +1909,7 @@ void SquaredEuclideanDistance::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in SquaredEuclideanDistance::backward");
   real scale = as_scalar(dEdf) * 2;
   if (i == 1) scale = -scale;
   dEdxi.tvec().device(*dev.edevice) += (xs[0]->tvec() - xs[1]->tvec()) * scale;
@@ -1913,7 +1918,7 @@ DYNET_NODE_INST_DEV_IMPL(SquaredEuclideanDistance)
 
 template<class MyDevice>
 void SquaredNorm::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SquaredNorm::forward");
   fx.t<0>().device(*dev.edevice) = xs[0]->tvec().square().sum();
 }
 
@@ -1924,7 +1929,7 @@ void SquaredNorm::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 1);
+  DYNET_ASSERT(i < 1, "Failed dimension check in SquaredNorm::backward");
   real scale = as_scalar(dEdf) * 2;
   dEdxi.tvec().device(*dev.edevice) += xs[0]->tvec() * scale;
 }
@@ -1961,7 +1966,7 @@ void Sum::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs
     bool allSameBatchSize = std::all_of(xs.begin(), xs.end(), [&](const Tensor* x) { return x->d.bd == xs[0]->d.bd;});
     if (allSameBatchSize) {
       // Since they are all the same batch size, we can easily unroll the addition (results in lower GPU latency by merging multiple adds together in one CUDA call):
-      assert(num_args > 4);        // If it was <=4, we would have handled it in the special cases above
+      DYNET_ASSERT(num_args > 4, "Bad loop unrolling in Sum::forward");        // If it was <=4, we would have handled it in the special cases above
       fx.tvec().device(*dev.edevice) = xs[0]->tvec() + xs[1]->tvec() + xs[2]->tvec() + xs[3]->tvec();
 
       const unsigned remainder = (num_args - 4 ) % 4;
@@ -2015,7 +2020,7 @@ DYNET_NODE_INST_DEV_IMPL(Sum)
 
 template<class MyDevice>
 void SumBatches::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 1);
+  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SumBatches::forward");
   unsigned num_args = xs[0]->d.bd;
 #ifdef __CUDACC__
   Eigen::array<int, 1> red_axis; red_axis[0] = 2;
@@ -2042,7 +2047,7 @@ void SumBatches::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i == 0);
+  DYNET_ASSERT(i == 0, "Failed dimension check in SumBatches::backward");
 #if __CUDACC__
   Eigen::array<int, 3> bcast({1, 1, (int)fx.d.bd});
   dEdxi.tb<2>().device(*dev.edevice) += dEdf.tb<2>().broadcast(bcast);
@@ -2056,7 +2061,7 @@ DYNET_NODE_INST_DEV_IMPL(SumBatches)
 template<class MyDevice>
 void TraceOfProduct::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
 #ifdef __CUDACC__
-  throw std::runtime_error("TraceOfProduct not yet implemented for CUDA");
+  DYNET_RUNTIME_ERR("TraceOfProduct not yet implemented for CUDA");
 #else
   auto x1 = **xs[0];
   auto x2 = **xs[1];
@@ -2071,9 +2076,9 @@ void TraceOfProduct::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  assert(i < 2);
+  DYNET_ASSERT(i < 2, "Failed dimension check in TraceOfProduce::backward");
 #ifdef __CUDACC__
-  throw std::runtime_error("TraceOfProduct not yet implemented for CUDA");
+  DYNET_RUNTIME_ERR("TraceOfProduct not yet implemented for CUDA");
 #else
   const float d = dEdf.v[0];
   auto xother = **xs[1 - i];
@@ -2134,7 +2139,7 @@ DYNET_NODE_INST_DEV_IMPL(Transpose)
 
 template<class MyDevice>
 void Zeroes::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in Zeroes::forward");
   TensorTools::Zero(fx);
 }
 
@@ -2145,13 +2150,13 @@ void Zeroes::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  throw std::runtime_error("Called backward() on an arity 0 node");
+  DYNET_RUNTIME_ERR("Called backward() on an arity 0 node");
 }
 DYNET_NODE_INST_DEV_IMPL(Zeroes)
 
 template<class MyDevice>
 void RandomNormal::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in RandomNormal::forward");
   TensorTools::RandomizeNormal(fx);
 }
 
@@ -2162,13 +2167,13 @@ void RandomNormal::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  throw std::runtime_error("Called backward() on an arity 0 node");
+  DYNET_RUNTIME_ERR("Called backward() on an arity 0 node");
 }
 DYNET_NODE_INST_DEV_IMPL(RandomNormal)
 
 template<class MyDevice>
 void RandomBernoulli::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in RandomBernoulli::forward");
   TensorTools::RandomizeBernoulli(fx, p, scale);
 }
 
@@ -2179,13 +2184,13 @@ void RandomBernoulli::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  throw std::runtime_error("Called backward() on an arity 0 node");
+  DYNET_RUNTIME_ERR("Called backward() on an arity 0 node");
 }
 DYNET_NODE_INST_DEV_IMPL(RandomBernoulli)
 
 template<class MyDevice>
 void RandomUniform::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in RandomUniform::forward");
   TensorTools::RandomizeUniform(fx, left, right);
 }
 
@@ -2196,7 +2201,7 @@ void RandomUniform::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  throw std::runtime_error("Called backward() on an arity 0 node");
+  DYNET_RUNTIME_ERR("Called backward() on an arity 0 node");
 }
 DYNET_NODE_INST_DEV_IMPL(RandomUniform)
 

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -268,6 +268,7 @@ struct Hinge : public Node {
   explicit Hinge(const std::initializer_list<VariableIndex>& a, const unsigned* pe, real m = 1.0) : Node(a), element(), pelement(pe), margin(m) {}
   explicit Hinge(const std::initializer_list<VariableIndex>& a, const std::vector<unsigned>& e, real m = 1.0) : Node(a), element(), pelement(), elements(e), pelements(&elements), margin(m) {}
   explicit Hinge(const std::initializer_list<VariableIndex>& a, const std::vector<unsigned>* pe, real m = 1.0) : Node(a), element(), pelement(), elements(), pelements(pe), margin(m) {}
+  virtual bool supports_multibatch() const override { return true; }
   DYNET_NODE_DEFINE_DEV_IMPL()
   size_t aux_storage_size() const override;
   unsigned element;

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -542,7 +542,9 @@ struct RandomNormal : public Node {
 
 // draw from Bernoulli(p)
 struct RandomBernoulli : public Node {
-  explicit RandomBernoulli(const std::initializer_list<VariableIndex>& a, const Dim& d, real p, real scale = 1.0f) : dim(d), p(p), scale(scale) { assert (a.size() == 0); }
+  explicit RandomBernoulli(const std::initializer_list<VariableIndex>& a, const Dim& d, real p, real scale = 1.0f) : dim(d), p(p), scale(scale) {
+    DYNET_ASSERT(a.size() == 0, "RandomBernoulli doesn't accept nodes as input");
+  }
   DYNET_NODE_DEFINE_DEV_IMPL()
   Dim dim;
   real p;
@@ -551,7 +553,9 @@ struct RandomBernoulli : public Node {
 
 // draw a random real from Uniform(left, right)
 struct RandomUniform : public Node {
-  explicit RandomUniform(const std::initializer_list<VariableIndex>& a, const Dim& d, real left, real right) : dim(d), left(left), right(right) { assert (a.size() == 0); }
+  explicit RandomUniform(const std::initializer_list<VariableIndex>& a, const Dim& d, real left, real right) : dim(d), left(left), right(right) {
+    DYNET_ASSERT(a.size() == 0, "RandomUniform doesn't accept nodes as input");
+  }
   DYNET_NODE_DEFINE_DEV_IMPL()
   Dim dim;
   real left, right;

--- a/dynet/param-nodes.cc
+++ b/dynet/param-nodes.cc
@@ -24,7 +24,7 @@ string ConstParameterNode::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConstParameterNode::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
   return dim;
 }
 
@@ -35,7 +35,7 @@ string ParameterNode::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ParameterNode::dim_forward(const vector<Dim>& xs) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
   return dim;
 }
 
@@ -45,7 +45,7 @@ void ParameterNode::accumulate_grad(const Tensor& g) {
   else if(lparams.mp != nullptr)
     lparams.get()->accumulate_grad(g);
   else
-    throw std::runtime_error("DyNet internal error: ConstParameterNode has neither Parameter nor LookupParameter");
+    DYNET_RUNTIME_ERR("ConstParameterNode has neither Parameter nor LookupParameter");
 }
 
 string InputNode::as_string(const vector<string>& arg_names) const {
@@ -65,7 +65,8 @@ string SparseInputNode::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SparseInputNode::dim_forward(const vector<Dim>& xs) const {
-  assert(ids.size() == data.size());
+  if(ids.size() != data.size())
+    DYNET_INVALID_ARG("Mismatch between size of ids (" << ids.size() << ") and size of data (" << data.size() << ") in SparseInput");
   return dim;
 }
 
@@ -101,7 +102,7 @@ void LookupNode::accumulate_grad(const Tensor& g) {
   if(pindex) {
     params.get()->accumulate_grad(*pindex, g);
   } else {
-    assert (pindices);
+    DYNET_ASSERT(pindices, "Have neither index nor index vector in LookupNode");
     params.get()->accumulate_grads(pindices->size(), &(*pindices)[0], (unsigned*)aux_mem, g.v);
   }
 }
@@ -110,13 +111,13 @@ void LookupNode::accumulate_grad(const Tensor& g) {
 
 template<class MyDevice>
 void ConstParameterNode::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
   if(params.mp != nullptr)
     fx.tvec().device(*dev.edevice) = params.get()->values.tvec() * params.mp->weight_decay.current_weight_decay();
   else if(lparams.mp != nullptr)
     fx.tvec().device(*dev.edevice) = lparams.get()->all_values.tvec() * lparams.mp->weight_decay.current_weight_decay();
   else
-    throw std::runtime_error("DyNet internal error: ConstParameterNode has neither Parameter nor LookupParameter");
+    DYNET_RUNTIME_ERR("ConstParameterNode has neither Parameter nor LookupParameter");
 }
 
 template<class MyDevice>
@@ -126,14 +127,13 @@ void ConstParameterNode::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  ostringstream oss; oss << "called backward() on arity 0 node: i = " << i;
-  throw std::invalid_argument(oss.str());
+  DYNET_RUNTIME_ERR("called backward() on arity 0 node: i = " << i);
 }
 DYNET_NODE_INST_DEV_IMPL(ConstParameterNode)
 
 template<class MyDevice>
 void ParameterNode::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
 // TODO
 //  if (params->not_regularized) {
 //    fx.v = params->values.v;
@@ -144,7 +144,7 @@ void ParameterNode::forward_dev_impl(const MyDevice & dev, const vector<const Te
   else if(lparams.mp != nullptr)
     fx.tvec().device(*dev.edevice) = lparams.get()->all_values.tvec() * lparams.mp->weight_decay.current_weight_decay();
   else
-    throw std::runtime_error("DyNet internal error: ParameterNode has neither Parameter nor LookupParameter");
+    DYNET_RUNTIME_ERR("ParameterNode has neither Parameter nor LookupParameter");
 }
 
 template<class MyDevice>
@@ -154,14 +154,13 @@ void ParameterNode::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  ostringstream oss; oss << "called backward() on arity 0 node: i = " << i;
-  throw std::invalid_argument(oss.str());
+  DYNET_RUNTIME_ERR("called backward() on arity 0 node: i = " << i);
 }
 DYNET_NODE_INST_DEV_IMPL(ParameterNode)
 
 template<class MyDevice>
 void InputNode::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
 #if __CUDACC__
   cudaMemcpyAsync(fx.v, &pdata->front(), dim.size() * sizeof(float), cudaMemcpyHostToDevice);
 #else
@@ -183,14 +182,13 @@ void InputNode::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  ostringstream oss; oss << "called backward() on arity 0 node: i = " << i;
-  throw std::invalid_argument(oss.str());
+  DYNET_RUNTIME_ERR("called backward() on arity 0 node: i = " << i);
 }
 DYNET_NODE_INST_DEV_IMPL(InputNode)
 
 template<class MyDevice>
 void SparseInputNode::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
   fx.tvec().device(*dev.edevice) = fx.tvec().constant(defdata);
 #if __CUDACC__
   unsigned int* ids_ptr = (unsigned int*)aux_mem;
@@ -211,14 +209,13 @@ void SparseInputNode::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  ostringstream oss; oss << "called backward() on arity 0 node: i = " << i;
-  throw std::invalid_argument(oss.str());
+  DYNET_RUNTIME_ERR("called backward() on arity 0 node: i = " << i);
 }
 DYNET_NODE_INST_DEV_IMPL(SparseInputNode)
 
 template<class MyDevice>
 void ScalarInputNode::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
 #if __CUDACC__
   cudaMemcpyAsync(fx.v, pdata, 1 * sizeof(float), cudaMemcpyHostToDevice);
 #else
@@ -233,28 +230,31 @@ void ScalarInputNode::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  ostringstream oss; oss << "called backward() on arity 0 node: i = " << i;
-  throw std::invalid_argument(oss.str());
+  DYNET_RUNTIME_ERR("called backward() on arity 0 node: i = " << i);
 }
 DYNET_NODE_INST_DEV_IMPL(ScalarInputNode)
 
 template<class MyDevice>
 void LookupNode::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  assert(xs.size() == 0);
+  DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
   if(pindex) {
-    assert(*pindex < params.get()->values.size());
-    assert (fx.d.batch_elems() == 1);
+    if(*pindex >= params.get()->values.size())
+      DYNET_INVALID_ARG("Out-of-bounds attempt to access index " << *pindex << " for LookupParameter of size " << params.get()->values.size());
+    DYNET_ASSERT(fx.d.batch_elems() == 1, "Batch dimension > 1 for lookup with single index");
     fx.tvec().device(*dev.edevice) = params.get()->values[*pindex].tvec() * params.mp->weight_decay.current_weight_decay();
   } else {
-    assert (pindices);
-    assert (fx.d.batch_elems() == pindices->size());
+    DYNET_ASSERT(pindices, "Have neither index nor index vector in LookupNode");
+    if(fx.d.batch_elems() != pindices->size())
+      DYNET_INVALID_ARG("In LookupNode, in index vector size (" << pindices->size() <<
+                        ") doesn't match batch size in expressions (" << fx.d.batch_elems() << ")");
 #if __CUDACC__
     CUDA_CHECK(cudaMemcpyAsync((unsigned*)aux_mem, &(*pindices)[0], fx.d.bd * sizeof(unsigned), cudaMemcpyHostToDevice));
     dynet::gpu::sparse_to_dense_block_assign_and_multiply(fx.d.bd, (unsigned*)aux_mem, fx.d.batch_size(), params.mp->weight_decay.current_weight_decay(), params.get()->all_values.v, fx.v);
 #else
     for (unsigned b = 0; b < pindices->size(); ++b) {
       unsigned i = pindices->at(b);
-      assert (i < params.get()->values.size());
+      if(i >= params.get()->values.size())
+        DYNET_INVALID_ARG("Out-of-bounds attempt to access index " << i << " for LookupParameter of size " << params.get()->values.size());
       fx.tb<2>().chip<2>(b).device(*dev.edevice) = params.get()->values[i].t<2>() * params.mp->weight_decay.current_weight_decay();
     }
 #endif
@@ -268,8 +268,7 @@ void LookupNode::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  ostringstream oss; oss << "called backward() on arity 0 node: i = " << i;
-  throw std::invalid_argument(oss.str());
+  DYNET_RUNTIME_ERR("called backward() on arity 0 node: i = " << i);
 }
 DYNET_NODE_INST_DEV_IMPL(LookupNode)
 

--- a/dynet/pretrain.cc
+++ b/dynet/pretrain.cc
@@ -17,7 +17,8 @@ void save_pretrained_embeddings(const std::string& fname,
     const LookupParameter& lp) {
   cerr << "Writing word vectors to " << fname << " ...\n";
   ofstream out(fname);
-  assert(out);
+  if(!out)
+    DYNET_INVALID_ARG("Could not save embeddings to " << fname);
   auto& m = *lp.get();
   for (unsigned i = 0; i < d.size(); ++i) {
     out << d.convert(i) << ' ' << (*m.values[i]).transpose() << endl;
@@ -31,7 +32,8 @@ void read_pretrained_embeddings(const std::string& fname,
   if (d.is_frozen()) unk = d.get_unk_id();
   cerr << "Loading word vectors from " << fname << " ...\n";
   ifstream in(fname);
-  assert(in);
+  if(!in)
+    DYNET_INVALID_ARG("Could not load embeddings from " << fname);
   string line;
   string word;
   vector<float> v;

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -139,7 +139,7 @@ Expression SimpleRNNBuilder::add_auxiliary_input(const Expression &in, const Exp
 void SimpleRNNBuilder::copy(const RNNBuilder & rnn) {
   const SimpleRNNBuilder & rnn_simple = (const SimpleRNNBuilder&)rnn;
   if(params.size() != rnn_simple.params.size())
-    DYNET_INVALID_ARG("Attempt to copiy between two SimpleRNNBuilders that are not the same size");
+    DYNET_INVALID_ARG("Attempt to copy between two SimpleRNNBuilders that are not the same size");
   for(size_t i = 0; i < rnn_simple.params.size(); ++i) {
       params[i][0] = rnn_simple.params[i][0];
       params[i][1] = rnn_simple.params[i][1];

--- a/dynet/tensor.cc
+++ b/dynet/tensor.cc
@@ -278,7 +278,7 @@ void Tensor::load(Archive& ar, const unsigned int ver) {
   if (dev_id == -1) {
     device = default_device;
   } else {
-    assert(dev_id > 0 && dev_id < (int)devices.size());
+    DYNET_ASSERT(dev_id > 0 && dev_id < (int)devices.size(), "Bad device id " << dev_id << " in Tensor::load with " << devices.size() << " total devices");
     device = devices[dev_id];
   }
   device->allocate_tensor(mem_pool, *this);

--- a/dynet/tensor.h
+++ b/dynet/tensor.h
@@ -69,13 +69,13 @@ struct Tensor {
    * \return Eigen matrix
    */
   Eigen::Map<Eigen::MatrixXf> operator*() {
-    assert(d.batch_elems() == 1);
-    assert(d.ndims() < 3);
+    if(d.batch_elems() != 1 || d.ndims() >= 3)
+      DYNET_INVALID_ARG("Attempted to access Tensor with more than one batch element or more than two dimensions in matrix form: " << d);
     return Eigen::Map<Eigen::MatrixXf>(v, d.rows(), d.cols());
   }
   const Eigen::Map<Eigen::MatrixXf> operator*() const {
-    assert(d.batch_elems() == 1);
-    assert(d.ndims() < 3);
+    if(d.batch_elems() != 1 || d.ndims() >= 3)
+      DYNET_INVALID_ARG("Attempted to access Tensor with more than one batch element or more than two dimensions in matrix form: " << d);
     return Eigen::Map<Eigen::MatrixXf>(v, d.rows(), d.cols());
   }
   /**
@@ -136,11 +136,11 @@ struct Tensor {
    * \return Pointer to the memory where the batch values are located
    */
   float* batch_ptr(unsigned bid) {
-    assert(d.bd == 1 || bid < d.bd);
+    DYNET_ASSERT(d.bd == 1 || bid < d.bd, "Batch index out of bounds in batch_ptr: index=" << bid << ", dim=" << d);
     return v + (bid % d.bd) * d.batch_size();
   }
   const float* batch_ptr(unsigned bid) const {
-    assert(d.bd == 1 || bid < d.bd);
+    DYNET_ASSERT(d.bd == 1 || bid < d.bd, "Batch index out of bounds in batch_ptr: index=" << bid << ", dim=" << d);
     return v + (bid % d.bd) * d.batch_size();
   }
   /**
@@ -253,52 +253,52 @@ private:
 };
 
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 0>> Tensor::t<0>() {
-  assert(d.batch_elems() == 1 && d.size() == 1);
+  DYNET_ASSERT(d.batch_elems() == 1 && d.size() == 1, "Illegal access of tensor in function t<0>(): dim=" << d);
   return Eigen::TensorMap<Eigen::Tensor<float, 0>>(v);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 0>> Tensor::t<0>() const {
-  assert(d.batch_elems() == 1 && d.size() == 1);
+  DYNET_ASSERT(d.batch_elems() == 1 && d.size() == 1, "Illegal access of tensor in function t<0>(): dim=" << d);
   return Eigen::TensorMap<Eigen::Tensor<float, 0>>(v);
 }
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 1>> Tensor::t<1>() {
-  assert(d.batch_elems() == 1 && (d.ndims() == 1 || d.size() == d.rows()));
+  DYNET_ASSERT(d.batch_elems() == 1 && (d.ndims() == 1 || d.size() == d.rows()), "Illegal access of tensor in function t<1>(): dim=" << d);
   return Eigen::TensorMap<Eigen::Tensor<float, 1>>(v, (int)d[0]);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 1>> Tensor::t<1>() const {
-  assert(d.batch_elems() == 1 && (d.ndims() == 1 || d.size() == d.rows()));
+  DYNET_ASSERT(d.batch_elems() == 1 && (d.ndims() == 1 || d.size() == d.rows()), "Illegal access of tensor in function t<1>(): dim=" << d);
   return Eigen::TensorMap<Eigen::Tensor<float, 1>>(v, (int)d[0]);
 }
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 2>> Tensor::t<2>() {
-  assert(d.batch_elems() == 1 && d.ndims() <= 2);
+  DYNET_ASSERT(d.batch_elems() == 1 && d.ndims() <= 2, "Illegal access of tensor in function t<2>(): dim=" << d);
   if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 2>>(v, (int)d[0], (int)d[1]);
   else               return Eigen::TensorMap<Eigen::Tensor<float, 2>>(v, (int)d[0], (int)1);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 2>> Tensor::t<2>() const {
-  assert(d.batch_elems() == 1 && d.ndims() <= 2);
+  DYNET_ASSERT(d.batch_elems() == 1 && d.ndims() <= 2, "Illegal access of tensor in function t<2>(): dim=" << d);
   if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 2>>(v, (int)d[0], (int)d[1]);
   else               return Eigen::TensorMap<Eigen::Tensor<float, 2>>(v, (int)d[0], (int)1);
 }
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 3>> Tensor::t<3>() {
-  assert(d.batch_elems() == 1 && d.ndims() <= 3);
+  DYNET_ASSERT(d.batch_elems() == 1 && d.ndims() <= 3, "Illegal access of tensor in function t<3>(): dim=" << d);
   if (d.ndims() == 3)      return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)d[1], (int)d[2]);
   else if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)d[1], (int)1);
   else                    return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)1, (int)1);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 3>> Tensor::t<3>() const {
-  assert(d.batch_elems() == 1 && d.ndims() <= 3);
+  DYNET_ASSERT(d.batch_elems() == 1 && d.ndims() <= 3, "Illegal access of tensor in function t<3>(): dim=" << d);
   if (d.ndims() == 3)      return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)d[1], (int)d[2]);
   else if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)d[1], (int)1);
   else                    return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)1, (int)1);
 }
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 4>> Tensor::t<4>() {
-  assert(d.batch_elems() == 1 && d.ndims() <= 4);
+  DYNET_ASSERT(d.batch_elems() == 1 && d.ndims() <= 4, "Illegal access of tensor in function t<4>(): dim=" << d);
   if (d.ndims() == 4)      return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)d[2], (int)d[3]);
   else if (d.ndims() == 3) return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)d[2], (int)1);
   else if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)1, (int)1);
   else                    return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)1, (int)1, (int)1);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 4>> Tensor::t<4>() const {
-  assert(d.batch_elems() == 1 && d.ndims() <= 4);
+  DYNET_ASSERT(d.batch_elems() == 1 && d.ndims() <= 4, "Illegal access of tensor in function t<4>(): dim=" << d);
   if (d.ndims() == 4)      return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)d[2], (int)d[3]);
   else if (d.ndims() == 3) return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)d[2], (int)1);
   else if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)1, (int)1);
@@ -307,52 +307,52 @@ template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 4>> Tensor::t<4>()
 // ...
 
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 1>> Tensor::tb<0>() {
-  assert(d.batch_size() == 1);
+  DYNET_ASSERT(d.batch_size() == 1, "Illegal access of tensor in function tb<0>(): dim=" << d);
   return Eigen::TensorMap<Eigen::Tensor<float, 1>>(v, (int)d.bd);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 1>> Tensor::tb<0>() const {
-  assert(d.batch_size() == 1);
+  DYNET_ASSERT(d.batch_size() == 1, "Illegal access of tensor in function tb<0>(): dim=" << d);
   return Eigen::TensorMap<Eigen::Tensor<float, 1>>(v, (int)d.bd);
 }
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 2>> Tensor::tb<1>() {
-  assert(d.ndims() == 1 || d.batch_size() == d.rows());
+  DYNET_ASSERT(d.ndims() == 1 || d.batch_size() == d.rows(), "Illegal access of tensor in function tb<1>(): dim=" << d);
   return Eigen::TensorMap<Eigen::Tensor<float, 2>>(v, (int)d[0], (int)d.bd);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 2>> Tensor::tb<1>() const {
-  assert(d.ndims() == 1 || d.batch_size() == d.rows());
+  DYNET_ASSERT(d.ndims() == 1 || d.batch_size() == d.rows(), "Illegal access of tensor in function tb<1>(): dim=" << d);
   return Eigen::TensorMap<Eigen::Tensor<float, 2>>(v, (int)d[0], (int)d.bd);
 }
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 3>> Tensor::tb<2>() {
-  assert(d.ndims() <= 2);
+  DYNET_ASSERT(d.ndims() <= 2, "Illegal access of tensor in function tb<2>(): dim=" << d);
   if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)d[1], (int)d.bd);
   else               return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)1, (int)d.bd);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 3>> Tensor::tb<2>() const {
-  assert(d.ndims() <= 2);
+  DYNET_ASSERT(d.ndims() <= 2, "Illegal access of tensor in function tb<2>(): dim=" << d);
   if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)d[1], (int)d.bd);
   else               return Eigen::TensorMap<Eigen::Tensor<float, 3>>(v, (int)d[0], (int)1, (int)d.bd);
 }
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 4>> Tensor::tb<3>() {
-  assert(d.ndims() <= 3);
+  DYNET_ASSERT(d.ndims() <= 3, "Illegal access of tensor in function tb<3>(): dim=" << d);
   if (d.ndims() == 3)      return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)d[2], (int)d.bd);
   else if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)1, (int)d.bd);
   else                    return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)1, (int)1, (int)d.bd);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 4>> Tensor::tb<3>() const {
-  assert(d.ndims() <= 3);
+  DYNET_ASSERT(d.ndims() <= 3, "Illegal access of tensor in function tb<3>(): dim=" << d);
   if (d.ndims() == 3)      return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)d[2], (int)d.bd);
   else if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)d[1], (int)1, (int)d.bd);
   else                    return Eigen::TensorMap<Eigen::Tensor<float, 4>>(v, (int)d[0], (int)1, (int)1, (int)d.bd);
 }
 template<> inline Eigen::TensorMap<Eigen::Tensor<float, 5>> Tensor::tb<4>() {
-  assert(d.ndims() <= 4);
+  DYNET_ASSERT(d.ndims() <= 4, "Illegal access of tensor in function tb<4>(): dim=" << d);
   if (d.ndims() == 4)      return Eigen::TensorMap<Eigen::Tensor<float, 5>>(v, (int)d[0], (int)d[1], (int)d[2], (int)d[3], (int)d.bd);
   else if (d.ndims() == 3) return Eigen::TensorMap<Eigen::Tensor<float, 5>>(v, (int)d[0], (int)d[1], (int)d[2], (int)1, (int)d.bd);
   else if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 5>>(v, (int)d[0], (int)d[1], (int)1, (int)1, (int)d.bd);
   else                    return Eigen::TensorMap<Eigen::Tensor<float, 5>>(v, (int)d[0], (int)1, (int)1, (int)1, (int)d.bd);
 }
 template<> inline const Eigen::TensorMap<Eigen::Tensor<float, 5>> Tensor::tb<4>() const {
-  assert(d.ndims() <= 4);
+  DYNET_ASSERT(d.ndims() <= 4, "Illegal access of tensor in function tb<4>(): dim=" << d);
   if (d.ndims() == 4)      return Eigen::TensorMap<Eigen::Tensor<float, 5>>(v, (int)d[0], (int)d[1], (int)d[2], (int)d[3], (int)d.bd);
   else if (d.ndims() == 3) return Eigen::TensorMap<Eigen::Tensor<float, 5>>(v, (int)d[0], (int)d[1], (int)d[2], (int)1, (int)d.bd);
   else if (d.ndims() == 2) return Eigen::TensorMap<Eigen::Tensor<float, 5>>(v, (int)d[0], (int)d[1], (int)1, (int)1, (int)d.bd);

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -1,5 +1,4 @@
 #include <string>
-#include <cassert>
 #include <vector>
 #include <iostream>
 
@@ -96,7 +95,7 @@ void NaryTreeLSTMBuilder::new_graph_impl(ComputationGraph& cg) {
     vector<Expression> vars = {i_x2i, i_bi, i_x2f, i_bf, i_x2o, i_bo, i_x2c, i_bc};
     param_vars.push_back(vars);
 
-    assert (lp.size() == C2O + 1);
+    DYNET_ASSERT(lp.size() == C2O + 1, "Dimension mismatch in TreeLSTM");
     vector<vector<Expression>> lvars(lp.size());
     for (unsigned p_type = H2I; p_type <= C2O; p_type++) {
     LookupParameter p = lp[p_type];
@@ -125,7 +124,8 @@ void NaryTreeLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hini
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    assert(layers*2 == hinit.size());
+    if(layers*2 != hinit.size())
+      DYNET_INVALID_ARG("Incorrectly sized initialization in TreeLSTM (" << hinit.size() << "). Must be twice the number of layers (which is " << layers<< ")");
     h0.resize(layers);
     c0.resize(layers);
     for (unsigned i = 0; i < layers; ++i) {
@@ -139,8 +139,8 @@ void NaryTreeLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hini
 }
 
 Expression NaryTreeLSTMBuilder::add_input(int id, vector<int> children, const Expression& x) {
-  assert (id >= 0 && h.size() == (unsigned)id);
-  assert (id >= 0 && c.size() == (unsigned)id);
+  DYNET_ASSERT(id >= 0 && h.size() == (unsigned)id, "Failed dimension check in TreeLSTMBuilder");
+  DYNET_ASSERT(id >= 0 && c.size() == (unsigned)id, "Failed dimension check in TreeLSTMBuilder");
   h.push_back(vector<Expression>(layers));
   c.push_back(vector<Expression>(layers));
   vector<Expression>& ht = h.back();
@@ -183,7 +183,7 @@ Expression NaryTreeLSTMBuilder::add_input(int id, vector<int> children, const Ex
         xs.push_back(Lookup(i, C2I, ej));
         xs.push_back(i_c_children[j]);
       }
-      assert (xs.size() == 4 * children.size() + 3);
+      DYNET_ASSERT(xs.size() == 4 * children.size() + 3, "Failed dimension check in TreeLSTMBuilder");
       i_ait = affine_transform(xs);
     }
     else
@@ -205,7 +205,7 @@ Expression NaryTreeLSTMBuilder::add_input(int id, vector<int> children, const Ex
           xs.push_back(Lookup(i, C2F, ej * N + ek));
           xs.push_back(i_c_children[j]);
         }
-        assert (xs.size() == 4 * children.size() + 3);
+        DYNET_ASSERT(xs.size() == 4 * children.size() + 3, "Failed dimension check in TreeLSTMBuilder");
         i_aft = affine_transform(xs);
       }
       else
@@ -225,7 +225,7 @@ Expression NaryTreeLSTMBuilder::add_input(int id, vector<int> children, const Ex
         xs.push_back(Lookup(i, H2C, ej));
         xs.push_back(i_h_children[j]);
       }
-      assert (xs.size() == 2 * children.size() + 3);
+      DYNET_ASSERT(xs.size() == 2 * children.size() + 3, "Failed dimension check in TreeLSTMBuilder");
       i_awt = affine_transform(xs);
     }
     else
@@ -258,7 +258,7 @@ Expression NaryTreeLSTMBuilder::add_input(int id, vector<int> children, const Ex
         xs.push_back(Lookup(i, C2O, ej));
         xs.push_back(i_c_children[j]);
       }
-      assert (xs.size() == 4 * children.size() + 3);
+      DYNET_ASSERT(xs.size() == 4 * children.size() + 3, "Failed dimension check in TreeLSTMBuilder");
       i_aot = affine_transform(xs);
     }
     else
@@ -274,7 +274,7 @@ Expression NaryTreeLSTMBuilder::add_input(int id, vector<int> children, const Ex
 
 void NaryTreeLSTMBuilder::copy(const RNNBuilder & rnn) {
   const NaryTreeLSTMBuilder & rnn_treelstm = (const NaryTreeLSTMBuilder&)rnn;
-  assert(params.size() == rnn_treelstm.params.size());
+  DYNET_ASSERT(params.size() == rnn_treelstm.params.size(), "Failed dimension check in TreeLSTMBuilder");
   for(size_t i = 0; i < params.size(); ++i) {
     for(size_t j = 0; j < params[i].size(); ++j) {
       params[i][j] = rnn_treelstm.params[i][j];
@@ -304,7 +304,7 @@ void UnidirectionalTreeLSTMBuilder::start_new_sequence_impl(const vector<Express
 }
 
 Expression UnidirectionalTreeLSTMBuilder::add_input(int id, vector<int> children, const Expression& x) {
-  assert (id >= 0 && h.size() == (unsigned)id);
+  DYNET_ASSERT(id >= 0 && h.size() == (unsigned)id, "Failed dimension check in TreeLSTMBuilder");
 
   RNNPointer prev = (RNNPointer)(-1);
   Expression embedding = node_builder.add_input(prev, x);
@@ -325,7 +325,7 @@ BidirectionalTreeLSTMBuilder::BidirectionalTreeLSTMBuilder(unsigned layers,
                          unsigned input_dim,
                          unsigned hidden_dim,
                          Model& model) {
-  assert (hidden_dim % 2 == 0);
+  DYNET_ASSERT(hidden_dim % 2 == 0, "Failed dimension check in TreeLSTMBuilder");
   fwd_node_builder = LSTMBuilder(layers, input_dim, hidden_dim / 2, model);
   rev_node_builder = LSTMBuilder(layers, input_dim, hidden_dim / 2, model);
 }
@@ -344,7 +344,7 @@ void BidirectionalTreeLSTMBuilder::start_new_sequence_impl(const vector<Expressi
 }
 
 Expression BidirectionalTreeLSTMBuilder::add_input(int id, vector<int> children, const Expression& x) {
-  assert (id >= 0 && h.size() == (unsigned)id);
+  DYNET_ASSERT(id >= 0 && h.size() == (unsigned)id, "Failed dimension check in TreeLSTMBuilder");
 
   RNNPointer prev = (RNNPointer)(-1);
   Expression fwd_embedding = fwd_node_builder.add_input(prev, x);


### PR DESCRIPTION
One of the most annoying things about DyNet at the moment is when you get a random and opaque C++ assert error. This pull request takes steps towards unifying error catching and reporting, and provides `DYNET_INVALID_ARG()` and `DYNET_RUNTIME_ERR()` macros that allow the easy throwing of formatted exceptions.

It is still in progress. When it is finished all throws and most asserts will be replaced by these macros.