### PR TITLE
implement pick_batch to allow picking one or more batches

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -116,7 +116,7 @@ Expression pick(const Expression& x, const unsigned* pv, unsigned d) { return Ex
 Expression pick(const Expression& x, const vector<unsigned> * pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
 
 Expression pick_batch(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickBatch>({x.i}, v)); }
-Expression pick_batch(const Expression & x, const std::vector<unsigned>& v) { return Expression(x.pg, x.pg->add_function<PickBatch>({x.i}, v)); }
+Expression pick_batches(const Expression & x, const std::vector<unsigned>& v) { return Expression(x.pg, x.pg->add_function<PickBatch>({x.i}, v)); }
 
 Expression pickrange(const Expression& x, unsigned v, unsigned u) { return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u)); }
 

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -115,6 +115,9 @@ Expression pick(const Expression& x, const vector<unsigned> & v, unsigned d) { r
 Expression pick(const Expression& x, const unsigned* pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
 Expression pick(const Expression& x, const vector<unsigned> * pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
 
+Expression pick_batch(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickBatch>({x.i}, v)); }
+Expression pick_batch(const Expression & x, const std::vector<unsigned>& v) { return Expression(x.pg, x.pg->add_function<PickBatch>({x.i}, v)); }
+
 Expression pickrange(const Expression& x, unsigned v, unsigned u) { return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u)); }
 
 Expression pickneglogsoftmax(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v)); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1354,11 +1354,35 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u);
 
 /**
  * \ingroup flowoperations
- * \brief Pick a batch from the expression.
- * \details Pick a batch from the expression.
+ * \brief Pick batch.
+ * \details Pick a batch from an expression. For a Tensor with 3 batches:
+ *
+ *    \f$
+ *      \begin{pmatrix}
+ *        x_{1,1,1} & x_{1,1,2} \\
+ *        x_{1,2,1} & x_{1,2,2} \\
+ *      \end{pmatrix}
+ *      \begin{pmatrix}
+ *        x_{2,1,1} & x_{2,1,2} \\
+ *        x_{2,2,1} & x_{2,2,2} \\
+ *      \end{pmatrix}
+ *      \begin{pmatrix}
+ *        x_{3,1,1} & x_{3,1,2} \\
+ *        x_{3,2,1} & x_{3,2,2} \\
+ *      \end{pmatrix}
+ *    \f$
+ * 
+ * pick_batch(t, 1) will return a Tensor of
+ * 
+ *    \f$
+ *      \begin{pmatrix}
+ *        x_{2,1,1} & x_{2,1,2} \\ 
+ *        x_{2,2,1} & x_{2,2,2} \\
+ *      \end{pmatrix}
+ *    \f$
  *
  * \param x The input expression
- * \param v The beginning index
+ * \param v The index of the batch to be picked.
  *
  * \return The expression of picked batch. The picked batch is a tensor
  *         whose `bd` equals to one.
@@ -1367,17 +1391,44 @@ Expression pick_batch(const Expression& x, unsigned v);
 
 /**
  * \ingroup flowoperations
- * \brief Batched pick
- * \details Pick elements from multiple batches.
+ * \brief Pick batch.
+ * \details Pick several batches from an expression. For a Tensor with 3 batches:
+ *
+ *    \f$
+ *      \begin{pmatrix}
+ *        x_{1,1,1} & x_{1,1,2} \\
+ *        x_{1,2,1} & x_{1,2,2} \\
+ *      \end{pmatrix}
+ *      \begin{pmatrix}
+ *        x_{2,1,1} & x_{2,1,2} \\
+ *        x_{2,2,1} & x_{2,2,2} \\
+ *      \end{pmatrix}
+ *      \begin{pmatrix}
+ *        x_{3,1,1} & x_{3,1,2} \\
+ *        x_{3,2,1} & x_{3,2,2} \\
+ *      \end{pmatrix}
+ *    \f$
+ * 
+ * pick_batch(t, {2, 3}) will return a Tensor of with 2 batches:
+ * 
+ *    \f$
+ *      \begin{pmatrix}
+ *        x_{2,1,1} & x_{2,1,2} \\ 
+ *        x_{2,2,1} & x_{2,2,2} \\
+ *      \end{pmatrix}
+ *      \begin{pmatrix}
+ *        x_{3,1,1} & x_{3,1,2} \\
+ *        x_{3,2,1} & x_{3,2,2} \\
+ *      \end{pmatrix}
+ *    \f$
  *
  * \param x The input expression
- * \param v A vector of indicies to choose, one for each batch in the
- *          input expression.
+ * \param v A vector of indicies of the batches to be picked.
  *
- * \return The expression of picked batch. The picked batch is a tensor
+ * \return The expression of picked batches. The picked batches is a tensor
  *         whose `bd` equals to the size of vector `v`.
  */
-Expression pick_batch(const Expression& x, const std::vector<unsigned> & v);
+Expression pick_batches(const Expression& x, const std::vector<unsigned> & v);
 
 /**
  * \ingroup flowoperations

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1343,6 +1343,33 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u);
 
 /**
  * \ingroup flowoperations
+ * \brief Pick a batch from the expression.
+ * \details Pick a batch from the expression.
+ *
+ * \param x The input expression
+ * \param v The beginning index
+ *
+ * \return The expression of picked batch. The picked batch is a tensor
+ *         whose `bd` equals to one.
+ */
+Expression pick_batch(const Expression& x, unsigned v);
+
+/**
+ * \ingroup flowoperations
+ * \brief Batched pick
+ * \details Pick elements from multiple batches.
+ *
+ * \param x The input expression
+ * \param v A vector of indicies to choose, one for each batch in the
+ *          input expression.
+ *
+ * \return The expression of picked batch. The picked batch is a tensor
+ *         whose `bd` equals to the size of vector `v`.
+ */
+Expression pick_batch(const Expression& x, const std::vector<unsigned> & v);
+
+/**
+ * \ingroup flowoperations
  * \brief Concatenate columns
  * \details Perform a concatenation of the columns in multiple expressions.
  *          All expressions must have the same number of rows.

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -650,6 +650,39 @@ Dim PickRange::dim_forward(const vector<Dim>& xs) const {
   return Dim({end - start}, xs[0].bd);
 }
 
+string PickBatch::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "pick_batch(" << arg_names[0] << ',';
+  if (pval) {
+    s << *pval;
+  } else {
+    DYNET_ASSERT(pvals, "Have neither index nor index vector in PickBatch");
+    s << '[';
+    if (pvals->size()) {
+      s << (*pvals)[0];
+      for (size_t i = 1; i < pvals->size(); ++i)
+        s << ',' << (*pvals)[i];
+    }
+    s << "]";
+  }
+  s << ")";
+  return s.str();
+}
+
+Dim PickBatch::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickBatch")
+  if (xs[0].nd >= 4)
+    DYNET_INVALID_ARG("PickElement not currently supported for tensors of 4 or more dimensions.");
+  Dim ret(xs[0]);
+  if (pval) {
+    // set batch size to one.
+    ret.bd = 1;
+  } else {
+    ret.bd = pvals->size();
+  }
+  return ret;
+}
+
 string MatrixMultiply::as_string(const vector<string>& arg_names) const {
   ostringstream s;
   s << arg_names[0] << " * " << arg_names[1];

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -689,6 +689,7 @@ Dim PickBatch::dim_forward(const vector<Dim>& xs) const {
     // set batch size to one.
     ret.bd = 1;
   } else {
+    DYNET_ASSERT(pvals, "Have neither index nor index vector in PickBatch");
     ret.bd = pvals->size();
   }
   return ret;

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -526,6 +526,17 @@ struct PickRange : public Node {
   unsigned end;
 };
 
+struct PickBatch : public Node {
+  explicit PickBatch(const std::initializer_list<VariableIndex>& a, unsigned v) : Node(a), val(v), pval(&val), vals(), pvals() {}
+  explicit PickBatch(const std::initializer_list<VariableIndex>& a, const std::vector<unsigned>& v) : Node(a), val(), pval(), vals(v), pvals(&vals) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return false; }
+  unsigned val;
+  const unsigned* pval;
+  std::vector<unsigned> vals;
+  const std::vector<unsigned>* pvals;
+};
+
 // represents a simple vector of 0s
 struct Zeroes : public Node {
   explicit Zeroes(const Dim& d) : dim(d) {}

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -533,11 +533,13 @@ struct PickRange : public Node {
   unsigned end;
 };
 
+// x_1 is a multibatch vector
+// y = (x_1)_{[*pval]}
 struct PickBatch : public Node {
   explicit PickBatch(const std::initializer_list<VariableIndex>& a, unsigned v) : Node(a), val(v), pval(&val), vals(), pvals() {}
   explicit PickBatch(const std::initializer_list<VariableIndex>& a, const std::vector<unsigned>& v) : Node(a), val(), pval(), vals(v), pvals(&vals) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
-  virtual bool supports_multibatch() const override { return false; }
+  virtual bool supports_multibatch() const override { return true; /* for the pick_batches, multibatch should be supported.*/ }
   unsigned val;
   const unsigned* pval;
   std::vector<unsigned> vals;

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT MSVC)
    set(MP_EXAMPLES rnnlm-mp xor-mp xor-simple-mp)
 endif()
 
-foreach(FOLDER encdec mlc mnist tok-embed poisson-regression tag-bilstm embed-cl xor xor-xent xor-batch xor-batch-lookup rnnlm rnnlm-aevb rnnlm-cfsm rnnlm-batch nlm textcat read-write segrnn-sup attention ${MP_EXAMPLES})
+foreach(FOLDER encdec mlc mnist tok-embed poisson-regression tag-bilstm embed-cl xor xor-xent xor-batch xor-batch-lookup rnnlm rnnlm-aevb rnnlm-cfsm rnnlm-batch nlm textcat read-write segrnn-sup attention imdb ${MP_EXAMPLES})
   set(TARGET train_${FOLDER})
   ADD_EXECUTABLE(${TARGET} cpp/${FOLDER}/${TARGET}.cc)
   if (WITH_CUDA_BACKEND)

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -1,0 +1,311 @@
+/**
+ * An implementation of [Document Modeling with Gated Recurrent Neural
+ * Network for Sentiment Classification](http://aclweb.org/anthology/D15-1167)
+ * using `pick_batch`.
+ * 
+ * The model in use a bidirectional GRU to represents every sentence in the
+ * document and feed the sentence representations into the another bi-GRU
+ * to get the final representation of the document.
+ *
+ * This implementation compiles each i-th words in the sentences into a batch
+ * (like that in the rnnlm-batch) and use `pick_batch` to get last representation
+ * in corresponding batch.
+ *
+ * On a small proportion of the IMDB data (2500 for training, 500 for dev.), this
+ * model achieves 80% accuracy on two-way classification.
+ */
+#include "dynet/nodes.h"
+#include "dynet/dynet.h"
+#include "dynet/training.h"
+#include "dynet/timing.h"
+#include "dynet/rnn.h"
+#include "dynet/gru.h"
+#include "dynet/lstm.h"
+#include "dynet/dict.h"
+#include "dynet/expr.h"
+#include "dynet/globals.h"
+#include "../utils/getpid.h"
+
+#include <iostream>
+#include <fstream>
+
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+
+using namespace std;
+using namespace dynet;
+
+unsigned INPUT_DIM = 100;
+unsigned SENTENCE_DIM = 200;
+unsigned DOCUMENT_DIM = 400;
+unsigned HIDDEN_DIM = 200;
+unsigned VOCAB_SIZE = 0;
+unsigned LABEL_SIZE = 0;
+unsigned N_LAYERS = 1;
+
+dynet::Dict d;
+dynet::Dict ld;
+int kSOS;
+int kEOS;
+
+typedef std::vector<std::vector<int>> Document;
+typedef std::pair<Document, int> Instance;
+
+struct DocumentModel {
+  LookupParameter p_w;
+  GRUBuilder fwd_sent_builder;
+  GRUBuilder bwd_sent_builder;
+  GRUBuilder fwd_doc_builder;
+  GRUBuilder bwd_doc_builder;
+  Parameter p_d2h;
+  Parameter p_hbias;
+  Parameter p_h2o;
+  Parameter p_obias;
+
+  DocumentModel(Model & m) :
+    p_w(m.add_lookup_parameters(VOCAB_SIZE, { INPUT_DIM })),
+    fwd_sent_builder(N_LAYERS, INPUT_DIM, SENTENCE_DIM, m),
+    bwd_sent_builder(N_LAYERS, INPUT_DIM, SENTENCE_DIM, m),
+    fwd_doc_builder(N_LAYERS, SENTENCE_DIM * 2, DOCUMENT_DIM, m),
+    bwd_doc_builder(N_LAYERS, SENTENCE_DIM * 2, DOCUMENT_DIM, m),
+    p_d2h(m.add_parameters({ HIDDEN_DIM , DOCUMENT_DIM * 2 })),
+    p_hbias(m.add_parameters({ HIDDEN_DIM })),
+    p_h2o(m.add_parameters({ LABEL_SIZE, HIDDEN_DIM })),
+    p_obias(m.add_parameters({ LABEL_SIZE })) {
+  }
+
+  Expression classify(ComputationGraph & cg, Instance & inst) {
+    unsigned n_sents = inst.first.size();
+    std::vector<Expression> sent_repr(n_sents);
+    get_sentence_repr(cg, inst, sent_repr);
+    Expression doc_repr = get_document_repr(cg, sent_repr);
+    Expression logits = get_logits(cg, doc_repr);
+    return logits;
+  }
+  
+  Expression objective(ComputationGraph & cg, Instance & inst, Expression & logits) {
+    return pickneglogsoftmax(logits, inst.second);
+  }
+
+  unsigned predict(ComputationGraph & cg, Instance & inst) {
+    Expression logits = classify(cg, inst);
+    std::vector<float> pred = dynet::as_vector(cg.get_value(logits));
+    return std::max_element(pred.begin(), pred.end()) - pred.begin();
+  }
+
+  unsigned get_max_steps(const Instance & inst) {
+    unsigned max_steps = 0;
+    for (const auto & sentence : inst.first) {
+      if (max_steps < sentence.size()) { max_steps = sentence.size(); }
+    }
+    return max_steps;
+  }
+
+  void get_sentence_repr(ComputationGraph & cg,
+                         const Instance & inst, 
+                         std::vector<Expression> & sent_repr) {
+    unsigned max_steps = get_max_steps(inst);
+    unsigned n_sents = inst.first.size();
+    std::vector<unsigned> fwd_last(n_sents);
+    std::vector<unsigned> bwd_last(n_sents);
+    sent_repr.resize(n_sents);
+
+    fwd_sent_builder.new_graph(cg);
+    bwd_sent_builder.new_graph(cg);
+    fwd_sent_builder.start_new_sequence();
+    bwd_sent_builder.start_new_sequence();
+    for (unsigned i = 0; i < max_steps; ++i) {
+      for (unsigned b = 0; b < n_sents; ++b) {
+        const std::vector<int> & sent = inst.first[b];
+        fwd_last[b] = (i < sent.size() ? sent[i] : kEOS);
+        bwd_last[b] = (i < sent.size() ? sent[sent.size() - 1 - i] : kSOS);
+      }
+      Expression fwd_i = lookup(cg, p_w, fwd_last);
+      Expression bwd_i = lookup(cg, p_w, bwd_last);
+      Expression fwd_output = fwd_sent_builder.add_input(fwd_i);
+      Expression bwd_output = bwd_sent_builder.add_input(bwd_i);
+      for (unsigned b = 0; b < n_sents; ++b) {
+        const std::vector<int> & sent = inst.first[b];
+        if (i + 1 == sent.size()) {
+          sent_repr[b] = concatenate({ pick_batch(fwd_output, b), pick_batch(bwd_output, b) });
+        }
+      }
+    }
+  }
+
+  Expression get_document_repr(ComputationGraph & cg,
+                               std::vector<Expression> & sent_expr) {
+    unsigned n_sents = sent_expr.size();
+    fwd_doc_builder.new_graph(cg);
+    bwd_doc_builder.new_graph(cg);
+    fwd_doc_builder.start_new_sequence();
+    bwd_doc_builder.start_new_sequence();
+    for (unsigned i = 0; i < n_sents; ++i) {
+      fwd_doc_builder.add_input(sent_expr[i]);
+      bwd_doc_builder.add_input(sent_expr[n_sents - 1 - i]);
+    }
+
+    return concatenate({ fwd_doc_builder.back(), bwd_doc_builder.back() });
+  }
+
+  Expression get_logits(ComputationGraph & cg, Expression & doc_repr) {
+    Expression h = rectify(parameter(cg, p_hbias) + parameter(cg, p_d2h) * doc_repr);
+    Expression logits = parameter(cg, p_obias) + parameter(cg, p_h2o) * h;
+    return logits;
+  }
+};
+
+void read_one_line(const string & line, Instance & inst, Dict & wd, Dict & td) {
+  istringstream in(line);
+  string token;
+  string label_doc_sep = "|||";
+  string sent_sep = "|";
+  Dict * d = &td; // first read the tags.
+  std::vector<int> sentence;
+  bool reading_label = true;
+  while (in) {
+    in >> token;
+    if (!in) { break; }
+    if (token == label_doc_sep) { reading_label = false; continue; }
+    if (reading_label) {
+      inst.second = td.convert(token);
+    } else {
+      if (token == sent_sep) { inst.first.push_back(sentence); sentence.clear(); }
+      else { sentence.push_back(wd.convert(token)); }
+    }
+  }
+  if (sentence.size() > 0) { inst.first.push_back(sentence); }
+}
+
+int main(int argc, char** argv) {
+  dynet::initialize(argc, argv);
+  if (argc != 3 && argc != 4) {
+    cerr << "Usage: " << argv[0] << " corpus.txt dev.txt [model.params]\n";
+    return 1;
+  }
+  kSOS = d.convert("<s>");
+  kEOS = d.convert("</s>");
+  vector<Instance> training, dev;
+  string line;
+  int tlc = 0;
+  int tsents = 0;
+  int ttoks = 0;
+  cerr << "Reading training data from " << argv[1] << "...\n";
+  {
+    ifstream in(argv[1]);
+    assert(in);
+    while (getline(in, line)) {
+      ++tlc;
+      Instance inst;
+      read_one_line(line, inst, d, ld);
+      training.push_back(inst);
+      for (auto & sent : inst.first) { ttoks += sent.size(); }
+      tsents += inst.first.size();
+    }
+    cerr << tlc << " lines, " << tsents << " sentences, " << ttoks << " tokens, " << d.size() << " types\n";
+    cerr << "Labels: " << ld.size() << endl;
+  }
+  LABEL_SIZE = ld.size();
+  d.freeze(); // no new word types allowed
+  d.set_unk("_unk_");
+  ld.freeze(); // no new tag types allowed
+
+  int dlc = 0;
+  int dsents = 0;
+  int dtoks = 0;
+  cerr << "Reading dev data from " << argv[2] << "...\n";
+  {
+    ifstream in(argv[2]);
+    assert(in);
+    while (getline(in, line)) {
+      ++dlc;
+      Instance inst;
+      read_one_line(line, inst, d, ld);
+      dev.push_back(inst);
+      for (auto & sent : inst.first) { dtoks += sent.size(); }
+      dsents += inst.first.size();
+    }
+    cerr << dlc << " lines, " << dsents << " sentences, " << dtoks << " tokens\n";
+  }
+  VOCAB_SIZE = d.size();
+  ostringstream os;
+  os << "imdb"
+    << '_' << INPUT_DIM
+    << '_' << SENTENCE_DIM
+    << '_' << DOCUMENT_DIM
+    << '_' << HIDDEN_DIM
+    << "-pid" << getpid() << ".params";
+  const string fname = os.str();
+  cerr << "Parameters will be written to: " << fname << endl;
+  double best = 9e+99;
+
+  Model model;
+  Trainer* sgd = nullptr;
+  sgd = new AdamTrainer(model);
+
+  DocumentModel engine(model);
+
+  unsigned report_every_i = min(100, int(training.size()));
+  unsigned dev_every_i_reports = 25;
+  unsigned si = training.size();
+  vector<unsigned> order(training.size());
+  for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
+  bool first = true;
+  int report = 0;
+  unsigned lines = 0;
+  while (1) {
+    Timer iteration("completed in");
+    double loss = 0;
+    unsigned ttags = 0;
+    unsigned correct = 0;
+    for (unsigned i = 0; i < report_every_i; ++i) {
+      if (si == training.size()) {
+        si = 0;
+        if (first) { first = false; } else { sgd->update_epoch(); }
+        cerr << "**SHUFFLE\n";
+        shuffle(order.begin(), order.end(), *rndeng);
+      }
+
+      // build graph for this instance
+      ComputationGraph cg;
+      auto& inst = training[order[si]];
+      ++si;
+      //cerr << "LINE: " << order[si] << endl;
+      Expression logits = engine.classify(cg, inst);
+      std::vector<float> pred = dynet::as_vector(cg.get_value(logits));
+      unsigned y_pred = std::max_element(pred.begin(), pred.end()) - pred.begin();
+      if (y_pred == inst.second) { correct ++; }
+      Expression loss_expr = engine.objective(cg, inst, logits);
+      loss += as_scalar(cg.forward(loss_expr));
+      cg.backward(loss_expr);
+      sgd->update(1.0);
+      ++lines;
+      ++ttags;
+    }
+    sgd->status();
+    cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / (double)ttags) << ") ";
+    model.project_weights();
+
+    // show score on dev data?
+    report++;
+    if (report % dev_every_i_reports == 0) {
+      double dloss = 0;
+      unsigned dtags = 0;
+      unsigned dcorr = 0;
+      for (auto& inst : dev) {
+        ComputationGraph cg;
+        unsigned y_pred = engine.predict(cg, inst);
+        if (y_pred == inst.second) dcorr++;
+        dtags++;
+      }
+      if (dloss < best) {
+        best = dloss;
+        ofstream out(fname);
+        boost::archive::text_oarchive oa(out);
+        oa << model;
+      }
+      cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / (double)dtags) << ' ';
+    }
+  }
+  delete sgd;
+}

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -918,6 +918,15 @@ BOOST_AUTO_TEST_CASE( pick_batch_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression pick_batch(const Expression& x, unsigned v);
+BOOST_AUTO_TEST_CASE( pick_batch_gradient1 ) {
+  unsigned idx = 0;
+  dynet::ComputationGraph cg;
+  Expression x1 = input(cg, Dim({ 3 }, 2), batch_vals);
+  Expression z = sum_rows(pick_batch(x1, idx));
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 // Expression pickrange(const Expression& x, unsigned v, unsigned u);
 BOOST_AUTO_TEST_CASE( pickrange_gradient ) {
   dynet::ComputationGraph cg;

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -911,6 +911,19 @@ BOOST_AUTO_TEST_CASE( pick_batch_gradient1 ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression pick_batches(const Expression& x, cosnt std::vector<unsigned> & v);
+BOOST_AUTO_TEST_CASE( pick_batches_gradient ) {
+  dynet::ComputationGraph cg;
+  std::vector<unsigned> indices = { 0, 1 };
+  Expression x1 = input(cg, Dim({ 3 }, 2), batch_vals);
+  Expression picked_x1 = pick_batches(x1, indices);
+  Expression z = sum({
+    sum_rows(pick_batch(picked_x1, 0)),
+    sum_rows(pick_batch(picked_x1, 1))
+  });
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 // Expression pickrange(const Expression& x, unsigned v, unsigned u);
 BOOST_AUTO_TEST_CASE( pickrange_gradient ) {
   dynet::ComputationGraph cg;


### PR DESCRIPTION
This PR includes

* implementation of `PickBatch` function and  `pick_batch` expression.
* test case for pick_batch
* an example that doing document classification on IMDB dataset.

Example:
For a Tensor with 4 batches:
```
[[0 1 2] [3 4 5]]
[[6 7 8] [9 10 11]]
[[12 13 14] [15 16 17]]
[[18 19 20] [21 22 23]]
```
`pick_batch(t, 1)` will return a Tensor of
```
[[6 7 8] [9 10 11]]
```
`pick_batch(t, {1, 2})` will return a Tensor of
```
[[6 7 8] [9 10 11]]
[[12 13 14] [15 16 17]]
```

Details:
Implementation basically follows the implementation of `PickElement` function which broadcast the Tensor with `tb()` and select the last row (batch row) with `chip` function.