### PR TITLE
configurable error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,6 +127,11 @@ endif()
 # echo "export BOOST_ROOT=/cygdrive/d/tools/boost_1_58_0/boost_1_58_0" >> ~/.bashrc
 # then run source ~/.bashrc to have those environment variable effective immediately
 
+if (NOT DEFINED DYNET_DEBUG_LEVEL)
+  set(DYNET_DEBUG_LEVEL 1)
+endif()
+add_definitions(-DDYNET_DEBUG_LEVEL=${DYNET_DEBUG_LEVEL})
+
 if(BACKEND)
   message("-- BACKEND: ${BACKEND}")
 else()

--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -94,8 +94,8 @@ void ClassFactoredSoftmaxBuilder::new_graph(ComputationGraph& cg) {
 Expression ClassFactoredSoftmaxBuilder::neg_log_softmax(const Expression& rep, unsigned wordidx) {
   // TODO check that new_graph has been called
   int clusteridx = widx2cidx[wordidx];
-  if(clusteridx < 0)
-    DYNET_INVALID_ARG("Word ID " << wordidx << " missing from clusters in ClassFactoredSoftmaxBuilder::neg_log_softmax");
+  DYNET_INVALID_ARG_CHECK(clusteridx < 0,
+                          "Word ID " << wordidx << " missing from clusters in ClassFactoredSoftmaxBuilder::neg_log_softmax");
   Expression cscores = affine_transform({cbias, r2c, rep});
   Expression cnlp = pickneglogsoftmax(cscores, clusteridx);
   if (singleton_cluster[clusteridx]) return cnlp;

--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -94,7 +94,7 @@ void ClassFactoredSoftmaxBuilder::new_graph(ComputationGraph& cg) {
 Expression ClassFactoredSoftmaxBuilder::neg_log_softmax(const Expression& rep, unsigned wordidx) {
   // TODO check that new_graph has been called
   int clusteridx = widx2cidx[wordidx];
-  DYNET_INVALID_ARG_CHECK(clusteridx < 0,
+  DYNET_INVALID_ARG_CHECK(clusteridx >= 0,
                           "Word ID " << wordidx << " missing from clusters in ClassFactoredSoftmaxBuilder::neg_log_softmax");
   Expression cscores = affine_transform({cbias, r2c, rep});
   Expression cnlp = pickneglogsoftmax(cscores, clusteridx);

--- a/dynet/deep-lstm.cc
+++ b/dynet/deep-lstm.cc
@@ -74,7 +74,7 @@ void DeepLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    DYNET_INVALID_ARG_CHECK(layers * 2 != hinit.size(),
+    DYNET_INVALID_ARG_CHECK(layers * 2 == hinit.size(),
                             "DeepLSTMBuilder must be initialized with 2 times as many expressions as layers "
                             "(hidden state and cell for each layer). However, for " << layers << " layers, "
                             << hinit.size() << " expressions were passed in");

--- a/dynet/deep-lstm.cc
+++ b/dynet/deep-lstm.cc
@@ -74,8 +74,10 @@ void DeepLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    if(layers * 2 != hinit.size())
-      DYNET_INVALID_ARG("DeepLSTMBuilder must be initialized with 2 times as many expressions as layers (hidden state and cell for each layer). However, for " << layers << " layers, " << hinit.size() << " expressions were passed in");
+    DYNET_INVALID_ARG_CHECK(layers * 2 != hinit.size(),
+                            "DeepLSTMBuilder must be initialized with 2 times as many expressions as layers "
+                            "(hidden state and cell for each layer). However, for " << layers << " layers, "
+                            << hinit.size() << " expressions were passed in");
     h0.resize(layers);
     c0.resize(layers);
     for (unsigned i = 0; i < layers; ++i) {

--- a/dynet/dict.h
+++ b/dynet/dict.h
@@ -46,7 +46,7 @@ public:
   }
   
   inline const std::string& convert(const int& id) const {
-    DYNET_INVALID_ARG_CHECK(id >= (int)words_.size(), 
+    DYNET_INVALID_ARG_CHECK(id < (int)words_.size(), 
                             "Out-of-bounds error in Dict::convert for word ID " << id <<
                             " (dict size: " << words_.size() << ")");
     return words_[id];

--- a/dynet/dict.h
+++ b/dynet/dict.h
@@ -46,8 +46,9 @@ public:
   }
   
   inline const std::string& convert(const int& id) const {
-    if(id >= (int)words_.size())
-      DYNET_INVALID_ARG("Out-of-bounds error in Dict::convert for word ID " << id << " (dict size: " << words_.size() << ")");
+    DYNET_INVALID_ARG_CHECK(id >= (int)words_.size(), 
+                            "Out-of-bounds error in Dict::convert for word ID " << id <<
+                            " (dict size: " << words_.size() << ")");
     return words_[id];
   }
   

--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -161,10 +161,8 @@ struct Dim {
    * \param s Dimension size
    */
   inline void set(unsigned int i, unsigned int s) {
-    if(i >= nd)
-      DYNET_INVALID_ARG("Out of bounds exception in Dim::set("<<i<<","<<s<<") for node of size " << d);
-    if(s == 0)
-      DYNET_INVALID_ARG("Attempt to set dimension size to zero in Dim::set("<<i<<","<<s<<") for node of size " << d);
+    DYNET_INVALID_ARG_CHECK(i >= nd, "Out of bounds exception in Dim::set(" << i << "," << s << ") for node of size " << d);
+    DYNET_INVALID_ARG_CHECK(s == 0, "Attempt to set dimension size to zero in Dim::set(" << i << "," << s << ") for node of size " << d);
     d[i] = s;
   }
   /**
@@ -186,8 +184,7 @@ struct Dim {
    * \param i index of the dimension to be removed
    */
   inline void delete_dim(unsigned int i) {
-    if(i >= nd)
-      DYNET_INVALID_ARG("Out of bounds exception in Dim::delete_dim("<<i<<") for node of size " << d);
+    DYNET_INVALID_ARG_CHECK(i >= nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << d);
     if (nd == 1) {
       d[0] = 1;
     } else {

--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -161,8 +161,8 @@ struct Dim {
    * \param s Dimension size
    */
   inline void set(unsigned int i, unsigned int s) {
-    DYNET_INVALID_ARG_CHECK(i >= nd, "Out of bounds exception in Dim::set(" << i << "," << s << ") for node of size " << d);
-    DYNET_INVALID_ARG_CHECK(s == 0, "Attempt to set dimension size to zero in Dim::set(" << i << "," << s << ") for node of size " << d);
+    DYNET_INVALID_ARG_CHECK(i < nd, "Out of bounds exception in Dim::set(" << i << "," << s << ") for node of size " << d);
+    DYNET_INVALID_ARG_CHECK(s != 0, "Attempt to set dimension size to zero in Dim::set(" << i << "," << s << ") for node of size " << d);
     d[i] = s;
   }
   /**
@@ -184,7 +184,7 @@ struct Dim {
    * \param i index of the dimension to be removed
    */
   inline void delete_dim(unsigned int i) {
-    DYNET_INVALID_ARG_CHECK(i >= nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << d);
+    DYNET_INVALID_ARG_CHECK(i < nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << d);
     if (nd == 1) {
       d[0] = 1;
     } else {

--- a/dynet/except.h
+++ b/dynet/except.h
@@ -34,11 +34,11 @@ class cuda_exception : public std::runtime_error {
     throw std::invalid_argument(oss.str()); \
   } while (0);
 
-  #define DYNET_INVALID_ARG_CHECK(cond, msg) do {  \
-    if (cond) {                                    \
-      std::ostringstream oss;                      \
-      oss << msg;                                  \
-      throw std::invalid_argument(oss.str()); }    \
+  #define DYNET_INVALID_ARG_CHECK(cond, msg) do { \
+    if (!(cond)) {                                \
+      std::ostringstream oss;                     \
+      oss << msg;                                 \
+      throw std::invalid_argument(oss.str()); }   \
   } while (0);
 
   #define DYNET_ASSERT(expr, msg)
@@ -56,7 +56,7 @@ class cuda_exception : public std::runtime_error {
   } while (0);
 
   #define DYNET_INVALID_ARG_CHECK(cond, msg) do { \
-    if (cond) {                                   \
+    if (!(cond)) {                                \
       std::ostringstream oss;                     \
       oss << msg;                                 \
       throw std::invalid_argument(oss.str()); }   \

--- a/dynet/except.h
+++ b/dynet/except.h
@@ -27,14 +27,14 @@ class cuda_exception : public std::runtime_error {
 };
 } // namespace dynet
 
-#if !defined(DYNET_DEBUG_LEVEL) || DYNET_DEBUG_LEVEL == 1
-  #define DYNET_INVALID_ARG(msg) do {      \
+#if DYNET_DEBUG_LEVEL == 1
+#define DYNET_INVALID_ARG(msg) do {         \
     std::ostringstream oss;                 \
     oss << msg;                             \
     throw std::invalid_argument(oss.str()); \
   } while (0);
 
-  #define DYNET_INVALID_ARG_CHECK(cond, msg) do { \
+  #define DYNET_INVALID_ARG_CHECK(cond, msg) do {  \
     if (cond) {                                    \
       std::ostringstream oss;                      \
       oss << msg;                                  \
@@ -44,7 +44,7 @@ class cuda_exception : public std::runtime_error {
   #define DYNET_ASSERT(expr, msg)
 
 #elif DYNET_DEBUG_LEVEL == 0
-  #define DYNET_INVALID_ARG(msg)
+  #define DYNET_INVALID_ARG(msg) 
   #define DYNET_INVALID_ARG_CHECK(cond, msg)
   #define DYNET_ASSERT(expr, msg)
 

--- a/dynet/except.h
+++ b/dynet/except.h
@@ -27,18 +27,48 @@ class cuda_exception : public std::runtime_error {
 };
 } // namespace dynet
 
-#define DYNET_INVALID_ARG(msg) do {             \
-    std::ostringstream oss;                     \
-    oss << msg;                                 \
-    throw std::invalid_argument(oss.str()); }   \
-  while (0);
-
-#define DYNET_ASSERT(expr, msg) do {            \
-  if(!(expr)) {                                  \
-    std::ostringstream oss;                     \
-    oss << msg;                                 \
-    throw std::runtime_error(oss.str()); }      \
+#if !defined(DYNET_DEBUG_LEVEL) || DYNET_DEBUG_LEVEL == 1
+  #define DYNET_INVALID_ARG(msg) do {      \
+    std::ostringstream oss;                 \
+    oss << msg;                             \
+    throw std::invalid_argument(oss.str()); \
   } while (0);
+
+  #define DYNET_INVALID_ARG_CHECK(cond, msg) do { \
+    if (cond) {                                    \
+      std::ostringstream oss;                      \
+      oss << msg;                                  \
+      throw std::invalid_argument(oss.str()); }    \
+  } while (0);
+
+  #define DYNET_ASSERT(expr, msg)
+
+#elif DYNET_DEBUG_LEVEL == 0
+  #define DYNET_INVALID_ARG(msg)
+  #define DYNET_INVALID_ARG_CHECK(cond, msg)
+  #define DYNET_ASSERT(expr, msg)
+
+#else
+  #define DYNET_INVALID_ARG(msg) do {       \
+    std::ostringstream oss;                 \
+    oss << msg;                             \
+    throw std::invalid_argument(oss.str()); \
+  } while (0);
+
+  #define DYNET_INVALID_ARG_CHECK(cond, msg) do { \
+    if (cond) {                                   \
+      std::ostringstream oss;                     \
+      oss << msg;                                 \
+      throw std::invalid_argument(oss.str()); }   \
+  } while (0);
+
+  #define DYNET_ASSERT(expr, msg) do {       \
+    if(!(expr)) {                            \
+      std::ostringstream oss;                \
+      oss << msg;                            \
+      throw std::runtime_error(oss.str()); } \
+  } while (0);
+#endif
 
 #define DYNET_RUNTIME_ERR(msg) do {             \
     std::ostringstream oss;                     \

--- a/dynet/fast-lstm.cc
+++ b/dynet/fast-lstm.cc
@@ -79,7 +79,7 @@ void FastLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    DYNET_INVALID_ARG_CHECK(layers * 2 != hinit.size(),
+    DYNET_INVALID_ARG_CHECK(layers * 2 == hinit.size(),
                             "FastLSTMBuilder must be initialized with 2 times as many expressions as layers "
                             "(hidden state and cell for each layer). However, for " << layers << 
                             " layers, " << hinit.size() << " expressions were passed in");
@@ -100,7 +100,7 @@ void FastLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
 // Also is creating a new step something we want? 
 // wouldn't overwriting the current one be better?
 Expression FastLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  DYNET_INVALID_ARG_CHECK(h_new.size() && h_new.size() != layers,
+  DYNET_INVALID_ARG_CHECK(!(h_new.size() && h_new.size() != layers),
                           "FastLSTMBuilder::set_h expects as many inputs as layers, "
                           "but got " << h_new.size() << " inputs for " << layers << " layers");
   const unsigned t = h.size();
@@ -117,7 +117,7 @@ Expression FastLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new
 // Current implementation : s_new is either {new_c[0],...,new_c[n]}
 // or {new_c[0],...,new_c[n],new_h[0],...,new_h[n]}
 Expression FastLSTMBuilder::set_s_impl(int prev, const std::vector<Expression>& s_new) {
-  DYNET_INVALID_ARG_CHECK(s_new.size() == layers || s_new.size() == 2 * layers,
+  DYNET_INVALID_ARG_CHECK(!(s_new.size() == layers || s_new.size() == 2 * layers),
                           "FastLSTMBuilder::set_s expects either as many inputs or twice as many "
                           "inputs as layers, but got " << s_new.size() << " inputs for " << layers << " layers");
   bool only_c = s_new.size() == layers;
@@ -205,7 +205,7 @@ Expression FastLSTMBuilder::add_input_impl(int prev, const Expression& x) {
 
 void FastLSTMBuilder::copy(const RNNBuilder & rnn) {
   const FastLSTMBuilder & rnn_lstm = (const FastLSTMBuilder&)rnn;
-  DYNET_INVALID_ARG_CHECK(params.size() != rnn_lstm.params.size(),
+  DYNET_INVALID_ARG_CHECK(params.size() == rnn_lstm.params.size(),
                           "Attempt to copy FastLSTMBuilder with different number of parameters "
                           "(" << params.size() << " != " << rnn_lstm.params.size() << ")");
   for(size_t i = 0; i < params.size(); ++i)

--- a/dynet/fast-lstm.cc
+++ b/dynet/fast-lstm.cc
@@ -79,8 +79,10 @@ void FastLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    if(layers * 2 != hinit.size())
-      DYNET_INVALID_ARG("FastLSTMBuilder must be initialized with 2 times as many expressions as layers (hidden state and cell for each layer). However, for " << layers << " layers, " << hinit.size() << " expressions were passed in");
+    DYNET_INVALID_ARG_CHECK(layers * 2 != hinit.size(),
+                            "FastLSTMBuilder must be initialized with 2 times as many expressions as layers "
+                            "(hidden state and cell for each layer). However, for " << layers << 
+                            " layers, " << hinit.size() << " expressions were passed in");
     h0.resize(layers);
     c0.resize(layers);
     for (unsigned i = 0; i < layers; ++i) {
@@ -98,9 +100,9 @@ void FastLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
 // Also is creating a new step something we want? 
 // wouldn't overwriting the current one be better?
 Expression FastLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  if (h_new.size() && h_new.size() != layers)
-    DYNET_INVALID_ARG("FastLSTMBuilder::set_h expects as many inputs as layers, but got " <<
-                      h_new.size() << " inputs for " << layers << " layers");
+  DYNET_INVALID_ARG_CHECK(h_new.size() && h_new.size() != layers,
+                          "FastLSTMBuilder::set_h expects as many inputs as layers, "
+                          "but got " << h_new.size() << " inputs for " << layers << " layers");
   const unsigned t = h.size();
   h.push_back(vector<Expression>(layers));
   c.push_back(vector<Expression>(layers));
@@ -115,9 +117,9 @@ Expression FastLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new
 // Current implementation : s_new is either {new_c[0],...,new_c[n]}
 // or {new_c[0],...,new_c[n],new_h[0],...,new_h[n]}
 Expression FastLSTMBuilder::set_s_impl(int prev, const std::vector<Expression>& s_new) {
-  if (s_new.size() == layers || s_new.size() == 2 * layers)
-    DYNET_INVALID_ARG("FastLSTMBuilder::set_s expects either as many inputs or twice as many inputs as layers, but got " <<
-                      s_new.size() << " inputs for " << layers << " layers");
+  DYNET_INVALID_ARG_CHECK(s_new.size() == layers || s_new.size() == 2 * layers,
+                          "FastLSTMBuilder::set_s expects either as many inputs or twice as many "
+                          "inputs as layers, but got " << s_new.size() << " inputs for " << layers << " layers");
   bool only_c = s_new.size() == layers;
   const unsigned t = c.size();
   h.push_back(vector<Expression>(layers));
@@ -203,8 +205,9 @@ Expression FastLSTMBuilder::add_input_impl(int prev, const Expression& x) {
 
 void FastLSTMBuilder::copy(const RNNBuilder & rnn) {
   const FastLSTMBuilder & rnn_lstm = (const FastLSTMBuilder&)rnn;
-  if(params.size() != rnn_lstm.params.size())
-    DYNET_INVALID_ARG("Attempt to copy FastLSTMBuilder with different number of parameters (" << params.size() << " != " << rnn_lstm.params.size() << ")")
+  DYNET_INVALID_ARG_CHECK(params.size() != rnn_lstm.params.size(),
+                          "Attempt to copy FastLSTMBuilder with different number of parameters "
+                          "(" << params.size() << " != " << rnn_lstm.params.size() << ")");
   for(size_t i = 0; i < params.size(); ++i)
       for(size_t j = 0; j < params[i].size(); ++j)
         params[i][j] = rnn_lstm.params[i][j];

--- a/dynet/gru.cc
+++ b/dynet/gru.cc
@@ -69,15 +69,15 @@ void GRUBuilder::new_graph_impl(ComputationGraph& cg) {
 void GRUBuilder::start_new_sequence_impl(const std::vector<Expression>& h_0) {
   h.clear();
   h0 = h_0;
-  if (!h0.empty() && h0.size() != layers)
-    DYNET_INVALID_ARG("Number of inputs passed to initialize GRUBuilder (" << h0.size() <<
-                      ") is not equal to the number of layers (" << layers << ")");
+  DYNET_INVALID_ARG_CHECK(!h0.empty() && h0.size() != layers,
+                          "Number of inputs passed to initialize GRUBuilder (" << h0.size() << ") "
+                          "is not equal to the number of layers (" << layers << ")");
 }
 
 Expression GRUBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  if (h_new.size() && h_new.size() != layers)
-  DYNET_INVALID_ARG("Number of inputs passed to RNNBuilder::set_h() (" << h_new.size() <<
-                    ") is not equal to the number of layers (" << layers << ")");
+  DYNET_INVALID_ARG_CHECK(h_new.size() && h_new.size() != layers,
+                          "Number of inputs passed to RNNBuilder::set_h() (" << h_new.size() << ") "
+                          "is not equal to the number of layers (" << layers << ")");
   const unsigned t = h.size();
   h.push_back(vector<Expression>(layers));
   for (unsigned i = 0; i < layers; ++i) {

--- a/dynet/gru.cc
+++ b/dynet/gru.cc
@@ -69,13 +69,13 @@ void GRUBuilder::new_graph_impl(ComputationGraph& cg) {
 void GRUBuilder::start_new_sequence_impl(const std::vector<Expression>& h_0) {
   h.clear();
   h0 = h_0;
-  DYNET_INVALID_ARG_CHECK(!h0.empty() && h0.size() != layers,
+  DYNET_INVALID_ARG_CHECK(h0.empty() || h0.size() == layers,
                           "Number of inputs passed to initialize GRUBuilder (" << h0.size() << ") "
                           "is not equal to the number of layers (" << layers << ")");
 }
 
 Expression GRUBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  DYNET_INVALID_ARG_CHECK(h_new.size() && h_new.size() != layers,
+  DYNET_INVALID_ARG_CHECK(h_new.empty() || h_new.size() == layers,
                           "Number of inputs passed to RNNBuilder::set_h() (" << h_new.size() << ") "
                           "is not equal to the number of layers (" << layers << ")");
   const unsigned t = h.size();

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -93,8 +93,10 @@ void LSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    if(layers * 2 != hinit.size())
-      DYNET_INVALID_ARG("LSTMBuilder must be initialized with 2 times as many expressions as layers (hidden state and cell for each layer). However, for " << layers << " layers, " << hinit.size() << " expressions were passed in");
+    DYNET_INVALID_ARG_CHECK(layers * 2 != hinit.size(),
+                            "LSTMBuilder must be initialized with 2 times as many expressions as layers "
+                            "(hidden state and cell for each layer). However, for " << layers << " layers, "
+                            << hinit.size() << " expressions were passed in");
     h0.resize(layers);
     c0.resize(layers);
     for (unsigned i = 0; i < layers; ++i) {
@@ -136,9 +138,8 @@ void LSTMBuilder::set_dropout_masks(unsigned batch_size) {
 // Also is creating a new step something we want?
 // wouldn't overwriting the current one be better?
 Expression LSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  if (h_new.size() && h_new.size() != layers)
-    DYNET_INVALID_ARG("LSTMBuilder::set_h expects as many inputs as layers, but got " <<
-                      h_new.size() << " inputs for " << layers << " layers");
+  DYNET_INVALID_ARG_CHECK(h_new.size() && h_new.size() != layers,
+                           "LSTMBuilder::set_h expects as many inputs as layers, but got " << h_new.size() << " inputs for " << layers << " layers");
   const unsigned t = h.size();
   h.push_back(vector<Expression>(layers));
   c.push_back(vector<Expression>(layers));
@@ -153,9 +154,8 @@ Expression LSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
 // Current implementation : s_new is either {new_c[0],...,new_c[n]}
 // or {new_c[0],...,new_c[n],new_h[0],...,new_h[n]}
 Expression LSTMBuilder::set_s_impl(int prev, const std::vector<Expression>& s_new) {
-  if (s_new.size() == layers || s_new.size() == 2 * layers)
-    DYNET_INVALID_ARG("LSTMBuilder::set_s expects either as many inputs or twice as many inputs as layers, but got " <<
-                      s_new.size() << " inputs for " << layers << " layers");
+  DYNET_INVALID_ARG_CHECK(s_new.size() == layers || s_new.size() == 2 * layers,
+                           "LSTMBuilder::set_s expects either as many inputs or twice as many inputs as layers, but got " << s_new.size() << " inputs for " << layers << " layers");
   bool only_c = s_new.size() == layers;
   const unsigned t = c.size();
   h.push_back(vector<Expression>(layers));
@@ -251,8 +251,8 @@ Expression LSTMBuilder::add_input_impl(int prev, const Expression& x) {
 
 void LSTMBuilder::copy(const RNNBuilder & rnn) {
   const LSTMBuilder & rnn_lstm = (const LSTMBuilder&)rnn;
-  if(params.size() != rnn_lstm.params.size())
-    DYNET_INVALID_ARG("Attempt to copy LSTMBuilder with different number of parameters (" << params.size() << " != " << rnn_lstm.params.size() << ")")
+  DYNET_INVALID_ARG_CHECK(params.size() != rnn_lstm.params.size(),
+                           "Attempt to copy LSTMBuilder with different number of parameters (" << params.size() << " != " << rnn_lstm.params.size() << ")");
   for (size_t i = 0; i < params.size(); ++i)
     for (size_t j = 0; j < params[i].size(); ++j)
       params[i][j] = rnn_lstm.params[i][j];
@@ -261,7 +261,7 @@ void LSTMBuilder::copy(const RNNBuilder & rnn) {
 void LSTMBuilder::save_parameters_pretraining(const string& fname) const {
   cerr << "Writing LSTM parameters to " << fname << endl;
   ofstream of(fname);
-  if(!of)
+  if (!of)
     DYNET_INVALID_ARG("Couldn't write LSTM parameters to " << fname);
   boost::archive::binary_oarchive oa(of);
   std::string id = "LSTMBuilder:params";
@@ -277,8 +277,8 @@ void LSTMBuilder::save_parameters_pretraining(const string& fname) const {
 void LSTMBuilder::load_parameters_pretraining(const string& fname) {
   cerr << "Loading LSTM parameters from " << fname << endl;
   ifstream of(fname);
-  if(!of)
-    DYNET_INVALID_ARG("Couldn't read LSTM parameters from " << fname)
+  if (!of)
+    DYNET_INVALID_ARG("Couldn't read LSTM parameters from " << fname);
   boost::archive::binary_iarchive ia(of);
   std::string id;
   ia >> id;
@@ -297,16 +297,16 @@ void LSTMBuilder::load_parameters_pretraining(const string& fname) {
 }
 
 void LSTMBuilder::set_dropout(float d) {
-  if (d < 0.f || d > 1.f)
-    DYNET_INVALID_ARG("dropout rate must be a probability (>=0 and <=1)");
+  DYNET_INVALID_ARG_CHECK(d < 0.f || d > 1.f,
+                           "dropout rate must be a probability (>=0 and <=1)");
   dropout_rate = d;
   dropout_rate_h = d;
   dropout_rate_c = d;
 }
 
 void LSTMBuilder::set_dropout(float d, float d_h, float d_c) {
-  if (d < 0.f || d > 1.f || d_h < 0.f || d_h > 1.f || d_c < 0.f || d_c > 1.f)
-    DYNET_INVALID_ARG("dropout rate must be a probability (>=0 and <=1)");
+  DYNET_INVALID_ARG_CHECK(d < 0.f || d > 1.f || d_h < 0.f || d_h > 1.f || d_c < 0.f || d_c > 1.f,
+                           "dropout rate must be a probability (>=0 and <=1)");
   dropout_rate = d;
   dropout_rate_h = d_h;
   dropout_rate_c = d_c;
@@ -371,8 +371,8 @@ void VanillaLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit
   c.clear();
 
   if (hinit.size() > 0) {
-    if(layers * 2 != hinit.size())
-      DYNET_INVALID_ARG("VanillaLSTMBuilder must be initialized with 2 times as many expressions as layers (hidden state, and cell for each layer). However, for " << layers << " layers, " << hinit.size() << " expressions were passed in");
+    DYNET_INVALID_ARG_CHECK(layers * 2 != hinit.size(),
+                             "VanillaLSTMBuilder must be initialized with 2 times as many expressions as layers (hidden state, and cell for each layer). However, for " << layers << " layers, " << hinit.size() << " expressions were passed in");
     h0.resize(layers);
     c0.resize(layers);
     for (unsigned i = 0; i < layers; ++i) {
@@ -413,9 +413,8 @@ void VanillaLSTMBuilder::set_dropout_masks(unsigned batch_size) {
 // Also is creating a new step something we want?
 // wouldn't overwriting the current one be better?
 Expression VanillaLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  if (h_new.size() && h_new.size() != layers)
-    DYNET_INVALID_ARG("VanillaLSTMBuilder::set_h expects as many inputs as layers, but got " <<
-                      h_new.size() << " inputs for " << layers << " layers");
+  DYNET_INVALID_ARG_CHECK(h_new.size() && h_new.size() != layers,
+                           "VanillaLSTMBuilder::set_h expects as many inputs as layers, but got " << h_new.size() << " inputs for " << layers << " layers");
   const unsigned t = h.size();
   h.push_back(vector<Expression>(layers));
   c.push_back(vector<Expression>(layers));
@@ -430,9 +429,8 @@ Expression VanillaLSTMBuilder::set_h_impl(int prev, const vector<Expression>& h_
 // Current implementation : s_new is either {new_c[0],...,new_c[n]}
 // or {new_c[0],...,new_c[n],new_h[0],...,new_h[n]}
 Expression VanillaLSTMBuilder::set_s_impl(int prev, const std::vector<Expression>& s_new) {
-  if (s_new.size() == layers || s_new.size() == 2 * layers)
-    DYNET_INVALID_ARG("LSTMBuilder::set_s expects either as many inputs or twice as many inputs as layers, but got " <<
-                      s_new.size() << " inputs for " << layers << " layers");
+  DYNET_INVALID_ARG_CHECK(s_new.size() == layers || s_new.size() == 2 * layers,
+                           "VanillaLSTMBuilder::set_s expects either as many inputs or twice as many inputs as layers, but got " << s_new.size() << " inputs for " << layers << " layers");
   bool only_c = s_new.size() == layers;
   const unsigned t = c.size();
   h.push_back(vector<Expression>(layers));
@@ -501,8 +499,8 @@ Expression VanillaLSTMBuilder::add_input_impl(int prev, const Expression& x) {
 
 void VanillaLSTMBuilder::copy(const RNNBuilder & rnn) {
   const LSTMBuilder & rnn_lstm = (const LSTMBuilder&)rnn;
-  if(params.size() != rnn_lstm.params.size())
-    DYNET_INVALID_ARG("Attempt to copy LSTMBuilder with different number of parameters (" << params.size() << " != " << rnn_lstm.params.size() << ")")
+  DYNET_INVALID_ARG_CHECK(params.size() != rnn_lstm.params.size(),
+                           "Attempt to copy LSTMBuilder with different number of parameters (" << params.size() << " != " << rnn_lstm.params.size() << ")");
   for (size_t i = 0; i < params.size(); ++i)
     for (size_t j = 0; j < params[i].size(); ++j)
       params[i][j] = rnn_lstm.params[i][j];
@@ -511,7 +509,7 @@ void VanillaLSTMBuilder::copy(const RNNBuilder & rnn) {
 void VanillaLSTMBuilder::save_parameters_pretraining(const string& fname) const {
   cerr << "Writing VanillaLSTM parameters to " << fname << endl;
   ofstream of(fname);
-  if(!of)
+  if (!of)
     DYNET_INVALID_ARG("Couldn't write LSTM parameters to " << fname);
   boost::archive::binary_oarchive oa(of);
   std::string id = "VanillaLSTMBuilder:params";
@@ -527,7 +525,7 @@ void VanillaLSTMBuilder::save_parameters_pretraining(const string& fname) const 
 void VanillaLSTMBuilder::load_parameters_pretraining(const string& fname) {
   cerr << "Loading VanillaLSTM parameters from " << fname << endl;
   ifstream of(fname);
-  if(!of)
+  if (!of)
     DYNET_INVALID_ARG("Couldn't read LSTM parameters from " << fname);
   boost::archive::binary_iarchive ia(of);
   std::string id;
@@ -547,15 +545,15 @@ void VanillaLSTMBuilder::load_parameters_pretraining(const string& fname) {
 }
 
 void VanillaLSTMBuilder::set_dropout(float d) {
-  if (d < 0.f || d > 1.f)
-    DYNET_INVALID_ARG("dropout rate must be a probability (>=0 and <=1)");
+  DYNET_INVALID_ARG_CHECK(d < 0.f || d > 1.f,
+                           "dropout rate must be a probability (>=0 and <=1)");
   dropout_rate = d;
   dropout_rate_h = d;
 }
 
 void VanillaLSTMBuilder::set_dropout(float d, float d_h) {
-  if (d < 0.f || d > 1.f || d_h < 0.f || d_h > 1.f)
-    DYNET_INVALID_ARG("dropout rate must be a probability (>=0 and <=1)");
+  DYNET_INVALID_ARG_CHECK(d < 0.f || d > 1.f || d_h < 0.f || d_h > 1.f,
+                           "dropout rate must be a probability (>=0 and <=1)");
   dropout_rate = d;
   dropout_rate_h = d_h;
 }

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -83,7 +83,7 @@ void ParameterStorage::zero() {
 }
 
 void ParameterStorage::copy(const ParameterStorage & param) {
-  DYNET_INVALID_ARG_CHECK(dim != param.dim,
+  DYNET_INVALID_ARG_CHECK(dim == param.dim,
                           "Attempt to copy between parameters with mismatched dimensions: " << dim << " != " << param.dim);
   TensorTools::CopyElements(values, param.values);
 }
@@ -494,7 +494,7 @@ void ParameterStorage::scale_parameters(float a) {
 
 template <class MyDevice>
 void LookupParameterStorage::initialize_dev(MyDevice & dev, unsigned index, const vector<float>& val) {
-  DYNET_INVALID_ARG_CHECK(int(val.size()) != int(dim.size()),
+  DYNET_INVALID_ARG_CHECK(int(val.size()) == int(dim.size()),
                           "Attempt to initialize LookupParameters with vector of wrong size "
                           "(" << val.size() << " != " << dim.size() << ")");
 #ifdef __CUDACC__

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -83,8 +83,8 @@ void ParameterStorage::zero() {
 }
 
 void ParameterStorage::copy(const ParameterStorage & param) {
-  if(dim != param.dim)
-    DYNET_INVALID_ARG("Attempt to copy between parameters with mismatched dimensions: " << dim << " != " << param.dim);
+  DYNET_INVALID_ARG_CHECK(dim != param.dim,
+                          "Attempt to copy between parameters with mismatched dimensions: " << dim << " != " << param.dim);
   TensorTools::CopyElements(values, param.values);
 }
 
@@ -494,8 +494,9 @@ void ParameterStorage::scale_parameters(float a) {
 
 template <class MyDevice>
 void LookupParameterStorage::initialize_dev(MyDevice & dev, unsigned index, const vector<float>& val) {
-  if(int(val.size()) != int(dim.size()))
-    DYNET_INVALID_ARG("Attempt to initialize LookupParameters with vector of wrong size (" << val.size() << " != " << dim.size() << ")");
+  DYNET_INVALID_ARG_CHECK(int(val.size()) != int(dim.size()),
+                          "Attempt to initialize LookupParameters with vector of wrong size "
+                          "(" << val.size() << " != " << dim.size() << ")");
 #ifdef __CUDACC__
   cudaMemcpyAsync(values[index].v, &val[0], val.size() * sizeof(float), cudaMemcpyHostToDevice);
 #else

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -18,8 +18,11 @@ string AddVectorToAllColumns::as_string(const vector<string>& arg_names) const {
 }
 
 Dim AddVectorToAllColumns::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 || xs[0].rows() != xs[1].rows() || xs[0].ndims() != 2 || (xs[1].ndims() != 1 && (xs[1].ndims() != 2 || xs[1].cols() != 1)))
-    DYNET_INVALID_ARG("Bad input dimensions in AddVectorToAllColumns: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 2 ||
+                          xs[0].rows() != xs[1].rows() ||
+                          xs[0].ndims() != 2 ||
+                          (xs[1].ndims() != 1 && (xs[1].ndims() != 2 || xs[1].cols() != 1)),
+                          "Bad input dimensions in AddVectorToAllColumns: " << xs);
   return Dim({xs[0][0], xs[0][1]}, max(xs[0].bd,xs[1].bd));
 }
 
@@ -30,8 +33,8 @@ string SparsemaxLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SparsemaxLoss::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || !LooksLikeVector(xs[0]))
-    DYNET_INVALID_ARG("Bad input dimensions in SparsemaxLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || !LooksLikeVector(xs[0]), 
+                          "Bad input dimensions in SparsemaxLoss: " << xs);
   return Dim({1});
 }
 
@@ -42,8 +45,8 @@ string Sparsemax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Sparsemax::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || !LooksLikeVector(xs[0]))
-    DYNET_INVALID_ARG("Bad input dimensions in Sparsemax: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || !LooksLikeVector(xs[0]),
+                          "Bad input dimensions in Sparsemax: " << xs);
   return xs[0];
 }
 
@@ -64,8 +67,8 @@ string LogDet::as_string(const vector<string>& arg_names) const {
 }
 
 Dim LogDet::dim_forward(const vector<Dim>& xs) const {
-  if (xs[0].ndims() > 2 || (xs[0].rows() != xs[0].cols()))
-    DYNET_INVALID_ARG("Bad arguments in LogDet: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].ndims() > 2 || (xs[0].rows() != xs[0].cols()),
+                          "Bad arguments in LogDet: " << xs);
   return Dim({1});
 }
 
@@ -76,8 +79,8 @@ string SelectRows::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SelectRows::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || xs[0].ndims() > 2)
-    DYNET_INVALID_ARG("Bad arguments in SelectRows: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || xs[0].ndims() > 2,
+                          "Bad arguments in SelectRows: " << xs);
   unsigned nrows = prows->size();
   if (xs[0].ndims() == 1) return Dim({nrows});
   return Dim({nrows, xs[0].cols()});
@@ -90,8 +93,7 @@ string SelectCols::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SelectCols::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || xs[0].ndims() != 2)
-    DYNET_INVALID_ARG("Bad arguments in SelectCols: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || xs[0].ndims() != 2, "Bad arguments in SelectCols: " << xs);
   unsigned ncols = pcols->size();
   return Dim({xs[0].rows(), ncols});
 }
@@ -103,8 +105,7 @@ string Min::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Min::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 || xs[0] != xs[1])
-    DYNET_INVALID_ARG("Bad arguments in Min: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 2 || xs[0] != xs[1], "Bad arguments in Min: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
 
@@ -115,8 +116,7 @@ string Max::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Max::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 || xs[0] != xs[1])
-    DYNET_INVALID_ARG("Bad arguments in Max: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 2 || xs[0] != xs[1], "Bad arguments in Max: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
 
@@ -127,8 +127,7 @@ string TraceOfProduct::as_string(const vector<string>& arg_names) const {
 }
 
 Dim TraceOfProduct::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 || xs[0] != xs[1])
-    DYNET_INVALID_ARG("Bad arguments in TraceOfProduct: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 2 || xs[0] != xs[1], "Bad arguments in TraceOfProduct: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -139,8 +138,7 @@ string ConstScalarMultiply::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConstScalarMultiply::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1)
-    DYNET_INVALID_ARG("ConstScalarMultiply expects one argument: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 1, "ConstScalarMultiply expects one argument: " << xs);
   return xs[0];
 }
 
@@ -151,11 +149,11 @@ string DotProduct::as_string(const vector<string>& arg_names) const {
 }
 
 Dim DotProduct::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 ||
-      !LooksLikeVector(xs[0]) ||
-      !LooksLikeVector(xs[1]) ||
-      xs[0].rows() != xs[1].rows())
-    DYNET_INVALID_ARG("Bad arguments to DotProduct: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 2 ||
+                          !LooksLikeVector(xs[0]) ||
+                          !LooksLikeVector(xs[1]) ||
+                          xs[0].rows() != xs[1].rows(),
+                          "Bad arguments to DotProduct: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -166,8 +164,7 @@ string Transpose::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Transpose::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1)
-    DYNET_INVALID_ARG("Bad arguments to Transpose: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 1, "Bad arguments to Transpose: " << xs);
   return xs[0].transpose();
 }
 
@@ -197,11 +194,9 @@ string KMHNGram::as_string(const vector<string>& arg_names) const {
 }
 
 Dim KMHNGram::dim_forward(const vector<Dim>& xs) const {
-  if (xs[0].ndims() != 2)
-    DYNET_INVALID_ARG("Bad input dimensions in KMHNGram: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].ndims() != 2, "Bad input dimensions in KMHNGram: " << xs);
   const unsigned new_cols = xs[0].cols() - n + 1;
-  if (new_cols < 1)
-    DYNET_INVALID_ARG("Bad input dimensions in KMHNGram: " << xs);
+  DYNET_INVALID_ARG_CHECK(new_cols < 1, "Bad input dimensions in KMHNGram: " << xs);
   return Dim({xs[0][0], new_cols});
 }
 
@@ -272,8 +267,8 @@ string LogSumExp::as_string(const vector<string>& arg_names) const {
 Dim LogSumExp::dim_forward(const vector<Dim>& xs) const {
   Dim d = xs[0].truncate();
   for (unsigned i = 1; i < xs.size(); ++i) {
-    if (d.single_batch() != xs[i].truncate().single_batch())
-      DYNET_INVALID_ARG("Mismatched input dimensions in LogSumExp: " << xs);
+    DYNET_INVALID_ARG_CHECK(d.single_batch() != xs[i].truncate().single_batch(),
+                            "Mismatched input dimensions in LogSumExp: " << xs);
     d.bd = max(xs[i].bd, d.bd);
   }
   return d;
@@ -290,8 +285,8 @@ Dim Sum::dim_forward(const vector<Dim>& xs) const {
   Dim d = xs[0].truncate();
   unsigned int batch = d.bd;
   for (unsigned i = 1; i < xs.size(); ++i) {
-    if (d.single_batch() != xs[i].truncate().single_batch())
-      DYNET_INVALID_ARG("Mismatched input dimensions in Sum: " << xs);
+    DYNET_INVALID_ARG_CHECK(d.single_batch() != xs[i].truncate().single_batch(),
+                            "Mismatched input dimensions in Sum: " << xs);
     batch = max(xs[i].bd, batch);
   }
   d = xs[0]; d.bd = batch;
@@ -332,8 +327,8 @@ string Average::as_string(const vector<string>& arg_names) const {
 Dim Average::dim_forward(const vector<Dim>& xs) const {
   Dim d(xs[0]);
   for (unsigned i = 1; i < xs.size(); ++i) {
-    if (xs[0].single_batch() != xs[1].single_batch())
-      DYNET_INVALID_ARG("Mismatched input dimensions in Average: " << xs);
+    DYNET_INVALID_ARG_CHECK(xs[0].single_batch() != xs[1].single_batch(),
+                            "Mismatched input dimensions in Average: " << xs);
     d.bd = max(xs[i].bd, d.bd);
   }
   return d;
@@ -445,8 +440,8 @@ Dim Concatenate::dim_forward(const vector<Dim>& xs) const {
     if (LooksLikeVector(c)) c.resize(1);
     new_rows += c[0];
     dr.set(0, c[0]);
-    if (dr.single_batch() != c.single_batch())
-      DYNET_INVALID_ARG("Bad input dimensions in Concatenate: " << xs);
+    DYNET_INVALID_ARG_CHECK(dr.single_batch() != c.single_batch(),
+                            "Bad input dimensions in Concatenate: " << xs);
     dr.bd = max(dr.bd, c.bd);
   }
   dr.set(0, new_rows);
@@ -469,8 +464,7 @@ Dim ConcatenateColumns::dim_forward(const vector<Dim>& xs) const {
   unsigned new_cols = 0;
   unsigned bd = 1;
   for (auto& d : xs) {
-    if (d[0] != rows)
-      DYNET_INVALID_ARG("Bad input dimensions in ConcatenateColumns: " << xs);
+    DYNET_INVALID_ARG_CHECK(d[0] != rows, "Bad input dimensions in ConcatenateColumns: " << xs);
     new_cols += d[1];
     bd = max(bd, d.bd);
   }
@@ -484,11 +478,11 @@ string PairwiseRankLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PairwiseRankLoss::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 2 ||
-      xs[0] != xs[1] ||
-      xs[0].rows() != 1 ||
-      (xs[0].ndims() != 1 && xs[0].ndims() != 2))
-    DYNET_INVALID_ARG("Bad input dimensions in PairwiseRankLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 2 ||
+                          xs[0] != xs[1] ||
+                          xs[0].rows() != 1 ||
+                          (xs[0].ndims() != 1 && xs[0].ndims() != 2),
+                          "Bad input dimensions in PairwiseRankLoss: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
 
@@ -499,8 +493,7 @@ string Hinge::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Hinge::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || !LooksLikeVector(xs[0]))
-    DYNET_INVALID_ARG("Bad input dimensions in Hinge: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || !LooksLikeVector(xs[0]), "Bad input dimensions in Hinge: " << xs);
   return Dim({1}, xs[0].bd);
 }
 
@@ -543,8 +536,8 @@ string Softmax::as_string(const vector<string>& arg_names) const {
 
 Dim Softmax::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in Softmax")
-  if (xs[0].nd > 2)
-    DYNET_INVALID_ARG("Bad input dimensions in Softmax, must be 2 or fewer: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].nd > 2,
+                          "Bad input dimensions in Softmax, must be 2 or fewer: " << xs);
   return xs[0];
 }
 
@@ -556,8 +549,8 @@ string SoftSign::as_string(const vector<string>& arg_names) const {
 
 Dim SoftSign::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in SoftSign")
-  if (!LooksLikeVector(xs[0]))
-    DYNET_INVALID_ARG("Bad input dimensions in SoftSign: " << xs);
+  DYNET_INVALID_ARG_CHECK(!LooksLikeVector(xs[0]),
+                          "Bad input dimensions in SoftSign: " << xs);
   return xs[0];
 }
 
@@ -576,17 +569,16 @@ string PickNegLogSoftmax::as_string(const vector<string>& arg_names) const {
 
 Dim PickNegLogSoftmax::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickNegLogSoftmax")
-  if (!LooksLikeVector(xs[0]))
-    DYNET_INVALID_ARG("Bad input dimensions in PickNegLogSoftmax: " << xs);
-  if (pval && xs[0].bd != 1) {
-    DYNET_INVALID_ARG("PickNegLogSoftmax was called with a single ID (" << *pval <<
-      "), but the expression under consideration had multiple mini-batch elements (" <<
-      xs[0].bd << "). A vector of IDs of size " << xs[0].bd << " must be passed instead.");
-  } else if (pvals && xs[0].bd != pvals->size()) {
-    DYNET_INVALID_ARG("The number of IDs passed to PickNegLogSoftmax (" << pvals->size() <<
-    "), did not match the number of mini-batch elements in the expression under consideration (" <<
-    xs[0].bd << "). These numbers must match.");
-  }
+  DYNET_INVALID_ARG_CHECK(!LooksLikeVector(xs[0]),
+                          "Bad input dimensions in PickNegLogSoftmax: " << xs);
+  DYNET_INVALID_ARG_CHECK((pval && xs[0].bd != 1),
+                          "PickNegLogSoftmax was called with a single ID (" << *pval <<
+                          "), but the expression under consideration had multiple mini-batch elements (" <<
+                          xs[0].bd << "). A vector of IDs of size " << xs[0].bd << " must be passed instead.");
+  DYNET_INVALID_ARG_CHECK((pvals && xs[0].bd != pvals->size()),
+                          "The number of IDs passed to PickNegLogSoftmax (" << pvals->size() <<
+                          "), did not match the number of mini-batch elements in the expression under consideration (" <<
+                          xs[0].bd << "). These numbers must match.");
   return Dim({1}, xs[0].bd);
 }
 
@@ -598,8 +590,8 @@ string LogSoftmax::as_string(const vector<string>& arg_names) const {
 
 Dim LogSoftmax::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in LogSoftmax")
-  if (xs[0].nd > 2)
-    DYNET_INVALID_ARG("Bad input dimensions in LogSoftmax, must be 2 or fewer: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].nd > 2,
+                          "Bad input dimensions in LogSoftmax, must be 2 or fewer: " << xs);
   return xs[0];
 }
 
@@ -611,8 +603,8 @@ string RestrictedLogSoftmax::as_string(const vector<string>& arg_names) const {
 
 Dim RestrictedLogSoftmax::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in RestrictedLogSoftmax")
-  if (!LooksLikeVector(xs[0]))
-    DYNET_INVALID_ARG("Bad input dimensions in RestrictedLogSoftmax: " << xs);
+  DYNET_INVALID_ARG_CHECK(!LooksLikeVector(xs[0]),
+                          "Bad input dimensions in RestrictedLogSoftmax: " << xs);
   return xs[0];
 }
 
@@ -637,10 +629,10 @@ string PickElement::as_string(const vector<string>& arg_names) const {
 
 Dim PickElement::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickElement")
-  if(dimension >= xs[0].nd)
-    DYNET_INVALID_ARG("Tried to PickElement on dimension " << dimension << " bigger than input " << xs[0]);
-  if(xs[0].nd >= 4)
-    DYNET_INVALID_ARG("PickElement not currently supported for tensors of 4 or more dimensions.");
+  DYNET_INVALID_ARG_CHECK(dimension >= xs[0].nd,
+                          "Tried to PickElement on dimension " << dimension << " bigger than input " << xs[0]);
+  DYNET_INVALID_ARG_CHECK(xs[0].nd >= 4,
+                          "PickElement not currently supported for tensors of 4 or more dimensions.");
   Dim ret(xs[0]);
   ret.delete_dim(dimension);
   return ret;
@@ -656,8 +648,8 @@ string PickRange::as_string(const vector<string>& arg_names) const {
 
 Dim PickRange::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickRange")
-  if (!LooksLikeVector(xs[0]) || end > xs[0][0])
-    DYNET_INVALID_ARG("Bad input dimensions or range in PickRange: " << xs << " range(" << start << ", " << end << ")");
+  DYNET_INVALID_ARG_CHECK(!LooksLikeVector(xs[0]) || end > xs[0][0],
+                          "Bad input dimensions or range in PickRange: " << xs << " range(" << start << ", " << end << ")");
   return Dim({end - start}, xs[0].bd);
 }
 
@@ -682,8 +674,8 @@ string PickBatch::as_string(const vector<string>& arg_names) const {
 
 Dim PickBatch::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickBatch")
-  if (xs[0].nd >= 4)
-    DYNET_INVALID_ARG("PickElement not currently supported for tensors of 4 or more dimensions.");
+  DYNET_INVALID_ARG_CHECK(xs[0].nd >= 4,
+                          "PickElement not currently supported for tensors of 4 or more dimensions.");
   Dim ret(xs[0]);
   if (pval) {
     // set batch size to one.
@@ -703,8 +695,8 @@ string MatrixMultiply::as_string(const vector<string>& arg_names) const {
 
 Dim MatrixMultiply::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 2, "Failed input count check in MatrixMultiply")
-  if (xs[0].cols() != xs[1].rows())
-    DYNET_INVALID_ARG("Mismatched input dimensions in MatrixMultiply: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].cols() != xs[1].rows(),
+                          "Mismatched input dimensions in MatrixMultiply: " << xs);
   if (xs[1].ndims() == 1) return Dim({xs[0].rows()}, max(xs[0].bd, xs[1].bd));
   return Dim({xs[0].rows(), xs[1].cols()}, max(xs[0].bd, xs[1].bd));
 }
@@ -718,8 +710,8 @@ string CwiseMultiply::as_string(const vector<string>& arg_names) const {
 Dim CwiseMultiply::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 2, "Failed input count check in CwiseMultiply")
   Dim d = xs[0].truncate();
-  if (d.single_batch() != xs[1].truncate().single_batch())
-    DYNET_INVALID_ARG("Mismatched input dimensions in CwiseMultiply: " << xs);
+  DYNET_INVALID_ARG_CHECK(d.single_batch() != xs[1].truncate().single_batch(),
+                          "Mismatched input dimensions in CwiseMultiply: " << xs);
   d.bd = max(xs[1].bd, d.bd);
   return d;
 }
@@ -733,8 +725,7 @@ string Pow::as_string(const vector<string>& arg_names) const {
 Dim Pow::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 2, "Failed input count check in Pow")
   Dim d = xs[0].truncate();
-  if (xs[1].truncate().single_batch().size() != 1)
-    DYNET_INVALID_ARG("Bad input dimensions in Pow: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[1].truncate().single_batch().size() != 1, "Bad input dimensions in Pow: " << xs);
   return d;
 }
 
@@ -747,8 +738,7 @@ string CwiseQuotient::as_string(const vector<string>& arg_names) const {
 Dim CwiseQuotient::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 2, "Failed input count check in CwiseQuotient")
   Dim d = xs[0].truncate();
-  if (d.single_batch() != xs[1].truncate().single_batch())
-    DYNET_INVALID_ARG("Bad input dimensions in CwiseQuotient: " << xs);
+  DYNET_INVALID_ARG_CHECK(d.single_batch() != xs[1].truncate().single_batch(), "Bad input dimensions in CwiseQuotient: " << xs);
   d.bd = max(xs[1].bd, d.bd);
   return d;
 }
@@ -762,18 +752,17 @@ string AffineTransform::as_string(const vector<string>& arg_names) const {
 }
 
 Dim AffineTransform::dim_forward(const vector<Dim>& xs) const {
-  if ((xs.size() - 1) % 2 != 0)
-    DYNET_INVALID_ARG("Bad number of inputs in AffineTransform: " << xs);
+  DYNET_INVALID_ARG_CHECK((xs.size() - 1) % 2 != 0, "Bad number of inputs in AffineTransform: " << xs);
   if(xs.size() == 1) return xs[0];
-  if (xs[0].rows() != xs[1].rows() ||
-      xs[1].cols() != xs[2].rows())
-    DYNET_INVALID_ARG("Bad dimensions for AffineTransform: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].rows() != xs[1].rows() ||
+                          xs[1].cols() != xs[2].rows(),
+                          "Bad dimensions for AffineTransform: " << xs);
   Dim d({xs[0].rows(), xs[2].cols()}, max(max(xs[0].bd, xs[1].bd), xs[2].bd));
   for (unsigned i = 3; i < xs.size(); i += 2) {
-    if (xs[i].cols() != xs[i+1].rows() ||
-        d.rows() != xs[i].rows() ||
-        d.cols() != xs[i+1].cols())
-      DYNET_INVALID_ARG("Bad dimensions for AffineTransform: " << xs);
+    DYNET_INVALID_ARG_CHECK(xs[i].cols() != xs[i+1].rows() ||
+                            d.rows() != xs[i].rows() ||
+                            d.cols() != xs[i+1].cols(),
+                            "Bad dimensions for AffineTransform: " << xs);
     d.bd = max(max(d.bd, xs[i].bd), xs[i+1].bd);
   }
   return d;
@@ -809,8 +798,10 @@ string HuberDistance::as_string(const vector<string>& arg_names) const {
 
 Dim HuberDistance::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 2, "Failed input count check in HuberDistance")
-  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
-    DYNET_INVALID_ARG("Mismatched input dimensions in HuberDistance: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() != xs[1].single_batch() &&
+                          !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) &&
+                          xs[0].batch_size() == xs[1].batch_size()),
+                          "Mismatched input dimensions in HuberDistance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -822,8 +813,11 @@ string L1Distance::as_string(const vector<string>& arg_names) const {
 
 Dim L1Distance::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 2, "Failed input count check in L1Distance")
-  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
-    DYNET_INVALID_ARG("Mismatched input dimensions in L1Distance: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() != xs[1].single_batch() &&
+                          !(LooksLikeVector(xs[0]) &&
+                          LooksLikeVector(xs[1]) &&
+                          xs[0].batch_size() == xs[1].batch_size()),
+                          "Mismatched input dimensions in L1Distance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -834,8 +828,7 @@ string PoissonRegressionLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PoissonRegressionLoss::dim_forward(const vector<Dim>& xs) const {
-  if (xs.size() != 1 || xs[0].size() != 1)
-    DYNET_INVALID_ARG("Bad input dimensions in PoissonRegressionLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || xs[0].size() != 1, "Bad input dimensions in PoissonRegressionLoss: " << xs);
   return xs[0];
 }
 
@@ -858,8 +851,10 @@ string SquaredEuclideanDistance::as_string(const vector<string>& arg_names) cons
 
 Dim SquaredEuclideanDistance::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 2, "Failed input count check in SquaredEuclideanDistance")
-  if (xs[0].single_batch() != xs[1].single_batch() && !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()))
-    DYNET_INVALID_ARG("Bad input dimensions in SquaredEuclideanDistance: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() != xs[1].single_batch() &&
+                          !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) &&
+                          xs[0].batch_size() == xs[1].batch_size()),
+                          "Bad input dimensions in SquaredEuclideanDistance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -882,10 +877,8 @@ string BinaryLogLoss::as_string(const vector<string>& arg_names) const {
 
 Dim BinaryLogLoss::dim_forward(const vector<Dim>& xs) const {
   DYNET_ASSERT(xs.size() == 2, "Failed input count check in BinaryLogLoss")
-  if (xs[0].rows() != 2 && xs[0].ndims() != 1)
-    DYNET_INVALID_ARG("Bad input dimensions in BinaryLogLoss: " << xs);
-  if (xs[1].rows() != 2 && xs[1].ndims() != 1)
-    DYNET_INVALID_ARG("Bad input dimensions in BinaryLogLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].rows() != 2 && xs[0].ndims() != 1, "Bad input dimensions in BinaryLogLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[1].rows() != 2 && xs[1].ndims() != 1, "Bad input dimensions in BinaryLogLoss: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -18,10 +18,10 @@ string AddVectorToAllColumns::as_string(const vector<string>& arg_names) const {
 }
 
 Dim AddVectorToAllColumns::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 2 ||
-                          xs[0].rows() != xs[1].rows() ||
-                          xs[0].ndims() != 2 ||
-                          (xs[1].ndims() != 1 && (xs[1].ndims() != 2 || xs[1].cols() != 1)),
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2 &&
+                          xs[0].rows() == xs[1].rows() &&
+                          xs[0].ndims() == 2 &&
+                          (xs[1].ndims() == 1 || (xs[1].ndims() == 2 && xs[1].cols() == 1)),
                           "Bad input dimensions in AddVectorToAllColumns: " << xs);
   return Dim({xs[0][0], xs[0][1]}, max(xs[0].bd,xs[1].bd));
 }
@@ -33,8 +33,7 @@ string SparsemaxLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SparsemaxLoss::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || !LooksLikeVector(xs[0]), 
-                          "Bad input dimensions in SparsemaxLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1 && LooksLikeVector(xs[0]), "Bad input dimensions in SparsemaxLoss: " << xs);
   return Dim({1});
 }
 
@@ -45,8 +44,7 @@ string Sparsemax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Sparsemax::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || !LooksLikeVector(xs[0]),
-                          "Bad input dimensions in Sparsemax: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1 && LooksLikeVector(xs[0]), "Bad input dimensions in Sparsemax: " << xs);
   return xs[0];
 }
 
@@ -67,8 +65,7 @@ string LogDet::as_string(const vector<string>& arg_names) const {
 }
 
 Dim LogDet::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs[0].ndims() > 2 || (xs[0].rows() != xs[0].cols()),
-                          "Bad arguments in LogDet: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].ndims() <= 2 && (xs[0].rows() == xs[0].cols()), "Bad arguments in LogDet: " << xs);
   return Dim({1});
 }
 
@@ -79,8 +76,7 @@ string SelectRows::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SelectRows::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || xs[0].ndims() > 2,
-                          "Bad arguments in SelectRows: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1 && xs[0].ndims() == 2, "Bad arguments in SelectRows: " << xs);
   unsigned nrows = prows->size();
   if (xs[0].ndims() == 1) return Dim({nrows});
   return Dim({nrows, xs[0].cols()});
@@ -93,7 +89,7 @@ string SelectCols::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SelectCols::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || xs[0].ndims() != 2, "Bad arguments in SelectCols: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1 && xs[0].ndims() == 2, "Bad arguments in SelectCols: " << xs);
   unsigned ncols = pcols->size();
   return Dim({xs[0].rows(), ncols});
 }
@@ -105,7 +101,7 @@ string Min::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Min::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 2 || xs[0] != xs[1], "Bad arguments in Min: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2 && xs[0] == xs[1], "Bad arguments in Min: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
 
@@ -116,7 +112,7 @@ string Max::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Max::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 2 || xs[0] != xs[1], "Bad arguments in Max: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2 && xs[0] == xs[1], "Bad arguments in Max: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
 
@@ -127,7 +123,7 @@ string TraceOfProduct::as_string(const vector<string>& arg_names) const {
 }
 
 Dim TraceOfProduct::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 2 || xs[0] != xs[1], "Bad arguments in TraceOfProduct: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2 && xs[0] == xs[1], "Bad arguments in TraceOfProduct: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 
@@ -138,7 +134,7 @@ string ConstScalarMultiply::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConstScalarMultiply::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 1, "ConstScalarMultiply expects one argument: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "ConstScalarMultiply expects one argument: " << xs);
   return xs[0];
 }
 
@@ -149,10 +145,10 @@ string DotProduct::as_string(const vector<string>& arg_names) const {
 }
 
 Dim DotProduct::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 2 ||
-                          !LooksLikeVector(xs[0]) ||
-                          !LooksLikeVector(xs[1]) ||
-                          xs[0].rows() != xs[1].rows(),
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2 &&
+                          LooksLikeVector(xs[0]) &&
+                          LooksLikeVector(xs[1]) &&
+                          xs[0].rows() == xs[1].rows(),
                           "Bad arguments to DotProduct: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
@@ -164,7 +160,7 @@ string Transpose::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Transpose::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 1, "Bad arguments to Transpose: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Bad arguments to Transpose: " << xs);
   return xs[0].transpose();
 }
 
@@ -175,7 +171,7 @@ string Reshape::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Reshape::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Reshape")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Reshape")
   if(to.size() == xs[0].size()) {
     return to;
   } else if(to.batch_elems() == 1 && to.batch_size() == xs[0].batch_size()) {
@@ -194,9 +190,9 @@ string KMHNGram::as_string(const vector<string>& arg_names) const {
 }
 
 Dim KMHNGram::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs[0].ndims() != 2, "Bad input dimensions in KMHNGram: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[0].ndims() == 2, "Bad input dimensions in KMHNGram: " << xs);
   const unsigned new_cols = xs[0].cols() - n + 1;
-  DYNET_INVALID_ARG_CHECK(new_cols < 1, "Bad input dimensions in KMHNGram: " << xs);
+  DYNET_INVALID_ARG_CHECK(new_cols >= 1, "Bad input dimensions in KMHNGram: " << xs);
   return Dim({xs[0][0], new_cols});
 }
 
@@ -207,7 +203,7 @@ string GaussianNoise::as_string(const vector<string>& arg_names) const {
 }
 
 Dim GaussianNoise::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in GaussianNoise")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in GaussianNoise")
   return xs[0];
 }
 
@@ -218,7 +214,7 @@ string Dropout::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Dropout::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Dropout")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Dropout")
   return xs[0];
 }
 
@@ -229,7 +225,7 @@ string BlockDropout::as_string(const vector<string>& arg_names) const {
 }
 
 Dim BlockDropout::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in BlockDropout")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in BlockDropout")
   return xs[0];
 }
 
@@ -240,7 +236,7 @@ string ConstantPlusX::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConstantPlusX::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in ConstantPlusX")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in ConstantPlusX")
   return xs[0];
 }
 
@@ -251,7 +247,7 @@ string ConstantMinusX::as_string(const vector<string>& arg_names) const {
 }
 
 Dim ConstantMinusX::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in ConstantMinusX")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in ConstantMinusX")
   return xs[0];
 }
 
@@ -267,7 +263,7 @@ string LogSumExp::as_string(const vector<string>& arg_names) const {
 Dim LogSumExp::dim_forward(const vector<Dim>& xs) const {
   Dim d = xs[0].truncate();
   for (unsigned i = 1; i < xs.size(); ++i) {
-    DYNET_INVALID_ARG_CHECK(d.single_batch() != xs[i].truncate().single_batch(),
+    DYNET_INVALID_ARG_CHECK(d.single_batch() == xs[i].truncate().single_batch(),
                             "Mismatched input dimensions in LogSumExp: " << xs);
     d.bd = max(xs[i].bd, d.bd);
   }
@@ -285,7 +281,7 @@ Dim Sum::dim_forward(const vector<Dim>& xs) const {
   Dim d = xs[0].truncate();
   unsigned int batch = d.bd;
   for (unsigned i = 1; i < xs.size(); ++i) {
-    DYNET_INVALID_ARG_CHECK(d.single_batch() != xs[i].truncate().single_batch(),
+    DYNET_INVALID_ARG_CHECK(d.single_batch() == xs[i].truncate().single_batch(),
                             "Mismatched input dimensions in Sum: " << xs);
     batch = max(xs[i].bd, batch);
   }
@@ -300,7 +296,7 @@ string SumElements::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SumElements::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in SumElements")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in SumElements")
   return Dim({1}, xs[0].bd);
 }
 
@@ -311,7 +307,7 @@ string SumBatches::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SumBatches::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in SumBatches")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in SumBatches")
   return xs[0].single_batch();
 }
 
@@ -327,7 +323,7 @@ string Average::as_string(const vector<string>& arg_names) const {
 Dim Average::dim_forward(const vector<Dim>& xs) const {
   Dim d(xs[0]);
   for (unsigned i = 1; i < xs.size(); ++i) {
-    DYNET_INVALID_ARG_CHECK(xs[0].single_batch() != xs[1].single_batch(),
+    DYNET_INVALID_ARG_CHECK(xs[0].single_batch() == xs[1].single_batch(),
                             "Mismatched input dimensions in Average: " << xs);
     d.bd = max(xs[i].bd, d.bd);
   }
@@ -341,7 +337,7 @@ string Sqrt::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Sqrt::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Sqrt")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Sqrt")
   return xs[0];
 }
 
@@ -352,7 +348,7 @@ string Erf::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Erf::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Erf")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Erf")
   return xs[0];
 }
 
@@ -363,7 +359,7 @@ string Tanh::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Tanh::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Tanh")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Tanh")
   return xs[0];
 }
 
@@ -374,7 +370,7 @@ string Square::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Square::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Square")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Square")
   return xs[0];
 }
 
@@ -385,7 +381,7 @@ string Cube::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Cube::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Cube")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Cube")
   return xs[0];
 }
 
@@ -396,7 +392,7 @@ string Exp::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Exp::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Exp")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Exp")
   return xs[0];
 }
 
@@ -407,7 +403,7 @@ string LogGamma::as_string(const vector<string>& arg_names) const {
 }
 
 Dim LogGamma::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in LogGamma")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in LogGamma")
   return xs[0];
 }
 
@@ -418,7 +414,7 @@ string Log::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Log::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Log")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Log")
   return xs[0];
 }
 
@@ -440,7 +436,7 @@ Dim Concatenate::dim_forward(const vector<Dim>& xs) const {
     if (LooksLikeVector(c)) c.resize(1);
     new_rows += c[0];
     dr.set(0, c[0]);
-    DYNET_INVALID_ARG_CHECK(dr.single_batch() != c.single_batch(),
+    DYNET_INVALID_ARG_CHECK(dr.single_batch() == c.single_batch(),
                             "Bad input dimensions in Concatenate: " << xs);
     dr.bd = max(dr.bd, c.bd);
   }
@@ -464,7 +460,7 @@ Dim ConcatenateColumns::dim_forward(const vector<Dim>& xs) const {
   unsigned new_cols = 0;
   unsigned bd = 1;
   for (auto& d : xs) {
-    DYNET_INVALID_ARG_CHECK(d[0] != rows, "Bad input dimensions in ConcatenateColumns: " << xs);
+    DYNET_INVALID_ARG_CHECK(d[0] == rows, "Bad input dimensions in ConcatenateColumns: " << xs);
     new_cols += d[1];
     bd = max(bd, d.bd);
   }
@@ -478,10 +474,10 @@ string PairwiseRankLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PairwiseRankLoss::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 2 ||
-                          xs[0] != xs[1] ||
-                          xs[0].rows() != 1 ||
-                          (xs[0].ndims() != 1 && xs[0].ndims() != 2),
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2 &&
+                          xs[0] == xs[1] &&
+                          xs[0].rows() == 1 &&
+                          (xs[0].ndims() == 1 || xs[0].ndims() == 2),
                           "Bad input dimensions in PairwiseRankLoss: " << xs);
   return xs[0].bd >= xs[1].bd ? xs[0] : xs[1];
 }
@@ -493,7 +489,7 @@ string Hinge::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Hinge::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || !LooksLikeVector(xs[0]), "Bad input dimensions in Hinge: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1 && LooksLikeVector(xs[0]), "Bad input dimensions in Hinge: " << xs);
   return Dim({1}, xs[0].bd);
 }
 
@@ -502,7 +498,7 @@ string Identity::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Identity::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Identity")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Identity")
   return xs[0];
 }
 
@@ -513,7 +509,7 @@ string NoBackprop::as_string(const vector<string>& arg_names) const {
 }
 
 Dim NoBackprop::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in NoBackprop")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in NoBackprop")
   return xs[0];
 }
 
@@ -524,7 +520,7 @@ string FlipGradient::as_string(const vector<string>& arg_names) const {
 }
 
 Dim FlipGradient::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in FlipGradient")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in FlipGradient");
   return xs[0];
 }  
   
@@ -535,9 +531,8 @@ string Softmax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Softmax::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Softmax")
-  DYNET_INVALID_ARG_CHECK(xs[0].nd > 2,
-                          "Bad input dimensions in Softmax, must be 2 or fewer: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Softmax");
+  DYNET_INVALID_ARG_CHECK(xs[0].nd <= 2, "Bad input dimensions in Softmax, must be 2 or fewer: " << xs);
   return xs[0];
 }
 
@@ -548,9 +543,8 @@ string SoftSign::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SoftSign::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in SoftSign")
-  DYNET_INVALID_ARG_CHECK(!LooksLikeVector(xs[0]),
-                          "Bad input dimensions in SoftSign: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in SoftSign");
+  DYNET_INVALID_ARG_CHECK(LooksLikeVector(xs[0]), "Bad input dimensions in SoftSign: " << xs);
   return xs[0];
 }
 
@@ -568,14 +562,13 @@ string PickNegLogSoftmax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PickNegLogSoftmax::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickNegLogSoftmax")
-  DYNET_INVALID_ARG_CHECK(!LooksLikeVector(xs[0]),
-                          "Bad input dimensions in PickNegLogSoftmax: " << xs);
-  DYNET_INVALID_ARG_CHECK((pval && xs[0].bd != 1),
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in PickNegLogSoftmax");
+  DYNET_INVALID_ARG_CHECK(LooksLikeVector(xs[0]), "Bad input dimensions in PickNegLogSoftmax: " << xs);
+  DYNET_INVALID_ARG_CHECK((pval == nullptr || xs[0].bd == 1),
                           "PickNegLogSoftmax was called with a single ID (" << *pval <<
                           "), but the expression under consideration had multiple mini-batch elements (" <<
                           xs[0].bd << "). A vector of IDs of size " << xs[0].bd << " must be passed instead.");
-  DYNET_INVALID_ARG_CHECK((pvals && xs[0].bd != pvals->size()),
+  DYNET_INVALID_ARG_CHECK((pvals == nullptr || xs[0].bd == pvals->size()),
                           "The number of IDs passed to PickNegLogSoftmax (" << pvals->size() <<
                           "), did not match the number of mini-batch elements in the expression under consideration (" <<
                           xs[0].bd << "). These numbers must match.");
@@ -589,9 +582,8 @@ string LogSoftmax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim LogSoftmax::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in LogSoftmax")
-  DYNET_INVALID_ARG_CHECK(xs[0].nd > 2,
-                          "Bad input dimensions in LogSoftmax, must be 2 or fewer: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in LogSoftmax")
+  DYNET_INVALID_ARG_CHECK(xs[0].nd <= 2, "Bad input dimensions in LogSoftmax, must be 2 or fewer: " << xs);
   return xs[0];
 }
 
@@ -602,9 +594,8 @@ string RestrictedLogSoftmax::as_string(const vector<string>& arg_names) const {
 }
 
 Dim RestrictedLogSoftmax::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in RestrictedLogSoftmax")
-  DYNET_INVALID_ARG_CHECK(!LooksLikeVector(xs[0]),
-                          "Bad input dimensions in RestrictedLogSoftmax: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in RestrictedLogSoftmax")
+  DYNET_INVALID_ARG_CHECK(LooksLikeVector(xs[0]), "Bad input dimensions in RestrictedLogSoftmax: " << xs);
   return xs[0];
 }
 
@@ -628,10 +619,10 @@ string PickElement::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PickElement::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickElement")
-  DYNET_INVALID_ARG_CHECK(dimension >= xs[0].nd,
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in PickElement");
+  DYNET_INVALID_ARG_CHECK(dimension < xs[0].nd,
                           "Tried to PickElement on dimension " << dimension << " bigger than input " << xs[0]);
-  DYNET_INVALID_ARG_CHECK(xs[0].nd >= 4,
+  DYNET_INVALID_ARG_CHECK(xs[0].nd < 4,
                           "PickElement not currently supported for tensors of 4 or more dimensions.");
   Dim ret(xs[0]);
   ret.delete_dim(dimension);
@@ -647,8 +638,8 @@ string PickRange::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PickRange::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickRange")
-  DYNET_INVALID_ARG_CHECK(!LooksLikeVector(xs[0]) || end > xs[0][0],
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in PickRange");
+  DYNET_INVALID_ARG_CHECK(LooksLikeVector(xs[0]) && end <= xs[0][0],
                           "Bad input dimensions or range in PickRange: " << xs << " range(" << start << ", " << end << ")");
   return Dim({end - start}, xs[0].bd);
 }
@@ -673,9 +664,8 @@ string PickBatch::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PickBatch::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in PickBatch")
-  DYNET_INVALID_ARG_CHECK(xs[0].nd >= 4,
-                          "PickElement not currently supported for tensors of 4 or more dimensions.");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in PickBatch")
+  DYNET_INVALID_ARG_CHECK(xs[0].nd < 4, "PickElement not currently supported for tensors of 4 or more dimensions.");
   Dim ret(xs[0]);
   if (pval) {
     // set batch size to one.
@@ -694,9 +684,8 @@ string MatrixMultiply::as_string(const vector<string>& arg_names) const {
 }
 
 Dim MatrixMultiply::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed input count check in MatrixMultiply")
-  DYNET_INVALID_ARG_CHECK(xs[0].cols() != xs[1].rows(),
-                          "Mismatched input dimensions in MatrixMultiply: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed input count check in MatrixMultiply")
+  DYNET_INVALID_ARG_CHECK(xs[0].cols() == xs[1].rows(), "Mismatched input dimensions in MatrixMultiply: " << xs);
   if (xs[1].ndims() == 1) return Dim({xs[0].rows()}, max(xs[0].bd, xs[1].bd));
   return Dim({xs[0].rows(), xs[1].cols()}, max(xs[0].bd, xs[1].bd));
 }
@@ -708,9 +697,9 @@ string CwiseMultiply::as_string(const vector<string>& arg_names) const {
 }
 
 Dim CwiseMultiply::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed input count check in CwiseMultiply")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed input count check in CwiseMultiply")
   Dim d = xs[0].truncate();
-  DYNET_INVALID_ARG_CHECK(d.single_batch() != xs[1].truncate().single_batch(),
+  DYNET_INVALID_ARG_CHECK(d.single_batch() == xs[1].truncate().single_batch(),
                           "Mismatched input dimensions in CwiseMultiply: " << xs);
   d.bd = max(xs[1].bd, d.bd);
   return d;
@@ -723,9 +712,9 @@ string Pow::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Pow::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed input count check in Pow")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed input count check in Pow")
   Dim d = xs[0].truncate();
-  DYNET_INVALID_ARG_CHECK(xs[1].truncate().single_batch().size() != 1, "Bad input dimensions in Pow: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[1].truncate().single_batch().size() == 1, "Bad input dimensions in Pow: " << xs);
   return d;
 }
 
@@ -736,9 +725,9 @@ string CwiseQuotient::as_string(const vector<string>& arg_names) const {
 }
 
 Dim CwiseQuotient::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed input count check in CwiseQuotient")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed input count check in CwiseQuotient")
   Dim d = xs[0].truncate();
-  DYNET_INVALID_ARG_CHECK(d.single_batch() != xs[1].truncate().single_batch(), "Bad input dimensions in CwiseQuotient: " << xs);
+  DYNET_INVALID_ARG_CHECK(d.single_batch() == xs[1].truncate().single_batch(), "Bad input dimensions in CwiseQuotient: " << xs);
   d.bd = max(xs[1].bd, d.bd);
   return d;
 }
@@ -752,16 +741,13 @@ string AffineTransform::as_string(const vector<string>& arg_names) const {
 }
 
 Dim AffineTransform::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK((xs.size() - 1) % 2 != 0, "Bad number of inputs in AffineTransform: " << xs);
+  DYNET_INVALID_ARG_CHECK((xs.size() - 1) % 2 == 0, "Bad number of inputs in AffineTransform: " << xs);
   if(xs.size() == 1) return xs[0];
-  DYNET_INVALID_ARG_CHECK(xs[0].rows() != xs[1].rows() ||
-                          xs[1].cols() != xs[2].rows(),
+  DYNET_INVALID_ARG_CHECK(xs[0].rows() == xs[1].rows() && xs[1].cols() == xs[2].rows(),
                           "Bad dimensions for AffineTransform: " << xs);
   Dim d({xs[0].rows(), xs[2].cols()}, max(max(xs[0].bd, xs[1].bd), xs[2].bd));
   for (unsigned i = 3; i < xs.size(); i += 2) {
-    DYNET_INVALID_ARG_CHECK(xs[i].cols() != xs[i+1].rows() ||
-                            d.rows() != xs[i].rows() ||
-                            d.cols() != xs[i+1].cols(),
+    DYNET_INVALID_ARG_CHECK(xs[i].cols() == xs[i+1].rows() && d.rows() == xs[i].rows() && d.cols() == xs[i+1].cols(),
                             "Bad dimensions for AffineTransform: " << xs);
     d.bd = max(max(d.bd, xs[i].bd), xs[i+1].bd);
   }
@@ -775,7 +761,7 @@ string Negate::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Negate::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Negate")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Negate");
   return xs[0];
 }
 
@@ -786,7 +772,7 @@ string Rectify::as_string(const vector<string>& arg_names) const {
 }
 
 Dim Rectify::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in Rectify")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in Rectify");
   return xs[0];
 }
 
@@ -797,10 +783,9 @@ string HuberDistance::as_string(const vector<string>& arg_names) const {
 }
 
 Dim HuberDistance::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed input count check in HuberDistance")
-  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() != xs[1].single_batch() &&
-                          !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) &&
-                          xs[0].batch_size() == xs[1].batch_size()),
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed input count check in HuberDistance");
+  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() == xs[1].single_batch() ||
+                          (LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()),
                           "Mismatched input dimensions in HuberDistance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
@@ -812,11 +797,9 @@ string L1Distance::as_string(const vector<string>& arg_names) const {
 }
 
 Dim L1Distance::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed input count check in L1Distance")
-  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() != xs[1].single_batch() &&
-                          !(LooksLikeVector(xs[0]) &&
-                          LooksLikeVector(xs[1]) &&
-                          xs[0].batch_size() == xs[1].batch_size()),
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed input count check in L1Distance")
+  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() == xs[1].single_batch() ||
+                          (LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()),
                           "Mismatched input dimensions in L1Distance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
@@ -828,7 +811,7 @@ string PoissonRegressionLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim PoissonRegressionLoss::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(xs.size() != 1 || xs[0].size() != 1, "Bad input dimensions in PoissonRegressionLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1 && xs[0].size() == 1, "Bad input dimensions in PoissonRegressionLoss: " << xs);
   return xs[0];
 }
 
@@ -839,7 +822,7 @@ string SquaredNorm::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SquaredNorm::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed input count check in SquaredNorm")
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed input count check in SquaredNorm")
   return Dim({1}, xs[0].bd);
 }
 
@@ -850,10 +833,9 @@ string SquaredEuclideanDistance::as_string(const vector<string>& arg_names) cons
 }
 
 Dim SquaredEuclideanDistance::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed input count check in SquaredEuclideanDistance")
-  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() != xs[1].single_batch() &&
-                          !(LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) &&
-                          xs[0].batch_size() == xs[1].batch_size()),
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed input count check in SquaredEuclideanDistance")
+  DYNET_INVALID_ARG_CHECK(xs[0].single_batch() == xs[1].single_batch() ||
+                          (LooksLikeVector(xs[0]) && LooksLikeVector(xs[1]) && xs[0].batch_size() == xs[1].batch_size()),
                           "Bad input dimensions in SquaredEuclideanDistance: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
@@ -876,9 +858,9 @@ string BinaryLogLoss::as_string(const vector<string>& arg_names) const {
 }
 
 Dim BinaryLogLoss::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed input count check in BinaryLogLoss")
-  DYNET_INVALID_ARG_CHECK(xs[0].rows() != 2 && xs[0].ndims() != 1, "Bad input dimensions in BinaryLogLoss: " << xs);
-  DYNET_INVALID_ARG_CHECK(xs[1].rows() != 2 && xs[1].ndims() != 1, "Bad input dimensions in BinaryLogLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed input count check in BinaryLogLoss")
+  DYNET_INVALID_ARG_CHECK(xs[0].rows() == 2 || xs[0].ndims() == 1, "Bad input dimensions in BinaryLogLoss: " << xs);
+  DYNET_INVALID_ARG_CHECK(xs[1].rows() == 2 || xs[1].ndims() == 1, "Bad input dimensions in BinaryLogLoss: " << xs);
   return Dim({1}, max(xs[0].bd, xs[1].bd));
 }
 

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -287,8 +287,7 @@ void AffineTransform::forward_dev_impl(const MyDevice & dev, const vector<const 
       Eigen::array<int, 3> bcast; bcast[0] = 1; bcast[1] = fx.d[1]/xs[0]->d[1]; bcast[2] = fx.d.bd/xs[0]->d.bd;
       fx.tb<2>().device(*dev.edevice) = xs[0]->tb<2>().broadcast(bcast);
 #else
-      DYNET_INVALID_ARG_CHECK(xs[0]->d.bd != 1,
-                              "In AffineTransform, broadcasting over columns with mini-batched inputs is not implemented yet");
+      DYNET_INVALID_ARG_CHECK(xs[0]->d.bd == 1, "In AffineTransform, broadcasting over columns with mini-batched inputs is not implemented yet");
       float *curr_ptr = fx.v, *end_ptr = curr_ptr + fx.d.size(), *in_ptr = xs[0]->v;
       do {
         memcpy(curr_ptr, in_ptr, sizeof(float)*b_size);
@@ -332,8 +331,7 @@ void AffineTransform::backward_dev_impl(const MyDevice & dev,
     if(dx_size == df_size) {
       dEdxi.tvec().device(*dev.edevice) += dEdf.tvec();
     } else {
-      DYNET_INVALID_ARG_CHECK(dEdxi.d.bd != 1, 
-                              "In AffineTransform, broadcasting over columns with mini-batched inputs is not implemented yet");
+      DYNET_INVALID_ARG_CHECK(dEdxi.d.bd == 1, "In AffineTransform, broadcasting over columns with mini-batched inputs is not implemented yet");
 #ifdef __CUDACC__
       if(dEdxi.d[1] == dEdf.d[1]) {
         Eigen::array<int, 1> red_axis; red_axis[0] = 2;
@@ -826,7 +824,7 @@ void Hinge::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& 
   Tensor eloss(xs[0]->d, static_cast<float*>(aux_mem), fx.device, DeviceMempool::FXS);
   // TODO: Can we do this on device?
   if(pelement != nullptr) {
-    DYNET_INVALID_ARG_CHECK(fx.d.bd != 1,
+    DYNET_INVALID_ARG_CHECK(fx.d.bd == 1, 
                             "Hinge was passed a single index but the corresponding expression has multiple mini-batch elements (" << fx.d.bd << ")");
     const real mlystar = margin - TensorTools::AccessElement(*xs[0], *pelement);
     eloss.tvec().device(*dev.edevice) = (xs[0]->tvec() + mlystar).cwiseMax(0.f);
@@ -834,7 +832,7 @@ void Hinge::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& 
     fx.t<0>().device(*dev.edevice) = eloss.tvec().sum();
   } else {
     DYNET_ASSERT(pelements != nullptr, "Hinge::forward has neither pointer to single element nor vector");
-    DYNET_INVALID_ARG_CHECK(xs[0]->d.bd != pelements->size(),
+    DYNET_INVALID_ARG_CHECK(xs[0]->d.bd == pelements->size(),
                             "The list of indexes passed to Hinge has a length (" << pelements->size() <<
                             ") that doesn't match the number of mini-batch elements in the corresponding expression (" << xs[0]->d << ")");
     size_t batch_size = xs[0]->d.batch_size();
@@ -1418,18 +1416,18 @@ DYNET_NODE_INST_DEV_IMPL(PairwiseRankLoss)
 template<class MyDevice>
 void PickElement::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   if(pval) {
-    DYNET_INVALID_ARG_CHECK(*pval >= xs[0]->d[dimension], 
+    DYNET_INVALID_ARG_CHECK(*pval < xs[0]->d[dimension], 
                             "PickElement::forward_impl requested element " << *pval << " from a dimension of length " << xs[0]->d[dimension]);
     // TODO: This limit of up to 4 is somewhat arbitrary. We need to decide how to handle
     //       things with "maximum tensor size".
     fx.tb<3>().device(*dev.edevice) = xs[0]->tb<4>().chip(*pval, dimension); 
   } else {
     DYNET_ASSERT(pvals != nullptr, "Neither single nor vector of elements available in PickElement::forward");
-    DYNET_INVALID_ARG_CHECK(pvals->size() != fx.d.batch_elems(),
+    DYNET_INVALID_ARG_CHECK(pvals->size() == fx.d.batch_elems(),
                             "In PickElement::forward, number of elements in the passed-in index vector (" <<  pvals->size() << ")"
                             " did not match number of elements in mini-batch elements in expression (of dimension" << fx.d << ")");
     for(unsigned b = 0; b < pvals->size(); ++b) {
-      DYNET_INVALID_ARG_CHECK((*pvals)[b] >= xs[0]->d[dimension], 
+      DYNET_INVALID_ARG_CHECK((*pvals)[b] < xs[0]->d[dimension], 
                               "PickElement::forward_impl requested element " << (*pvals)[b] << " from a dimension of length " << xs[0]->d[dimension]);
       fx.tb<2>().chip<2>(b).device(*dev.edevice) = xs[0]->tb<3>().chip<3>(b).chip((*pvals)[b], dimension); 
     }
@@ -1444,7 +1442,7 @@ void PickElement::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ASSERT(i == 0, "Failed dimension check in PickElement::backward");
+  DYNET_INVALID_ARG_CHECK(i == 0, "Failed dimension check in PickElement::backward");
   if(pval) {
     dEdxi.tb<3>().chip(*pval, dimension).device(*dev.edevice) += dEdf.tb<2>();
   } else {
@@ -1470,9 +1468,9 @@ void PickNegLogSoftmax::forward_dev_impl(const MyDevice & dev, const vector<cons
       *ids_host = *pval;
     } else {
       DYNET_ASSERT(pvals, "Neither single nor vector of elements available in PickNegLogSoftmax::forward");
-      DYNET_INVALID_ARG_CHECK(pvals->size() != fx.d.batch_elems(), 
-                               "In PickNegLogSoftmax::forward, number of elements in the passed-in index vector (" << pvals->size() << ")"
-                               " did not match number of elements in mini-batch elements in expression (of dimension" << fx.d << ")");
+      DYNET_INVALID_ARG_CHECK(pvals->size() == fx.d.batch_elems(), 
+                              "In PickNegLogSoftmax::forward, number of elements in the passed-in index vector (" << pvals->size() << ")"
+                              " did not match number of elements in mini-batch elements in expression (of dimension" << fx.d << ")");
       size_t batch_size = xs[0]->d.batch_size();
       for(unsigned b = 0; b < fx.d.bd; ++b)
         ids_host[b] = batch_size * b + (*pvals)[b];
@@ -1552,11 +1550,11 @@ void PickBatch::forward_dev_impl(const MyDevice & dev, const vector<const Tensor
     fx.tvec().device(*dev.edevice) = xs[0]->tbvec().chip<1>(*pval);
   } else {
     DYNET_ASSERT(pvals != nullptr, "Neither single nor vector of elements available in PickBatch::forward");
-    DYNET_INVALID_ARG_CHECK(pvals->size() != fx.d.batch_elems(), 
-                            "In PickBatch::forward, number of elements in the passed-in index vector (" << pvals->size() << ")"
-                            " did not match number of elements in mini-batch elements in expression (of dimension" << fx.d << ")");
+    DYNET_INVALID_ARG_CHECK(pvals->size() == fx.d.batch_elems(), 
+                            "In PickBatch::forward, number of elements in the passed-in index vector (" << pvals->size() << ") "
+                            "did not match number of elements in mini-batch elements in expression (of dimension" << fx.d << ")");
     for (unsigned b = 0; b < pvals->size(); ++b) {
-      DYNET_INVALID_ARG_CHECK((*pvals)[b] >= xs[0]->d.bd,
+      DYNET_INVALID_ARG_CHECK((*pvals)[b] < xs[0]->d.bd,
                               "PickBatch::forward_impl requested element " << (*pvals)[b] << " from a batch size of " << xs[0]->d.nd);
       fx.tbvec().chip<1>(b).device(*dev.edevice) = xs[0]->tbvec().chip<1>((*pvals)[b]);
     }
@@ -1603,7 +1601,7 @@ DYNET_NODE_INST_DEV_IMPL(PoissonRegressionLoss)
 
 template<class MyDevice>
 void Pow::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in Pow::forward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed dimension check in Pow::forward");
   fx.tvec().device(*dev.edevice) = xs[0]->tvec().pow(as_scalar(*xs[1]));
 }
 
@@ -1614,7 +1612,7 @@ void Pow::backward_dev_impl(const MyDevice & dev,
                             const Tensor& dEdf,
                             unsigned i,
                             Tensor& dEdxi) const {
-  DYNET_ASSERT(xs.size() == 2, "Failed dimension check in Pow::backward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 2, "Failed dimension check in Pow::backward");
   real x2 = as_scalar(*xs[1]);
   if (i == 0) {
     dEdxi.tvec().device(*dev.edevice) += xs[0]->tvec().pow(x2 - 1) * dEdf.tvec() * x2;
@@ -1631,7 +1629,7 @@ DYNET_NODE_INST_DEV_IMPL(Pow)
 
 template<class MyDevice>
 void Rectify::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in Rectify::forward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in Rectify::forward");
   fx.tvec().device(*dev.edevice) = xs[0]->tvec().cwiseMax(0.f);
 }
 
@@ -1708,10 +1706,10 @@ DYNET_NODE_INST_DEV_IMPL(RestrictedLogSoftmax)
 
 template<class MyDevice>
 void SelectCols::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SelectCols::forward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectCols::forward");
   auto& rm = *pcols;
   for (unsigned i = 0; i < rm.size(); ++i) {
-    DYNET_INVALID_ARG_CHECK(rm[i] >= xs[0]->d.cols(),
+    DYNET_INVALID_ARG_CHECK(rm[i] < xs[0]->d.cols(),
                             "Out-of-bounds index " << rm[i] << " in SelectCols over expression of dimensions " << xs[0]->d);
     fx.t<2>().chip<1>(i).device(*dev.edevice) = xs[0]->t<2>().chip<1>(rm[i]);
   }
@@ -1724,7 +1722,7 @@ void SelectCols::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SelectCols::backward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectCols::backward");
   auto& rm = *pcols;
   for (unsigned i = 0; i < rm.size(); ++i)
     dEdxi.t<2>().chip<1>(rm[i]).device(*dev.edevice) = dEdf.t<2>().chip<1>(i);
@@ -1733,10 +1731,10 @@ DYNET_NODE_INST_DEV_IMPL(SelectCols)
 
 template<class MyDevice>
 void SelectRows::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SelectRows::forward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectRows::forward");
   auto& rm = *prows;
   for (unsigned i = 0; i < rm.size(); ++i) {
-    DYNET_INVALID_ARG_CHECK(rm[i] >= xs[0]->d.rows(),
+    DYNET_INVALID_ARG_CHECK(rm[i] < xs[0]->d.rows(),
                             "Out-of-bounds index " << rm[i] << " in SelectRows over expression of dimensions " << xs[0]->d);
     fx.t<2>().chip<0>(i).device(*dev.edevice) = xs[0]->t<2>().chip<0>(rm[i]);
   }
@@ -1749,7 +1747,7 @@ void SelectRows::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SelectRows::backward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectRows::backward");
   auto& rm = *prows;
   for (unsigned i = 0; i < rm.size(); ++i)
     dEdxi.t<2>().chip<0>(rm[i]).device(*dev.edevice) = dEdf.t<2>().chip<0>(i);
@@ -1758,7 +1756,7 @@ DYNET_NODE_INST_DEV_IMPL(SelectRows)
 
 template<class MyDevice>
 void Softmax::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in Softmax::forward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in Softmax::forward");
   Tensor z(Dim({xs[0]->d.cols()},fx.d.bd), (float*)aux_mem, fx.device, DeviceMempool::FXS);
   Tensor m(Dim({xs[0]->d.cols()},fx.d.bd), (float*)aux_mem + z.d.size(), fx.device, DeviceMempool::FXS);
   logsumexp(dev, *xs[0], m, z);
@@ -1787,7 +1785,7 @@ DYNET_NODE_INST_DEV_IMPL(Softmax)
 
 template<class MyDevice>
 void SoftSign::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SoftSign::forward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in SoftSign::forward");
   fx.tvec().device(*dev.edevice) = xs[0]->tvec().unaryExpr(FSoftSign());
 }
 
@@ -2054,7 +2052,7 @@ DYNET_NODE_INST_DEV_IMPL(Sum)
 
 template<class MyDevice>
 void SumElements::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SumElements::forward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in SumElements::forward");
   Eigen::array<int, 1> red_axis; red_axis[0] = 0;
   fx.tb<0>().device(*dev.edevice) = xs[0]->tbvec().sum(red_axis);
 }
@@ -2066,7 +2064,7 @@ void SumElements::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ASSERT(i == 0, "Failed dimension check in SumElements::backward");
+  DYNET_INVALID_ARG_CHECK(i == 0, "Failed dimension check in SumElements::backward");
   Eigen::array<int, 2> bcast = {(int)xs[0]->d.batch_size(), 1};
   dEdxi.tbvec().device(*dev.edevice) += dEdf.tbvec().broadcast(bcast);
 }
@@ -2074,7 +2072,7 @@ DYNET_NODE_INST_DEV_IMPL(SumElements)
 
 template<class MyDevice>
 void SumBatches::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  DYNET_ASSERT(xs.size() == 1, "Failed dimension check in SumBatches::forward");
+  DYNET_INVALID_ARG_CHECK(xs.size() == 1, "Failed dimension check in SumBatches::forward");
   unsigned num_args = xs[0]->d.bd;
 #ifdef __CUDACC__
   Eigen::array<int, 1> red_axis; red_axis[0] = 2;
@@ -2101,7 +2099,7 @@ void SumBatches::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ASSERT(i == 0, "Failed dimension check in SumBatches::backward");
+  DYNET_INVALID_ARG_CHECK(i == 0, "Failed dimension check in SumBatches::backward");
 #if __CUDACC__
   Eigen::array<int, 3> bcast({1, 1, (int)fx.d.bd});
   dEdxi.tb<2>().device(*dev.edevice) += dEdf.tb<2>().broadcast(bcast);
@@ -2130,7 +2128,7 @@ void TraceOfProduct::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ASSERT(i < 2, "Failed dimension check in TraceOfProduce::backward");
+  DYNET_INVALID_ARG_CHECK(i < 2, "Failed dimension check in TraceOfProduce::backward");
 #ifdef __CUDACC__
   DYNET_RUNTIME_ERR("TraceOfProduct not yet implemented for CUDA");
 #else

--- a/dynet/param-nodes.cc
+++ b/dynet/param-nodes.cc
@@ -65,8 +65,8 @@ string SparseInputNode::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SparseInputNode::dim_forward(const vector<Dim>& xs) const {
-  if(ids.size() != data.size())
-    DYNET_INVALID_ARG("Mismatch between size of ids (" << ids.size() << ") and size of data (" << data.size() << ") in SparseInput");
+  DYNET_INVALID_ARG_CHECK(ids.size() != data.size(),
+                          "Mismatch between size of ids (" << ids.size() << ") and size of data (" << data.size() << ") in SparseInput");
   return dim;
 }
 
@@ -238,23 +238,23 @@ template<class MyDevice>
 void LookupNode::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
   if(pindex) {
-    if(*pindex >= params.get()->values.size())
-      DYNET_INVALID_ARG("Out-of-bounds attempt to access index " << *pindex << " for LookupParameter of size " << params.get()->values.size());
+    DYNET_INVALID_ARG_CHECK(*pindex >= params.get()->values.size(),
+                            "Out-of-bounds attempt to access index " << *pindex << " for LookupParameter of size " << params.get()->values.size());
     DYNET_ASSERT(fx.d.batch_elems() == 1, "Batch dimension > 1 for lookup with single index");
     fx.tvec().device(*dev.edevice) = params.get()->values[*pindex].tvec() * params.mp->weight_decay.current_weight_decay();
   } else {
     DYNET_ASSERT(pindices, "Have neither index nor index vector in LookupNode");
-    if(fx.d.batch_elems() != pindices->size())
-      DYNET_INVALID_ARG("In LookupNode, in index vector size (" << pindices->size() <<
-                        ") doesn't match batch size in expressions (" << fx.d.batch_elems() << ")");
+    DYNET_INVALID_ARG_CHECK(fx.d.batch_elems() != pindices->size(),
+                            "In LookupNode, in index vector size (" << pindices->size() << ") "
+                            "doesn't match batch size in expressions (" << fx.d.batch_elems() << ")");
 #if __CUDACC__
     CUDA_CHECK(cudaMemcpyAsync((unsigned*)aux_mem, &(*pindices)[0], fx.d.bd * sizeof(unsigned), cudaMemcpyHostToDevice));
     dynet::gpu::sparse_to_dense_block_assign_and_multiply(fx.d.bd, (unsigned*)aux_mem, fx.d.batch_size(), params.mp->weight_decay.current_weight_decay(), params.get()->all_values.v, fx.v);
 #else
     for (unsigned b = 0; b < pindices->size(); ++b) {
       unsigned i = pindices->at(b);
-      if(i >= params.get()->values.size())
-        DYNET_INVALID_ARG("Out-of-bounds attempt to access index " << i << " for LookupParameter of size " << params.get()->values.size());
+      DYNET_INVALID_ARG_CHECK(i >= params.get()->values.size(),
+                              "Out-of-bounds attempt to access index " << i << " for LookupParameter of size " << params.get()->values.size());
       fx.tb<2>().chip<2>(b).device(*dev.edevice) = params.get()->values[i].t<2>() * params.mp->weight_decay.current_weight_decay();
     }
 #endif

--- a/dynet/param-nodes.cc
+++ b/dynet/param-nodes.cc
@@ -65,7 +65,7 @@ string SparseInputNode::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SparseInputNode::dim_forward(const vector<Dim>& xs) const {
-  DYNET_INVALID_ARG_CHECK(ids.size() != data.size(),
+  DYNET_INVALID_ARG_CHECK(ids.size() == data.size(),
                           "Mismatch between size of ids (" << ids.size() << ") and size of data (" << data.size() << ") in SparseInput");
   return dim;
 }
@@ -238,13 +238,13 @@ template<class MyDevice>
 void LookupNode::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   DYNET_ASSERT(xs.size() == 0, "Failed dimension check in FUNCNAME");
   if(pindex) {
-    DYNET_INVALID_ARG_CHECK(*pindex >= params.get()->values.size(),
+    DYNET_INVALID_ARG_CHECK(*pindex < params.get()->values.size(),
                             "Out-of-bounds attempt to access index " << *pindex << " for LookupParameter of size " << params.get()->values.size());
     DYNET_ASSERT(fx.d.batch_elems() == 1, "Batch dimension > 1 for lookup with single index");
     fx.tvec().device(*dev.edevice) = params.get()->values[*pindex].tvec() * params.mp->weight_decay.current_weight_decay();
   } else {
     DYNET_ASSERT(pindices, "Have neither index nor index vector in LookupNode");
-    DYNET_INVALID_ARG_CHECK(fx.d.batch_elems() != pindices->size(),
+    DYNET_INVALID_ARG_CHECK(fx.d.batch_elems() == pindices->size(),
                             "In LookupNode, in index vector size (" << pindices->size() << ") "
                             "doesn't match batch size in expressions (" << fx.d.batch_elems() << ")");
 #if __CUDACC__
@@ -253,7 +253,7 @@ void LookupNode::forward_dev_impl(const MyDevice & dev, const vector<const Tenso
 #else
     for (unsigned b = 0; b < pindices->size(); ++b) {
       unsigned i = pindices->at(b);
-      DYNET_INVALID_ARG_CHECK(i >= params.get()->values.size(),
+      DYNET_INVALID_ARG_CHECK(i < params.get()->values.size(),
                               "Out-of-bounds attempt to access index " << i << " for LookupParameter of size " << params.get()->values.size());
       fx.tb<2>().chip<2>(b).device(*dev.edevice) = params.get()->values[i].t<2>() * params.mp->weight_decay.current_weight_decay();
     }

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -72,12 +72,12 @@ void SimpleRNNBuilder::new_graph_impl(ComputationGraph& cg) {
 void SimpleRNNBuilder::start_new_sequence_impl(const vector<Expression>& h_0) {
   h.clear();
   h0 = h_0;
-  DYNET_INVALID_ARG_CHECK(h0.size() && h0.size() != layers,
+  DYNET_INVALID_ARG_CHECK(h0.empty() || h0.size() == layers,
                           "Number of inputs passed to initialize RNNBuilder (" << h0.size() << ") is not equal to the number of layers (" << layers << ")");
 }
 
 Expression SimpleRNNBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  DYNET_INVALID_ARG_CHECK(h_new.size() && h_new.size() != layers,
+  DYNET_INVALID_ARG_CHECK(h_new.empty() || h_new.size() == layers,
                           "Number of inputs passed to RNNBuilder::set_h() (" << h_new.size() << ") is not equal to the number of layers (" << layers << ")");
   const unsigned t = h.size();
   h.push_back(vector<Expression>(layers));
@@ -136,12 +136,12 @@ Expression SimpleRNNBuilder::add_auxiliary_input(const Expression &in, const Exp
 
 void SimpleRNNBuilder::copy(const RNNBuilder & rnn) {
   const SimpleRNNBuilder & rnn_simple = (const SimpleRNNBuilder&)rnn;
-  DYNET_INVALID_ARG_CHECK(params.size() != rnn_simple.params.size(),
+  DYNET_INVALID_ARG_CHECK(params.size() == rnn_simple.params.size(),
                           "Attempt to copy between two SimpleRNNBuilders that are not the same size");
   for(size_t i = 0; i < rnn_simple.params.size(); ++i) {
-      params[i][0] = rnn_simple.params[i][0];
-      params[i][1] = rnn_simple.params[i][1];
-      params[i][2] = rnn_simple.params[i][2];
+    params[i][0] = rnn_simple.params[i][0];
+    params[i][1] = rnn_simple.params[i][1];
+    params[i][2] = rnn_simple.params[i][2];
   }
 }
 

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -72,15 +72,13 @@ void SimpleRNNBuilder::new_graph_impl(ComputationGraph& cg) {
 void SimpleRNNBuilder::start_new_sequence_impl(const vector<Expression>& h_0) {
   h.clear();
   h0 = h_0;
-  if (h0.size() && h0.size() != layers)
-    DYNET_INVALID_ARG("Number of inputs passed to initialize RNNBuilder (" << h0.size() <<
-                      ") is not equal to the number of layers (" << layers << ")");
+  DYNET_INVALID_ARG_CHECK(h0.size() && h0.size() != layers,
+                          "Number of inputs passed to initialize RNNBuilder (" << h0.size() << ") is not equal to the number of layers (" << layers << ")");
 }
 
 Expression SimpleRNNBuilder::set_h_impl(int prev, const vector<Expression>& h_new) {
-  if (h_new.size() && h_new.size() != layers)
-    DYNET_INVALID_ARG("Number of inputs passed to RNNBuilder::set_h() (" << h_new.size() <<
-                      ") is not equal to the number of layers (" << layers << ")");
+  DYNET_INVALID_ARG_CHECK(h_new.size() && h_new.size() != layers,
+                          "Number of inputs passed to RNNBuilder::set_h() (" << h_new.size() << ") is not equal to the number of layers (" << layers << ")");
   const unsigned t = h.size();
   h.push_back(vector<Expression>(layers));
   for (unsigned i = 0; i < layers; ++i) {
@@ -138,8 +136,8 @@ Expression SimpleRNNBuilder::add_auxiliary_input(const Expression &in, const Exp
 
 void SimpleRNNBuilder::copy(const RNNBuilder & rnn) {
   const SimpleRNNBuilder & rnn_simple = (const SimpleRNNBuilder&)rnn;
-  if(params.size() != rnn_simple.params.size())
-    DYNET_INVALID_ARG("Attempt to copy between two SimpleRNNBuilders that are not the same size");
+  DYNET_INVALID_ARG_CHECK(params.size() != rnn_simple.params.size(),
+                          "Attempt to copy between two SimpleRNNBuilders that are not the same size");
   for(size_t i = 0; i < rnn_simple.params.size(); ++i) {
       params[i][0] = rnn_simple.params[i][0];
       params[i][1] = rnn_simple.params[i][1];
@@ -150,7 +148,7 @@ void SimpleRNNBuilder::copy(const RNNBuilder & rnn) {
 void SimpleRNNBuilder::save_parameters_pretraining(const string& fname) const {
   cerr << "Writing parameters to " << fname << endl;
   ofstream of(fname);
-  if(!of)
+  if (!of)
     DYNET_INVALID_ARG("Could not write parameters to " << fname << " in SimpleRNNBuilder");
   boost::archive::binary_oarchive oa(of);
   std::string id = "SimpleRNNBuilder:params";
@@ -166,7 +164,7 @@ void SimpleRNNBuilder::save_parameters_pretraining(const string& fname) const {
 void SimpleRNNBuilder::load_parameters_pretraining(const string& fname) {
   cerr << "Loading parameters from " << fname << endl;
   ifstream of(fname);
-  if(!of)
+  if (!of)
     DYNET_INVALID_ARG("Could not load parameters from " << fname << " in SimpleRNNBuilder");
   boost::archive::binary_iarchive ia(of);
   std::string id;

--- a/dynet/tensor.h
+++ b/dynet/tensor.h
@@ -69,13 +69,13 @@ struct Tensor {
    * \return Eigen matrix
    */
   Eigen::Map<Eigen::MatrixXf> operator*() {
-    if(d.batch_elems() != 1 || d.ndims() >= 3)
-      DYNET_INVALID_ARG("Attempted to access Tensor with more than one batch element or more than two dimensions in matrix form: " << d);
+    DYNET_INVALID_ARG_CHECK((d.batch_elems() != 1 || d.ndims() >= 3),
+                            "Attempted to access Tensor with more than one batch element or more than two dimensions in matrix form: " << d);
     return Eigen::Map<Eigen::MatrixXf>(v, d.rows(), d.cols());
   }
   const Eigen::Map<Eigen::MatrixXf> operator*() const {
-    if(d.batch_elems() != 1 || d.ndims() >= 3)
-      DYNET_INVALID_ARG("Attempted to access Tensor with more than one batch element or more than two dimensions in matrix form: " << d);
+    DYNET_INVALID_ARG_CHECK((d.batch_elems() != 1 || d.ndims() >= 3),
+                            "Attempted to access Tensor with more than one batch element or more than two dimensions in matrix form: " << d);
     return Eigen::Map<Eigen::MatrixXf>(v, d.rows(), d.cols());
   }
   /**

--- a/dynet/tensor.h
+++ b/dynet/tensor.h
@@ -69,12 +69,12 @@ struct Tensor {
    * \return Eigen matrix
    */
   Eigen::Map<Eigen::MatrixXf> operator*() {
-    DYNET_INVALID_ARG_CHECK((d.batch_elems() != 1 || d.ndims() >= 3),
+    DYNET_INVALID_ARG_CHECK((d.batch_elems() == 1 && d.ndims() < 3),
                             "Attempted to access Tensor with more than one batch element or more than two dimensions in matrix form: " << d);
     return Eigen::Map<Eigen::MatrixXf>(v, d.rows(), d.cols());
   }
   const Eigen::Map<Eigen::MatrixXf> operator*() const {
-    DYNET_INVALID_ARG_CHECK((d.batch_elems() != 1 || d.ndims() >= 3),
+    DYNET_INVALID_ARG_CHECK((d.batch_elems() == 1 && d.ndims() < 3),
                             "Attempted to access Tensor with more than one batch element or more than two dimensions in matrix form: " << d);
     return Eigen::Map<Eigen::MatrixXf>(v, d.rows(), d.cols());
   }

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -124,8 +124,9 @@ void NaryTreeLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hini
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    DYNET_INVALID_ARG_CHECK(layers*2 != hinit.size(),
-                            "Incorrectly sized initialization in TreeLSTM (" << hinit.size() << "). Must be twice the number of layers (which is " << layers<< ")");
+    DYNET_INVALID_ARG_CHECK(layers*2 == hinit.size(),
+                            "Incorrectly sized initialization in TreeLSTM (" << hinit.size() << "). "
+                            "Must be twice the number of layers (which is " << layers<< ")");
     h0.resize(layers);
     c0.resize(layers);
     for (unsigned i = 0; i < layers; ++i) {

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -124,8 +124,8 @@ void NaryTreeLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hini
   h.clear();
   c.clear();
   if (hinit.size() > 0) {
-    if(layers*2 != hinit.size())
-      DYNET_INVALID_ARG("Incorrectly sized initialization in TreeLSTM (" << hinit.size() << "). Must be twice the number of layers (which is " << layers<< ")");
+    DYNET_INVALID_ARG_CHECK(layers*2 != hinit.size(),
+                            "Incorrectly sized initialization in TreeLSTM (" << hinit.size() << "). Must be twice the number of layers (which is " << layers<< ")");
     h0.resize(layers);
     c0.resize(layers);
     for (unsigned i = 0; i < layers; ++i) {


### PR DESCRIPTION
Add a new compile time flag `DYNET_DEBUG_LEVEL`. When
* `DYNET_DEBUG_LEVEL=0`, no error assertion is adopted.
* `DYNET_DEBUG_LEVEL=1`, activate runtime checking on the computation graph but disable development assertion
* `DYNET_DEBUG_LEVEL=2`, do all the assertion.
This flag is 1 by default.

NOTE:
Currently, the boundary between graph checking and development assertion is a little bit vague. So this PR didn't change the implementation of different checking but only wrap the code like
```
if (wrong_cond)
  DYNET_INVALID_ARG(msg)
```
with a `DYNET_INVALID_ARG_CHECK(wrong_cond, msg)` macro.
BTW, error checking is a little bit messy. I've seen the code of checking whether a file is correctly opened, raises an invalid_argument exception. Semantically, a runtime_error exception may be more suitable. But this kind of improvements are not involved in this PR.