### PR TITLE
expression functions with varargs

### DIFF
--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Dim.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Dim.scala
@@ -36,6 +36,8 @@ class Dim private[dynet] (private[dynet] val dim: internal.Dim) {
     case _ => false
   }
   override def hashCode(): Int = dim.hashCode()
+
+  def debugString(): String = s"(Dim: ${size} ${nDims} ${(0 until nDims.toInt).map(get(_))} )"
 }
 
 /** Factory for [[edu.cmu.dynet.Dim]] instances. */

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
@@ -3,7 +3,13 @@ package edu.cmu.dynet
 /** Represents an expression on the computation graph. Can only be constructed using the
   * functions contained in the companion object.
   */
-class Expression private[dynet](private[dynet] val expr: internal.Expression) {
+class Expression private[dynet](
+  private[dynet] val expr: internal.Expression,
+  // Expressions sometimes rely on things (e.g. wrapped C++ vectors) that get deleted when the JVM
+  // garbage collector runs. By explicitly grabbing references to them, we can prevent this
+  // premature garbage collection.
+  val references: Seq[AnyRef] = Seq.empty
+) {
   // Give it the current version
   val version = ComputationGraph.version
 
@@ -27,6 +33,8 @@ class Expression private[dynet](private[dynet] val expr: internal.Expression) {
   def -(r: Float): Expression = Expression.exprMinus(this, r)
   def /(r: Float): Expression = Expression.exprDivide(this, r)
   def unary_-(): Expression = Expression.exprMinus(this)
+
+  def debugString(): String = s"(Expression: ${dim.debugString} ${value.toSeq})"
 }
 
 /** Contains methods for creating [[edu.cmu.dynet.Expression]]s. There are several ways to create
@@ -42,38 +50,44 @@ object Expression {
 
   /** Private helper function for wrapping methods that get expressions from the computation
     * graph */
-  private def makeExpr(f: internal.ComputationGraph => internal.Expression): Expression = {
+  private def makeExpr(
+    f: internal.ComputationGraph => internal.Expression,
+    references: Seq[AnyRef] = Seq.empty
+  ): Expression = {
     val version = ComputationGraph.version
     val expr = f(ComputationGraph.cg)
-    new Expression(expr)
+    new Expression(expr, references)
   }
 
   def input(s: Float): Expression = makeExpr(cg => dn.input(ComputationGraph.cg, s))
-  def input(fp: FloatPointer): Expression = makeExpr(cg => dn.input(ComputationGraph.cg, fp.floatp))
+  def input(fp: FloatPointer): Expression =
+    makeExpr(cg => dn.input(ComputationGraph.cg, fp.floatp), Seq(fp))
   def input(d: Dim, pdata: FloatVector): Expression =
-    makeExpr(cg => dn.input(cg, d.dim, pdata.vector))
+    makeExpr(cg => dn.input(cg, d.dim, pdata.vector), Seq(d, pdata))
   def input(d: Dim, ids: UnsignedVector, data: FloatVector, defdata: Float = 0f) =
-    makeExpr(cg => dn.input(cg, d.dim, ids.vector, data.vector, defdata))
+    makeExpr(cg => dn.input(cg, d.dim, ids.vector, data.vector, defdata), Seq(d, ids, data))
 
-  def parameter(p: Parameter): Expression = makeExpr(cg => dn.parameter(cg, p.parameter))
-  def constParameter(p: Parameter): Expression = makeExpr(cg => dn.const_parameter(cg, p.parameter))
+  def parameter(p: Parameter): Expression = makeExpr(cg => dn.parameter(cg, p.parameter), Seq(p))
+  def constParameter(p: Parameter): Expression =
+    makeExpr(cg => dn.const_parameter(cg, p.parameter), Seq(p))
 
-  def lookup(p: LookupParameter, index: Long) = makeExpr(cg => dn.lookup(cg, p.lookupParameter, index))
+  def lookup(p: LookupParameter, index: Long) =
+    makeExpr(cg => dn.lookup(cg, p.lookupParameter, index), Seq(p))
   def lookup(p: LookupParameter, pindex: UnsignedPointer) =
-    makeExpr(cg => dn.lookup(cg, p.lookupParameter, pindex.uintp))
+    makeExpr(cg => dn.lookup(cg, p.lookupParameter, pindex.uintp), Seq(p, pindex))
   def constLookup(p: LookupParameter, index: Long) =
-    makeExpr(cg => dn.lookup(cg, p.lookupParameter, index))
+    makeExpr(cg => dn.lookup(cg, p.lookupParameter, index), Seq(p))
   // def constLookup
   def lookup(p: LookupParameter, indices: UnsignedVector) =
-    makeExpr(cg => dn.lookup(cg, p.lookupParameter, indices.vector))
+    makeExpr(cg => dn.lookup(cg, p.lookupParameter, indices.vector), Seq(p, indices))
 
 
-  def zeroes(d: Dim) = makeExpr(cg => dn.zeroes(cg, d.dim))
-  def randomNormal(d: Dim) = makeExpr(cg => dn.random_normal(cg, d.dim))
+  def zeroes(d: Dim) = makeExpr(cg => dn.zeroes(cg, d.dim), Seq(d))
+  def randomNormal(d: Dim) = makeExpr(cg => dn.random_normal(cg, d.dim), Seq(d))
   def randomBernoulli(d: Dim, p: Float, scale: Float = 1.0f) = makeExpr(
-    cg => dn.random_bernoulli(cg, d.dim, p, scale))
+    cg => dn.random_bernoulli(cg, d.dim, p, scale), Seq(d))
   def randomUniform(d: Dim, left: Float, right: Float) = makeExpr(
-    cg => dn.random_uniform(cg, d.dim, left, right))
+    cg => dn.random_uniform(cg, d.dim, left, right), Seq(d))
 
   /* ARITHMETIC OPERATIONS */
 
@@ -82,13 +96,15 @@ object Expression {
     e1.ensureFresh()
     e2.ensureFresh()
     val expr = combiner(e1.expr, e2.expr)
-    new Expression(expr)
+    // Specify e1 and e2 as references so they can't get prematurely garbage collected.
+    new Expression(expr, Seq(e1, e2))
   }
 
   private type UnaryTransform = internal.Expression => internal.Expression
   private def unary(e: Expression, transformer: UnaryTransform) = {
     e.ensureFresh()
-    new Expression(transformer(e.expr))
+    // Specify e as reference so it can't get prematurely garbage collected.
+    new Expression(transformer(e.expr), Seq(e))
   }
 
   def exprMinus(e: Expression): Expression = unary(e, dn.exprMinus)
@@ -106,12 +122,18 @@ object Expression {
   private type VectorTransform = internal.ExpressionVector => internal.Expression
   private def vectory(v: ExpressionVector, transformer: VectorTransform) = {
     v.ensureFresh()
-    new Expression(transformer(v.vector))
+    // Specify v as reference so it can't get prematurely garbage collected.
+    new Expression(transformer(v.vector), Seq(v))
   }
 
   def affineTransform(ev: ExpressionVector): Expression = vectory(ev, dn.affine_transform)
+  def affineTransform(exprs: Expression*): Expression = affineTransform(new ExpressionVector(exprs))
+
   def sum(ev: ExpressionVector): Expression = vectory(ev, dn.sum)
+  def sum(exprs: Expression*): Expression = sum(new ExpressionVector(exprs))
+
   def average(ev: ExpressionVector): Expression = vectory(ev, dn.average)
+  def average(exprs: Expression*): Expression = sum(new ExpressionVector(exprs))
 
   def sqrt(e: Expression): Expression = unary(e, dn.sqrt)
   def erf(e: Expression): Expression = unary(e, dn.erf)
@@ -193,7 +215,10 @@ object Expression {
     unary(x, x => dn.pickrange(x, v, u))
 
   def concatenateCols(v: ExpressionVector): Expression = vectory(v, dn.concatenate_cols)
+  def concatenateCols(exprs: Expression*): Expression = concatenateCols(new ExpressionVector(exprs))
+
   def concatenate(v: ExpressionVector): Expression = vectory(v, dn.concatenate)
+  def concatenate(exprs: Expression*): Expression = concatenate(new ExpressionVector(exprs))
 
   /* NOISE OPERATIONS */
 
@@ -219,15 +244,15 @@ object Expression {
   def contract3d1d(x: Expression, y: Expression): Expression = binary(x, y, dn.contract3d_1d)
   def contract3d1d1d(x: Expression, y: Expression, z: Expression): Expression = {
     Seq(x, y, z).foreach(_.ensureFresh)
-    new Expression(dn.contract3d_1d_1d(x.expr, y.expr, z.expr))
+    new Expression(dn.contract3d_1d_1d(x.expr, y.expr, z.expr), Seq(x, y, z))
   }
   def contract3d1d1d(x: Expression, y: Expression, z: Expression, b: Expression): Expression = {
     Seq(x, y, z, b).foreach(_.ensureFresh)
-    new Expression(dn.contract3d_1d_1d(x.expr, y.expr, z.expr, b.expr))
+    new Expression(dn.contract3d_1d_1d(x.expr, y.expr, z.expr, b.expr), Seq(x, y, z, b))
   }
   def contract3d1d(x: Expression, y: Expression, b: Expression): Expression = {
     Seq(x, y, b).foreach(_.ensureFresh)
-    new Expression(dn.contract3d_1d(x.expr, y.expr, b.expr))
+    new Expression(dn.contract3d_1d(x.expr, y.expr, b.expr), Seq(x, y, b))
   }
 
   /* LINEAR ALGEBRA OPERATIONS */

--- a/contrib/swig/src/test/scala/edu/cmu/dynet/ExpressionSpec.scala
+++ b/contrib/swig/src/test/scala/edu/cmu/dynet/ExpressionSpec.scala
@@ -70,4 +70,29 @@ class ExpressionSpec extends FlatSpec with Matchers {
 
     // TODO(joelgrus): write more tests
   }
+
+  "lists of expressions" should "get converted to vectors" in {
+    ComputationGraph.renew()
+
+    val exprs = for (i <- 1 to 100) yield Expression.input(i)
+
+    val sums = for (i <- 1 to 50) yield Expression.sum(exprs: _*)
+    sums.foreach(_ shouldHaveValue (1 to 100).sum)
+
+    val uberSum = Expression.sum(
+      new ExpressionVector(
+        for {
+          _ <- 1 to 1000
+          i1 = scala.util.Random.nextInt(100)
+          i2 = scala.util.Random.nextInt(100)
+          i3 = scala.util.Random.nextInt(100)
+        } yield Expression.sum(exprs(i1), exprs(i2), exprs(i3))
+      )
+    )
+
+    val value = uberSum.value.toFloat
+    value should be > 30f * 1000 * 3
+    value should be < 70f * 1000 * 3
+
+  }
 }


### PR DESCRIPTION
Added versions of all the `Expression.f(ev: ExpressionVector)` functions that take `Expression*` args. 

This requires creating potentially ephemeral `ExpressionVector` instances. as we discovered before, this can lead to problems when the garbage collector runs and deletes the underlying `std::vector`. I couldn't actually produce a segfault this way, but I think it's possible. 

Accordingly, I gave each `Expression` instance a `Seq[AnyRef]` of things that shouldn't be garbage collected before it is, and I modified all of the `Expression`-generating functions to set them.

let me know if you don't like this approach, but I think it's the right defensive thing to do.

(I also added some `debugString` methods, since outside of this package -- and in particular in PNP -- you can't see the internal state of DyNet objects, which makes it hard to figure out why something is not working right. I'll probably keep adding these as needed.)