### PR TITLE
Implement for new ParameterCollection interface

### DIFF
--- a/dynet/c2w.h
+++ b/dynet/c2w.h
@@ -18,13 +18,14 @@ struct C2WBuilder {
   LookupParameter p_lookup;
   std::vector<VariableIndex> words;
   std::map<int, VariableIndex> wordid2vi;
+  ParameterCollection local_model;
   explicit C2WBuilder(int vocab_size,
                       unsigned layers,
                       unsigned input_dim,
                       unsigned hidden_dim,
                       ParameterCollection& m) :
       p_lookup(m->add_lookup_parameters(vocab_size, {input_dim})) {
-    auto local_model = m.add_subcollection("--c2w-builder");
+    local_model = m.add_subcollection("--c2w-builder");
     fc2w = LSTMBuilder(layers, input_dim, hidden_dim, local_model);
     rc2w = LSTMBuilder(layers, input_dim, hidden_dim, local_model);
   }
@@ -56,10 +57,7 @@ struct C2WBuilder {
     return it->second;
   }
   std::vector<ParameterStorage*> get_parameters() {
-    std::vector<ParameterStorage*> rl = fc2w.get_parameters();
-    auto rev_ps = rc2w.get_parameters();
-    rl.insert(rl.end(), rev_ps.begin(), rev_ps.end());
-    return rl;
+    return local_model.get_parameters();
   }
 };
 

--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -20,7 +20,7 @@ SoftmaxBuilder::~SoftmaxBuilder() {}
 StandardSoftmaxBuilder::StandardSoftmaxBuilder() {}
 
 StandardSoftmaxBuilder::StandardSoftmaxBuilder(unsigned rep_dim, unsigned vocab_size, ParameterCollection& model) {
-  auto local_model = model.add_subcollection("--standard-softmax-builder");
+  local_model = model.add_subcollection("--standard-softmax-builder");
   p_w = local_model.add_parameters({vocab_size, rep_dim});
   p_b = local_model.add_parameters({vocab_size});
 }
@@ -65,7 +65,7 @@ ClassFactoredSoftmaxBuilder::ClassFactoredSoftmaxBuilder(unsigned rep_dim,
                              ParameterCollection& model) {
   read_cluster_file(cluster_file, word_dict);
   const unsigned num_clusters = cdict.size();
-  auto local_model = model.add_subcollection("--class-factored-softmax-builder");
+  local_model = model.add_subcollection("--class-factored-softmax-builder");
   p_r2c = local_model.add_parameters({num_clusters, rep_dim});
   p_cbias = local_model.add_parameters({num_clusters});
   p_rc2ws.resize(num_clusters);

--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -20,8 +20,9 @@ SoftmaxBuilder::~SoftmaxBuilder() {}
 StandardSoftmaxBuilder::StandardSoftmaxBuilder() {}
 
 StandardSoftmaxBuilder::StandardSoftmaxBuilder(unsigned rep_dim, unsigned vocab_size, ParameterCollection& model) {
-  p_w = model.add_parameters({vocab_size, rep_dim});
-  p_b = model.add_parameters({vocab_size});
+  auto local_model = model.add_subcollection("--standard-softmax-builder");
+  p_w = local_model.add_parameters({vocab_size, rep_dim});
+  p_b = local_model.add_parameters({vocab_size});
 }
 
 void StandardSoftmaxBuilder::new_graph(ComputationGraph& cg) {
@@ -64,8 +65,9 @@ ClassFactoredSoftmaxBuilder::ClassFactoredSoftmaxBuilder(unsigned rep_dim,
                              ParameterCollection& model) {
   read_cluster_file(cluster_file, word_dict);
   const unsigned num_clusters = cdict.size();
-  p_r2c = model.add_parameters({num_clusters, rep_dim});
-  p_cbias = model.add_parameters({num_clusters});
+  auto local_model = model.add_subcollection("--class-factored-softmax-builder");
+  p_r2c = local_model.add_parameters({num_clusters, rep_dim});
+  p_cbias = local_model.add_parameters({num_clusters});
   p_rc2ws.resize(num_clusters);
   p_rcwbiases.resize(num_clusters);
   for (unsigned i = 0; i < num_clusters; ++i) {
@@ -74,8 +76,8 @@ ClassFactoredSoftmaxBuilder::ClassFactoredSoftmaxBuilder(unsigned rep_dim,
     if (num_words_in_cluster > 1) {
       // for singleton clusters, we don't need these parameters, so
       // we don't create them
-      p_rc2ws[i] = model.add_parameters({num_words_in_cluster, rep_dim});
-      p_rcwbiases[i] = model.add_parameters({num_words_in_cluster});
+      p_rc2ws[i] = local_model.add_parameters({num_words_in_cluster, rep_dim});
+      p_rcwbiases[i] = local_model.add_parameters({num_words_in_cluster});
     }
   }
 }

--- a/dynet/cfsm-builder.h
+++ b/dynet/cfsm-builder.h
@@ -38,7 +38,12 @@ public:
   expr::Expression neg_log_softmax(const expr::Expression& rep, unsigned wordidx);
   unsigned sample(const expr::Expression& rep);
   expr::Expression full_log_distribution(const expr::Expression& rep);
-
+  std::vector<ParameterStorage*> get_parameters() {
+    std::vector<ParameterStorage*> rl;
+    rl.push_back(&p_w.get_storage());
+    rl.push_back(&p_b.get_storage());
+    return rl;
+  }
 private:
   StandardSoftmaxBuilder();
   Parameter p_w;
@@ -65,6 +70,19 @@ class ClassFactoredSoftmaxBuilder : public SoftmaxBuilder {
   unsigned sample(const expr::Expression& rep);
   expr::Expression full_log_distribution(const expr::Expression& rep);
   void initialize_expressions();
+
+  std::vector<ParameterStorage*> get_parameters() {
+    std::vector<ParameterStorage*> rl;
+    rl.push_back(&p_r2c.get_storage());
+    rl.push_back(&p_cbias.get_storage());
+    for (auto & p : p_rc2ws) {
+      rl.push_back(&p.get_storage());
+    }
+    for (auto & p : p_rcwbiases) {
+      rl.push_back(&p.get_storage());
+    }
+    return rl;
+  }
 
  private:
   ClassFactoredSoftmaxBuilder();

--- a/dynet/cfsm-builder.h
+++ b/dynet/cfsm-builder.h
@@ -39,10 +39,7 @@ public:
   unsigned sample(const expr::Expression& rep);
   expr::Expression full_log_distribution(const expr::Expression& rep);
   std::vector<ParameterStorage*> get_parameters() {
-    std::vector<ParameterStorage*> rl;
-    rl.push_back(&p_w.get_storage());
-    rl.push_back(&p_b.get_storage());
-    return rl;
+    return local_model.get_parameters();
   }
 private:
   StandardSoftmaxBuilder();
@@ -51,6 +48,7 @@ private:
   expr::Expression w;
   expr::Expression b;
   ComputationGraph* pcg;
+  ParameterCollection local_model;
 
   DYNET_SERIALIZE_DECLARE()
 };
@@ -72,16 +70,7 @@ class ClassFactoredSoftmaxBuilder : public SoftmaxBuilder {
   void initialize_expressions();
 
   std::vector<ParameterStorage*> get_parameters() {
-    std::vector<ParameterStorage*> rl;
-    rl.push_back(&p_r2c.get_storage());
-    rl.push_back(&p_cbias.get_storage());
-    for (auto & p : p_rc2ws) {
-      rl.push_back(&p.get_storage());
-    }
-    for (auto & p : p_rcwbiases) {
-      rl.push_back(&p.get_storage());
-    }
-    return rl;
+    return local_model.get_parameters();
   }
 
  private:
@@ -94,6 +83,7 @@ class ClassFactoredSoftmaxBuilder : public SoftmaxBuilder {
   std::vector<std::vector<unsigned>> cidx2words;
   std::vector<bool> singleton_cluster; // does cluster contain a single word type?
 
+  ParameterCollection local_model;
   // parameters
   Parameter p_r2c;
   Parameter p_cbias;

--- a/dynet/deep-lstm.cc
+++ b/dynet/deep-lstm.cc
@@ -18,7 +18,7 @@ DeepLSTMBuilder::DeepLSTMBuilder(unsigned layers,
                          unsigned hidden_dim,
                          ParameterCollection& model) : layers(layers) {
   unsigned layer_input_dim = input_dim;
-  auto local_model = model.add_subcollection("--deep-lstm-builder");
+  local_model = model.add_subcollection("--deep-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
     Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
@@ -161,13 +161,7 @@ Expression DeepLSTMBuilder::add_input_impl(int prev, const Expression& x) {
 }
 
 std::vector<ParameterStorage*> DeepLSTMBuilder::get_parameters() {
-  std::vector<ParameterStorage*> rl;
-  for (auto & p_l : params) {
-    for (auto & p : p_l) {
-      rl.push_back(&p.get_storage());
-    }
-  }
-  return rl;
+  return local_model.get_parameters();
 }
 
 } // namespace dynet

--- a/dynet/deep-lstm.cc
+++ b/dynet/deep-lstm.cc
@@ -18,23 +18,24 @@ DeepLSTMBuilder::DeepLSTMBuilder(unsigned layers,
                          unsigned hidden_dim,
                          ParameterCollection& model) : layers(layers) {
   unsigned layer_input_dim = input_dim;
+  auto local_model = model.add_subcollection("--deep-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
-    Parameter p_x2i = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bi = model.add_parameters({hidden_dim});
+    Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2i = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_c2i = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bi = local_model.add_parameters({hidden_dim});
 
     // o
-    Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_c2o = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bo = model.add_parameters({hidden_dim});
+    Parameter p_x2o = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2o = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_c2o = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bo = local_model.add_parameters({hidden_dim});
 
     // c
-    Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bc = model.add_parameters({hidden_dim});
+    Parameter p_x2c = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2c = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bc = local_model.add_parameters({hidden_dim});
     layer_input_dim = hidden_dim + input_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_h2i, p_c2i, p_bi, p_x2o, p_h2o, p_c2o, p_bo, p_x2c, p_h2c, p_bc};
@@ -157,6 +158,16 @@ Expression DeepLSTMBuilder::add_input_impl(int prev, const Expression& x) {
   }
   ot = concatenate(cc);
   return ot;
+}
+
+std::vector<ParameterStorage*> DeepLSTMBuilder::get_parameters() {
+  std::vector<ParameterStorage*> rl;
+  for (auto & p_l : params) {
+    for (auto & p : p_l) {
+      rl.push_back(&p.get_storage());
+    }
+  }
+  return rl;
 }
 
 } // namespace dynet

--- a/dynet/deep-lstm.h
+++ b/dynet/deep-lstm.h
@@ -36,6 +36,7 @@ struct DeepLSTMBuilder : public RNNBuilder {
   Expression add_input_impl(int prev, const Expression& x) override;
 
  public:
+  ParameterCollection local_model;
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;
 

--- a/dynet/deep-lstm.h
+++ b/dynet/deep-lstm.h
@@ -25,6 +25,11 @@ struct DeepLSTMBuilder : public RNNBuilder {
     for(auto my_h : final_h()) ret.push_back(my_h);
     return ret;
   }
+  /**
+   * \brief Get parameters in DeepLSTMBuilder
+   * \return list of points to ParameterStorage object
+   */
+  std::vector<ParameterStorage*> get_parameters();
  protected:
   void new_graph_impl(ComputationGraph& cg) override;
   void start_new_sequence_impl(const std::vector<Expression>& h0) override;

--- a/dynet/fast-lstm.cc
+++ b/dynet/fast-lstm.cc
@@ -23,23 +23,24 @@ FastLSTMBuilder::FastLSTMBuilder(unsigned layers,
                                  unsigned hidden_dim,
                                  ParameterCollection& model) : layers(layers) {
   unsigned layer_input_dim = input_dim;
+  auto local_model = model.add_subcollection("--fast-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
-    Parameter p_x2i = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_c2i = model.add_parameters({hidden_dim, 1});
-    Parameter p_bi = model.add_parameters({hidden_dim});
+    Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2i = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_c2i = local_model.add_parameters({hidden_dim, 1});
+    Parameter p_bi = local_model.add_parameters({hidden_dim});
 
     // o
-    Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_c2o = model.add_parameters({hidden_dim, 1});
-    Parameter p_bo = model.add_parameters({hidden_dim});
+    Parameter p_x2o = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2o = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_c2o = local_model.add_parameters({hidden_dim, 1});
+    Parameter p_bo = local_model.add_parameters({hidden_dim});
 
     // c
-    Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bc = model.add_parameters({hidden_dim});
+    Parameter p_x2c = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2c = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bc = local_model.add_parameters({hidden_dim});
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_h2i, p_c2i, p_bi, p_x2o, p_h2o, p_c2o, p_bo, p_x2c, p_h2c, p_bc};
@@ -208,6 +209,16 @@ void FastLSTMBuilder::copy(const RNNBuilder & rnn) {
   for(size_t i = 0; i < params.size(); ++i)
       for(size_t j = 0; j < params[i].size(); ++j)
         params[i][j] = rnn_lstm.params[i][j];
+}
+
+std::vector<ParameterStorage*> FastLSTMBuilder::get_parameters() {
+  std::vector<ParameterStorage*> rl;
+  for (auto & p_l : params) {
+    for (auto & p : p_l) {
+      rl.push_back(&p.get_storage());
+    }
+  }
+  return rl;
 }
 
 } // namespace dynet

--- a/dynet/fast-lstm.cc
+++ b/dynet/fast-lstm.cc
@@ -23,7 +23,7 @@ FastLSTMBuilder::FastLSTMBuilder(unsigned layers,
                                  unsigned hidden_dim,
                                  ParameterCollection& model) : layers(layers) {
   unsigned layer_input_dim = input_dim;
-  auto local_model = model.add_subcollection("--fast-lstm-builder");
+  local_model = model.add_subcollection("--fast-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
     Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
@@ -212,13 +212,7 @@ void FastLSTMBuilder::copy(const RNNBuilder & rnn) {
 }
 
 std::vector<ParameterStorage*> FastLSTMBuilder::get_parameters() {
-  std::vector<ParameterStorage*> rl;
-  for (auto & p_l : params) {
-    for (auto & p : p_l) {
-      rl.push_back(&p.get_storage());
-    }
-  }
-  return rl;
+  return local_model.get_parameters();
 }
 
 } // namespace dynet

--- a/dynet/fast-lstm.h
+++ b/dynet/fast-lstm.h
@@ -38,6 +38,11 @@ struct FastLSTMBuilder : public RNNBuilder {
   }
 
   void copy(const RNNBuilder & params) override;
+  /**
+   * \brief Get parameters in FastLSTMBuilder
+   * \return list of points to ParameterStorage objects
+   */
+  std::vector<ParameterStorage*> get_parameters();
  protected:
   void new_graph_impl(ComputationGraph& cg) override;
   void start_new_sequence_impl(const std::vector<Expression>& h0) override;

--- a/dynet/fast-lstm.h
+++ b/dynet/fast-lstm.h
@@ -51,6 +51,7 @@ struct FastLSTMBuilder : public RNNBuilder {
   Expression set_s_impl(int prev, const std::vector<Expression>& s_new) override;
 
  public:
+  ParameterCollection local_model;
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;
 

--- a/dynet/gru.cc
+++ b/dynet/gru.cc
@@ -18,21 +18,22 @@ GRUBuilder::GRUBuilder(unsigned layers,
                        unsigned hidden_dim,
                        ParameterCollection& model) : hidden_dim(hidden_dim), layers(layers) {
   unsigned layer_input_dim = input_dim;
+  auto local_model = model.add_subcollection("--gru-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // z
-    Parameter p_x2z = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2z = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bz = model.add_parameters({hidden_dim});
+    Parameter p_x2z = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2z = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bz = local_model.add_parameters({hidden_dim});
 
     // r
-    Parameter p_x2r = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2r = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_br = model.add_parameters({hidden_dim});
+    Parameter p_x2r = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2r = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_br = local_model.add_parameters({hidden_dim});
 
     // h
-    Parameter p_x2h = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2h = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bh = model.add_parameters({hidden_dim});
+    Parameter p_x2h = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2h = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bh = local_model.add_parameters({hidden_dim});
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2z, p_h2z, p_bz, p_x2r, p_h2r, p_br, p_x2h, p_h2h, p_bh};
@@ -152,6 +153,16 @@ void GRUBuilder::copy(const RNNBuilder & rnn) {
   for (size_t i = 0; i < params.size(); ++i)
     for (size_t j = 0; j < params[i].size(); ++j)
       params[i][j] = rnn_gru.params[i][j];
+}
+
+std::vector<ParameterStorage*> GRUBuilder::get_parameters() {
+  std::vector<ParameterStorage*> rl;
+  for (auto & p_l : params) {
+    for (auto & p : p_l) {
+      rl.push_back(&p.get_storage());
+    }
+  }
+  return rl;
 }
 
 } // namespace dynet

--- a/dynet/gru.cc
+++ b/dynet/gru.cc
@@ -18,7 +18,7 @@ GRUBuilder::GRUBuilder(unsigned layers,
                        unsigned hidden_dim,
                        ParameterCollection& model) : hidden_dim(hidden_dim), layers(layers) {
   unsigned layer_input_dim = input_dim;
-  auto local_model = model.add_subcollection("--gru-builder");
+  local_model = model.add_subcollection("--gru-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // z
     Parameter p_x2z = local_model.add_parameters({hidden_dim, layer_input_dim});
@@ -156,13 +156,7 @@ void GRUBuilder::copy(const RNNBuilder & rnn) {
 }
 
 std::vector<ParameterStorage*> GRUBuilder::get_parameters() {
-  std::vector<ParameterStorage*> rl;
-  for (auto & p_l : params) {
-    for (auto & p : p_l) {
-      rl.push_back(&p.get_storage());
-    }
-  }
-  return rl;
+  return local_model.get_parameters();
 }
 
 } // namespace dynet

--- a/dynet/gru.h
+++ b/dynet/gru.h
@@ -21,7 +21,7 @@ struct GRUBuilder : public RNNBuilder {
   std::vector<Expression> get_s(RNNPointer i) const override { return get_h(i); }
   unsigned num_h0_components() const override { return layers; }
   void copy(const RNNBuilder & params) override;
-
+  std::vector<ParameterStorage*> get_parameters();
 
  protected:
   void new_graph_impl(ComputationGraph& cg) override;

--- a/dynet/gru.h
+++ b/dynet/gru.h
@@ -30,6 +30,7 @@ struct GRUBuilder : public RNNBuilder {
   Expression set_h_impl(int prev, const std::vector<Expression>& h_new) override;
   Expression set_s_impl(int prev, const std::vector<Expression>& s_new) override;
 
+  ParameterCollection local_model;
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;
 

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -19,7 +19,7 @@ LSTMBuilder::LSTMBuilder(unsigned layers,
                          unsigned hidden_dim,
                          ParameterCollection& model) : layers(layers), input_dim(input_dim), hid(hidden_dim) {
   unsigned layer_input_dim = input_dim;
-  auto local_model = model.add_subcollection("lstm-builder");
+  auto local_model = model.add_subcollection("--lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
     Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
@@ -348,12 +348,13 @@ VanillaLSTMBuilder::VanillaLSTMBuilder(unsigned layers,
                                        unsigned hidden_dim,
                                        ParameterCollection& model) : layers(layers), input_dim(input_dim), hid(hidden_dim) {
   unsigned layer_input_dim = input_dim;
+  auto local_model = model.add_subcollection("--vanilla-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
-    Parameter p_x2i = model.add_parameters({hidden_dim * 4, layer_input_dim});
-    Parameter p_h2i = model.add_parameters({hidden_dim * 4, hidden_dim});
+    Parameter p_x2i = local_model.add_parameters({hidden_dim * 4, layer_input_dim});
+    Parameter p_h2i = local_model.add_parameters({hidden_dim * 4, hidden_dim});
     //Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bi = model.add_parameters({hidden_dim * 4});
+    Parameter p_bi = local_model.add_parameters({hidden_dim * 4});
 
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
@@ -419,6 +420,15 @@ void VanillaLSTMBuilder::set_dropout_masks(unsigned batch_size) {
   }
 }
 
+std::vector<ParameterStorage*> VanillaLSTMBuilder::get_parameters() {
+  std::vector<ParameterStorage*> rl;
+  for (auto & p_l : params) {
+    for (auto & p : p_l) {
+      rl.push_back(&p.get_storage());
+    }
+  }
+  return rl;
+}
 
 // TODO - Make this correct
 // Copied c from the previous step (otherwise c.size()< h.size())

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -19,7 +19,7 @@ LSTMBuilder::LSTMBuilder(unsigned layers,
                          unsigned hidden_dim,
                          ParameterCollection& model) : layers(layers), input_dim(input_dim), hid(hidden_dim) {
   unsigned layer_input_dim = input_dim;
-  auto local_model = model.add_subcollection("--lstm-builder");
+  local_model = model.add_subcollection("--lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
     Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
@@ -134,13 +134,7 @@ void LSTMBuilder::set_dropout_masks(unsigned batch_size) {
 }
 
 std::vector<ParameterStorage*> LSTMBuilder::get_parameters() {
-  std::vector<ParameterStorage*> rl;
-  for (auto & p_l : params) {
-    for (auto & p : p_l) {
-      rl.push_back(&p.get_storage());
-    }
-  }
-  return rl;
+  return local_model.get_parameters();
 }
 
 // TO DO - Make this correct
@@ -348,7 +342,7 @@ VanillaLSTMBuilder::VanillaLSTMBuilder(unsigned layers,
                                        unsigned hidden_dim,
                                        ParameterCollection& model) : layers(layers), input_dim(input_dim), hid(hidden_dim) {
   unsigned layer_input_dim = input_dim;
-  auto local_model = model.add_subcollection("--vanilla-lstm-builder");
+  local_model = model.add_subcollection("--vanilla-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
     Parameter p_x2i = local_model.add_parameters({hidden_dim * 4, layer_input_dim});
@@ -421,13 +415,7 @@ void VanillaLSTMBuilder::set_dropout_masks(unsigned batch_size) {
 }
 
 std::vector<ParameterStorage*> VanillaLSTMBuilder::get_parameters() {
-  std::vector<ParameterStorage*> rl;
-  for (auto & p_l : params) {
-    for (auto & p : p_l) {
-      rl.push_back(&p.get_storage());
-    }
-  }
-  return rl;
+  return local_model.get_parameters();
 }
 
 // TODO - Make this correct

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -19,23 +19,24 @@ LSTMBuilder::LSTMBuilder(unsigned layers,
                          unsigned hidden_dim,
                          ParameterCollection& model) : layers(layers), input_dim(input_dim), hid(hidden_dim) {
   unsigned layer_input_dim = input_dim;
+  auto local_model = model.add_subcollection("lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
-    Parameter p_x2i = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bi = model.add_parameters({hidden_dim});
+    Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2i = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_c2i = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bi = local_model.add_parameters({hidden_dim});
 
     // o
-    Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_c2o = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bo = model.add_parameters({hidden_dim});
+    Parameter p_x2o = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2o = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_c2o = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bo = local_model.add_parameters({hidden_dim});
 
     // c
-    Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bc = model.add_parameters({hidden_dim});
+    Parameter p_x2c = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2c = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_bc = local_model.add_parameters({hidden_dim});
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_h2i, p_c2i, p_bi, p_x2o, p_h2o, p_c2o, p_bo, p_x2c, p_h2c, p_bc};
@@ -131,6 +132,17 @@ void LSTMBuilder::set_dropout_masks(unsigned batch_size) {
     }
   }
 }
+
+std::vector<ParameterStorage*> LSTMBuilder::get_parameters() {
+  std::vector<ParameterStorage*> rl;
+  for (auto & p_l : params) {
+    for (auto & p : p_l) {
+      rl.push_back(&p.get_storage());
+    }
+  }
+  return rl;
+}
+
 // TO DO - Make this correct
 // Copied c from the previous step (otherwise c.size()< h.size())
 // Also is creating a new step something we want?

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -141,6 +141,8 @@ protected:
   Expression set_s_impl(int prev, const std::vector<Expression>& s_new) override;
 
 public:
+  ParameterCollection local_model;
+
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;
 
@@ -281,6 +283,7 @@ protected:
   Expression set_s_impl(int prev, const std::vector<Expression>& s_new) override;
 
 public:
+  ParameterCollection local_model;
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;
 

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -128,6 +128,11 @@ struct LSTMBuilder : public RNNBuilder {
    * \param batch_size Batch size
    */
   void set_dropout_masks(unsigned batch_size = 1);
+  /**
+   * \brief Get parameters in LSTMBuilder
+   * \return list of points to ParameterStorage objects
+   */
+  std::vector<ParameterStorage*> get_parameters();
 protected:
   void new_graph_impl(ComputationGraph& cg) override;
   void start_new_sequence_impl(const std::vector<Expression>& h0) override;

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -268,6 +268,11 @@ struct VanillaLSTMBuilder : public RNNBuilder {
    * \param batch_size Batch size
    */
   void set_dropout_masks(unsigned batch_size = 1);
+  /**
+   * \brief Get parameters in VanillaLSTMBuilder 
+   * \return list of points to ParameterStorage objects
+   */
+  std::vector<ParameterStorage*> get_parameters();
 protected:
   void new_graph_impl(ComputationGraph& cg) override;
   void start_new_sequence_impl(const std::vector<Expression>& h0) override;

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -307,6 +307,20 @@ void ParameterCollection::add_parameters_to_storage(ParameterStorage *p) {
   }
 }
 
+ParameterStorage* ParameterCollection::get_parameter(const std::string & pname) {
+  if (pname.find(name) == 0) {
+    ParameterCollection *t = this;
+    while (t->parent != nullptr) { t = t->parent; }
+    for (auto & param : t->get_storage().params) {
+      if (param->name == pname) {
+        return param;
+      }
+    }
+  }
+  std::string errMsg = "No existing parameter " + pname + " found in " + name;
+  throw std::runtime_error(errMsg);
+}
+
 std::vector<ParameterStorage*> ParameterCollection::get_parameters() {
   std::vector<ParameterStorage*> params;
   ParameterCollection *t = this;
@@ -343,6 +357,21 @@ void ParameterCollection::add_lookup_parameters_to_storage(LookupParameterStorag
     storage->all_params.push_back(p);
     storage->lookup_params.push_back(p);
   }
+}
+
+LookupParameterStorage* ParameterCollection::get_lookup_parameter(const std::string & lookup_pname)
+{
+  if (lookup_pname.find(name) == 0) {
+    ParameterCollection *t = this;
+    while (t->parent != nullptr) { t = t->parent; }
+    for (auto & lookup_param : t->get_storage().lookup_params) {
+      if (lookup_param->name == lookup_pname) {
+        return lookup_param;
+      }
+    }
+  }
+  std::string errMsg = "No existing parameter " + lookup_pname + " found in " + name;
+  throw std::runtime_error(errMsg);
 }
 
 std::vector<LookupParameterStorage*> ParameterCollection::get_lookup_parameters() {

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -158,6 +158,11 @@ void Parameter::zero() {
   get_storage().zero();
 }
 
+string Parameter::get_fullname() const {
+  DYNET_ASSERT(p != nullptr, "Attempt to get pointer for null parameter");
+  return p->name;
+}
+
 void Parameter::set_updated(bool b) {
   get_storage().updated = b;
 }
@@ -190,6 +195,11 @@ void LookupParameter::zero() {
 
 void LookupParameter::initialize(unsigned index, const std::vector<float>& val) const {
   get_storage().initialize(index, val);
+}
+
+string LookupParameter::get_fullname() const {
+  DYNET_ASSERT(p != nullptr, "Attempt to get pointer for null parameter");
+  return p->name;
 }
 
 void LookupParameter::set_updated(bool b) {
@@ -240,7 +250,7 @@ ParameterCollection::ParameterCollection(const string & my_name, ParameterCollec
     name(my_name), storage(nullptr), parent(my_parent) { }
 
 ParameterCollection ParameterCollection::add_subcollection(const string & sub_name) {
-  ostringstream oss; oss << name << sub_name << "__" << ++collec_name_cntr[sub_name] << "/";
+  ostringstream oss; oss << name << sub_name << "__" << collec_name_cntr[sub_name]++ << "/";
   return ParameterCollection(oss.str(), this);
 }
 
@@ -257,6 +267,10 @@ void ParameterCollection::project_weights(float radius) {
   get_storage().project_weights(radius);
 }
 
+Parameter ParameterCollection::add_parameters(const Dim & d, const std::string & p_name) {
+  return add_parameters(d, ParameterInitGlorot(), p_name);
+}
+
 Parameter ParameterCollection::add_parameters(const Dim& d, float scale, const std::string & p_name) {
   if(scale == 0.0f)
     return add_parameters(d, ParameterInitGlorot(), p_name);
@@ -265,7 +279,7 @@ Parameter ParameterCollection::add_parameters(const Dim& d, float scale, const s
 }
 
 Parameter ParameterCollection::add_parameters(const Dim& d, const ParameterInit & init, const std::string & p_name) {
-  ostringstream oss; oss << name << p_name << "__" << ++name_cntr[p_name];
+  ostringstream oss; oss << name << p_name << "__" << name_cntr[p_name]++;
   ParameterStorage* p = new ParameterStorage(d, init, oss.str());
   add_parameters_to_storage(p);
   return Parameter(p);
@@ -287,7 +301,7 @@ LookupParameter ParameterCollection::add_lookup_parameters(unsigned n, const Dim
 }
 
 LookupParameter ParameterCollection::add_lookup_parameters(unsigned n, const Dim& d, const ParameterInit & init, const std::string & p_name) {
-  ostringstream oss; oss << name << p_name << "__" << ++name_cntr[p_name];
+  ostringstream oss; oss << name << p_name << "__" << name_cntr[p_name]++;
   LookupParameterStorage* p = new LookupParameterStorage(n, d, init, oss.str());
   add_lookup_parameters_to_storage(p);
   return LookupParameter(p);

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -307,6 +307,18 @@ void ParameterCollection::add_parameters_to_storage(ParameterStorage *p) {
   }
 }
 
+std::vector<ParameterStorage*> ParameterCollection::get_parameters() {
+  std::vector<ParameterStorage*> params;
+  ParameterCollection *t = this;
+  while (t->parent != nullptr) { t = t->parent; }
+  for (auto & param : t->get_storage().params) {
+    if (param->name.find(name) == 0) {
+      params.push_back(param);
+    }
+  }
+  return params;
+}
+
 LookupParameter ParameterCollection::add_lookup_parameters(unsigned n, const Dim& d, const std::string & p_name) {
   return add_lookup_parameters(n, d, ParameterInitGlorot(true), p_name);
 }
@@ -331,6 +343,18 @@ void ParameterCollection::add_lookup_parameters_to_storage(LookupParameterStorag
     storage->all_params.push_back(p);
     storage->lookup_params.push_back(p);
   }
+}
+
+std::vector<LookupParameterStorage*> ParameterCollection::get_lookup_parameters() {
+  std::vector<LookupParameterStorage*> lookup_params;
+  ParameterCollection *t = this;
+  while (t->parent != nullptr) { t = t->parent; }
+  for (auto & lookup_param: t->get_storage().lookup_params) {
+    if (lookup_param->name.find(name) == 0) {
+      lookup_params.push_back(lookup_param); 
+    }
+  }
+  return lookup_params;
 }
 
 void ParameterCollection::reset_gradient() {

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -83,7 +83,7 @@ DYNET_SERIALIZE_COMMIT(ParameterStorage,
 DYNET_SERIALIZE_IMPL(ParameterStorage)
 #endif
 
-bool validParameter(const std::string & s) {
+bool valid_parameter(const std::string & s) {
   auto it = std::find_if(s.begin(), s.end(), [] (char ch) { return ch == '/' || ch == '_'; });
   return it == s.end();
 }
@@ -253,7 +253,7 @@ ParameterCollection::ParameterCollection(const string & my_name, ParameterCollec
     name(my_name), storage(nullptr), parent(my_parent) { }
 
 ParameterCollection ParameterCollection::add_subcollection(const string & sub_name) {
-  if (validParameter(sub_name)) {
+  if (valid_parameter(sub_name)) {
     ostringstream oss; oss << name << sub_name << "__" << collec_name_cntr[sub_name]++ << "/";
     return ParameterCollection(oss.str(), this);
   } else {
@@ -286,7 +286,7 @@ Parameter ParameterCollection::add_parameters(const Dim& d, float scale, const s
 }
 
 Parameter ParameterCollection::add_parameters(const Dim& d, const ParameterInit & init, const std::string & p_name) {
-  if (validParameter(p_name)) {
+  if (valid_parameter(p_name)) {
     ostringstream oss; oss << name << p_name << "__" << name_cntr[p_name]++;
     ParameterStorage* p = new ParameterStorage(d, init, oss.str());
     add_parameters_to_storage(p);
@@ -338,7 +338,7 @@ LookupParameter ParameterCollection::add_lookup_parameters(unsigned n, const Dim
 }
 
 LookupParameter ParameterCollection::add_lookup_parameters(unsigned n, const Dim& d, const ParameterInit & init, const std::string & p_name) {
-  if (validParameter(p_name)) {
+  if (valid_parameter(p_name)) {
     ostringstream oss; oss << name << p_name << "__" << name_cntr[p_name]++;
     LookupParameterStorage* p = new LookupParameterStorage(n, d, init, oss.str());
     add_lookup_parameters_to_storage(p);

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -448,6 +448,12 @@ public:
    */
   Parameter add_parameters(const Dim& d, const ParameterInit & init, const std::string & name = "");
   /**
+   * \brief Get parameters in current model
+   *
+   * \return list of points to ParameterStorage objects
+   */
+  std::vector<ParameterStorage*> get_parameters();
+  /**
    * \brief Add lookup parameter to model
    * \details Same as add_parameters. Initializes with Glorot
    *
@@ -468,6 +474,12 @@ public:
    * \return LookupParameter object to be used in the computation graph
    */
   LookupParameter add_lookup_parameters(unsigned n, const Dim& d, const ParameterInit & init, const std::string & name = "");
+  /**
+   * \brief Get lookup parameters in current model
+   *
+   * \return list of points to LookupParameterStorage objects
+   */
+  std::vector<LookupParameterStorage*> get_lookup_parameters();
   //
   /**
    * \brief project weights so their L2 norm = radius

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -72,7 +72,7 @@ struct ParameterStorageBase {
   virtual size_t size() const = 0;
   virtual ~ParameterStorageBase();
   DYNET_SERIALIZE_COMMIT_EMPTY()
-};
+}; // struct ParameterStorageBase
 
 // represents parameters (e.g., a weight matrix) that will be optimized
 /**
@@ -125,7 +125,7 @@ private:
   ParameterStorage() : updated(true), owner(nullptr) {}
   explicit ParameterStorage(const Dim& d, const ParameterInit & init, const std::string & name); // initialize with custom initializer
   DYNET_SERIALIZE_DECLARE()
-};
+}; // struct ParameterStorage
 
 // represents a matrix/vector embedding of a discrete set
 /**
@@ -220,7 +220,7 @@ private:
   LookupParameterStorage() : updated(true), all_updated(false), owner(nullptr) {}
   LookupParameterStorage(unsigned n, const Dim& d, const ParameterInit & init, const std::string & name);
   DYNET_SERIALIZE_SPLIT_DECLARE()
-};
+}; // // struct LookupParameterStorage
 
 /**
  * \ingroup params
@@ -245,6 +245,11 @@ struct Parameter {
    * @return ParameterStorage holding the parameter values
    */
   ParameterStorage& get_storage() const;
+
+  /**
+   * @brief Get the full name of the ParameterStorage object
+   */
+  std::string get_fullname() const;
 
   /**
    * \brief Zero the parameters
@@ -286,7 +291,7 @@ struct Parameter {
 
 private:
   DYNET_SERIALIZE_DECLARE()
-};
+}; // struct Parameter
 
 /**
  * \ingroup params
@@ -315,6 +320,11 @@ struct LookupParameter {
   void zero();
 
   LookupParameterStorage* p; /**< Pointer to the storage for this Parameter */
+
+  /**
+   * @brief Get the full name of the ParameterStorage object
+   */
+  std::string get_fullname() const;
 
   /**
    * \brief Shape of the lookup parameter
@@ -348,7 +358,7 @@ struct LookupParameter {
 
 private:
   DYNET_SERIALIZE_DECLARE()
-};
+}; // struct LookupParameter
 
 // This is an internal class to store parameters in the collection
 struct ParameterCollectionStorage {
@@ -405,6 +415,16 @@ public:
    * \brief Sets all gradients to zero
    */
   void reset_gradient();
+  /**
+   * \brief Add parameters to model and returns Parameter object
+   * \details creates a ParameterStorage object holding a tensor of dimension `d` and returns a Parameter object (to be used as input in the computation graph).
+   *
+   * \param d Shape of the parameter
+   * \param name Name of the parameter
+   *
+   * \return Parameter object to be used in the computation graph
+   */
+  Parameter add_parameters(const Dim& d, const std::string & name);
   // set scale to use custom initialization
   /**
    * \brief Add parameters to model and returns Parameter object
@@ -533,6 +553,11 @@ public:
    * \return The subcollection
    */
   ParameterCollection add_subcollection(const std::string& name = "");
+
+  /**
+   * @brief get namespace of current ParameterCollection object(end with a slash)
+   */
+  std::string get_namespace() { return name; }
 
   /**
    * \brief Get the weight decay object

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -448,6 +448,12 @@ public:
    */
   Parameter add_parameters(const Dim& d, const ParameterInit & init, const std::string & name = "");
   /**
+   * \brief Get parameter in current model
+   * \details It is not recommended to use this
+   * \return the pointer to the Parameter object
+   */
+  ParameterStorage* get_parameter(const std::string & pname);
+  /**
    * \brief Get parameters in current model
    *
    * \return list of points to ParameterStorage objects
@@ -474,6 +480,12 @@ public:
    * \return LookupParameter object to be used in the computation graph
    */
   LookupParameter add_lookup_parameters(unsigned n, const Dim& d, const ParameterInit & init, const std::string & name = "");
+  /**
+   * \brief Get lookup parameter in current model
+   * \details It is not recommended to use this
+   * \return the pointer to the LookupParameter object
+   */
+  LookupParameterStorage* get_lookup_parameter(const std::string & lookup_pname);
   /**
    * \brief Get lookup parameters in current model
    *

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -34,14 +34,15 @@ SimpleRNNBuilder::SimpleRNNBuilder(unsigned layers,
                        unsigned hidden_dim,
                        ParameterCollection& model,
                        bool support_lags) : layers(layers), lagging(support_lags) {
+  auto local_model = model.add_subcollection("simple-rnn-builder");
   unsigned layer_input_dim = input_dim;
   for (unsigned i = 0; i < layers; ++i) {
-    Parameter p_x2h = model.add_parameters({hidden_dim, layer_input_dim});
-    Parameter p_h2h = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_hb = model.add_parameters({hidden_dim});
+    Parameter p_x2h = local_model.add_parameters({hidden_dim, layer_input_dim});
+    Parameter p_h2h = local_model.add_parameters({hidden_dim, hidden_dim});
+    Parameter p_hb = local_model.add_parameters({hidden_dim});
     vector<Parameter> ps = {p_x2h, p_h2h, p_hb};
     if (lagging)
-        ps.push_back(model.add_parameters({hidden_dim, hidden_dim}));
+        ps.push_back(local_model.add_parameters({hidden_dim, hidden_dim}));
     params.push_back(ps);
     layer_input_dim = hidden_dim;
   }

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -34,7 +34,7 @@ SimpleRNNBuilder::SimpleRNNBuilder(unsigned layers,
                        unsigned hidden_dim,
                        ParameterCollection& model,
                        bool support_lags) : layers(layers), lagging(support_lags) {
-  auto local_model = model.add_subcollection("simple-rnn-builder");
+  auto local_model = model.add_subcollection("--simple-rnn-builder");
   unsigned layer_input_dim = input_dim;
   for (unsigned i = 0; i < layers; ++i) {
     Parameter p_x2h = local_model.add_parameters({hidden_dim, layer_input_dim});
@@ -184,6 +184,16 @@ void SimpleRNNBuilder::load_parameters_pretraining(const string& fname) {
       ia >> p.get_storage().values;
     }
   }
+}
+
+std::vector<ParameterStorage*> SimpleRNNBuilder::get_parameters() {
+  std::vector<ParameterStorage*> rl;
+  for (auto & p_l : params) {
+    for (auto & p : p_l) {
+      rl.push_back(&p.get_storage());
+    }
+  }
+  return rl;
 }
 
 DYNET_SERIALIZE_COMMIT(SimpleRNNBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(RNNBuilder, params, layers, lagging))

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -34,7 +34,7 @@ SimpleRNNBuilder::SimpleRNNBuilder(unsigned layers,
                        unsigned hidden_dim,
                        ParameterCollection& model,
                        bool support_lags) : layers(layers), lagging(support_lags) {
-  auto local_model = model.add_subcollection("--simple-rnn-builder");
+  local_model = model.add_subcollection("--simple-rnn-builder");
   unsigned layer_input_dim = input_dim;
   for (unsigned i = 0; i < layers; ++i) {
     Parameter p_x2h = local_model.add_parameters({hidden_dim, layer_input_dim});
@@ -187,13 +187,7 @@ void SimpleRNNBuilder::load_parameters_pretraining(const string& fname) {
 }
 
 std::vector<ParameterStorage*> SimpleRNNBuilder::get_parameters() {
-  std::vector<ParameterStorage*> rl;
-  for (auto & p_l : params) {
-    for (auto & p : p_l) {
-      rl.push_back(&p.get_storage());
-    }
-  }
-  return rl;
+  return local_model.get_parameters();
 }
 
 DYNET_SERIALIZE_COMMIT(SimpleRNNBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(RNNBuilder, params, layers, lagging))

--- a/dynet/rnn.h
+++ b/dynet/rnn.h
@@ -350,6 +350,7 @@ public:
   std::vector<ParameterStorage*> get_parameters();
 
 private:
+  ParameterCollection local_model;
   // first index is layer, then x2h h2h hb
   std::vector<std::vector<Parameter>> params;
 

--- a/dynet/rnn.h
+++ b/dynet/rnn.h
@@ -347,6 +347,8 @@ public:
   void save_parameters_pretraining(const std::string& fname) const override;
   void load_parameters_pretraining(const std::string& fname) override;
 
+  std::vector<ParameterStorage*> get_parameters();
+
 private:
   // first index is layer, then x2h h2h hb
   std::vector<std::vector<Parameter>> params;

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -36,7 +36,7 @@ NaryTreeLSTMBuilder::NaryTreeLSTMBuilder(unsigned N,
                          unsigned hidden_dim,
                          ParameterCollection& model) : layers(layers), N(N), cg(nullptr) {
   unsigned layer_input_dim = input_dim;
-  auto local_model = model.add_subcollection("--nary-tree-lstm-builder");
+  local_model = model.add_subcollection("--nary-tree-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
     Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
@@ -284,13 +284,7 @@ void NaryTreeLSTMBuilder::copy(const RNNBuilder & rnn) {
 }
 
 std::vector<ParameterStorage*> NaryTreeLSTMBuilder::get_parameters() {
-  std::vector<ParameterStorage*> rl;
-  for (auto & p_l : params) {
-    for (auto & p : p_l) {
-      rl.push_back(&p.get_storage());
-    }
-  }
-  return rl;
+  return local_model.get_parameters();
 }
 
 DYNET_SERIALIZE_COMMIT(NaryTreeLSTMBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(TreeLSTMBuilder, params, lparams, layers, N))
@@ -300,7 +294,7 @@ UnidirectionalTreeLSTMBuilder::UnidirectionalTreeLSTMBuilder(unsigned layers,
                          unsigned input_dim,
                          unsigned hidden_dim,
                          ParameterCollection& model) {
-  auto local_model = model.add_subcollection("--unidirectional-tree-lstm-builder");
+  local_model = model.add_subcollection("--unidirectional-tree-lstm-builder");
   node_builder = LSTMBuilder(layers, input_dim, hidden_dim, local_model);
 }
 
@@ -338,7 +332,7 @@ BidirectionalTreeLSTMBuilder::BidirectionalTreeLSTMBuilder(unsigned layers,
                          unsigned hidden_dim,
                          ParameterCollection& model) {
   DYNET_ASSERT(hidden_dim % 2 == 0, "Failed dimension check in TreeLSTMBuilder");
-  auto local_model = model.add_subcollection("--bidirectional-tree-lstm-builder");
+  local_model = model.add_subcollection("--bidirectional-tree-lstm-builder");
   fwd_node_builder = LSTMBuilder(layers, input_dim, hidden_dim / 2, local_model);
   rev_node_builder = LSTMBuilder(layers, input_dim, hidden_dim / 2, local_model);
 }

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -36,29 +36,30 @@ NaryTreeLSTMBuilder::NaryTreeLSTMBuilder(unsigned N,
                          unsigned hidden_dim,
                          ParameterCollection& model) : layers(layers), N(N), cg(nullptr) {
   unsigned layer_input_dim = input_dim;
+  auto local_model = model.add_subcollection("--nary-tree-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
     // i
-    Parameter p_x2i = model.add_parameters({hidden_dim, layer_input_dim});
-    LookupParameter p_h2i = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
-    LookupParameter p_c2i = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
-    Parameter p_bi = model.add_parameters({hidden_dim});
+    Parameter p_x2i = local_model.add_parameters({hidden_dim, layer_input_dim});
+    LookupParameter p_h2i = local_model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
+    LookupParameter p_c2i = local_model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
+    Parameter p_bi = local_model.add_parameters({hidden_dim});
 
     // f
-    Parameter p_x2f = model.add_parameters({hidden_dim, layer_input_dim});
-    LookupParameter p_h2f = model.add_lookup_parameters(N*N, {hidden_dim, hidden_dim});
-    LookupParameter p_c2f = model.add_lookup_parameters(N*N, {hidden_dim, hidden_dim});
-    Parameter p_bf = model.add_parameters({hidden_dim});
+    Parameter p_x2f = local_model.add_parameters({hidden_dim, layer_input_dim});
+    LookupParameter p_h2f = local_model.add_lookup_parameters(N*N, {hidden_dim, hidden_dim});
+    LookupParameter p_c2f = local_model.add_lookup_parameters(N*N, {hidden_dim, hidden_dim});
+    Parameter p_bf = local_model.add_parameters({hidden_dim});
 
     // o
-    Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
-    LookupParameter p_h2o = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
-    LookupParameter p_c2o = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
-    Parameter p_bo = model.add_parameters({hidden_dim});
+    Parameter p_x2o = local_model.add_parameters({hidden_dim, layer_input_dim});
+    LookupParameter p_h2o = local_model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
+    LookupParameter p_c2o = local_model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
+    Parameter p_bo = local_model.add_parameters({hidden_dim});
 
     // c (a.k.a. u)
-    Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
-    LookupParameter p_h2c = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
-    Parameter p_bc = model.add_parameters({hidden_dim});
+    Parameter p_x2c = local_model.add_parameters({hidden_dim, layer_input_dim});
+    LookupParameter p_h2c = local_model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
+    Parameter p_bc = local_model.add_parameters({hidden_dim});
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_bi, p_x2f, p_bf, p_x2o, p_bo, p_x2c, p_bc};
@@ -282,6 +283,16 @@ void NaryTreeLSTMBuilder::copy(const RNNBuilder & rnn) {
   }
 }
 
+std::vector<ParameterStorage*> NaryTreeLSTMBuilder::get_parameters() {
+  std::vector<ParameterStorage*> rl;
+  for (auto & p_l : params) {
+    for (auto & p : p_l) {
+      rl.push_back(&p.get_storage());
+    }
+  }
+  return rl;
+}
+
 DYNET_SERIALIZE_COMMIT(NaryTreeLSTMBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(TreeLSTMBuilder, params, lparams, layers, N))
 DYNET_SERIALIZE_IMPL(NaryTreeLSTMBuilder);
 
@@ -289,7 +300,8 @@ UnidirectionalTreeLSTMBuilder::UnidirectionalTreeLSTMBuilder(unsigned layers,
                          unsigned input_dim,
                          unsigned hidden_dim,
                          ParameterCollection& model) {
-  node_builder = LSTMBuilder(layers, input_dim, hidden_dim, model);
+  auto local_model = model.add_subcollection("--unidirectional-tree-lstm-builder");
+  node_builder = LSTMBuilder(layers, input_dim, hidden_dim, local_model);
 }
 
 void UnidirectionalTreeLSTMBuilder::new_graph_impl(ComputationGraph& cg) {
@@ -326,8 +338,9 @@ BidirectionalTreeLSTMBuilder::BidirectionalTreeLSTMBuilder(unsigned layers,
                          unsigned hidden_dim,
                          ParameterCollection& model) {
   DYNET_ASSERT(hidden_dim % 2 == 0, "Failed dimension check in TreeLSTMBuilder");
-  fwd_node_builder = LSTMBuilder(layers, input_dim, hidden_dim / 2, model);
-  rev_node_builder = LSTMBuilder(layers, input_dim, hidden_dim / 2, model);
+  auto local_model = model.add_subcollection("--bidirectional-tree-lstm-builder");
+  fwd_node_builder = LSTMBuilder(layers, input_dim, hidden_dim / 2, local_model);
+  rev_node_builder = LSTMBuilder(layers, input_dim, hidden_dim / 2, local_model);
 }
 
 void BidirectionalTreeLSTMBuilder::new_graph_impl(ComputationGraph& cg) {

--- a/dynet/treelstm.h
+++ b/dynet/treelstm.h
@@ -43,6 +43,7 @@ struct NaryTreeLSTMBuilder : public TreeLSTMBuilder {
 
   Expression add_input(int id, std::vector<int> children, const Expression& x) override;
   void copy(const RNNBuilder & params) override;
+  std::vector<ParameterStorage*> get_parameters();
  protected:
   void new_graph_impl(ComputationGraph& cg) override;
   void start_new_sequence_impl(const std::vector<Expression>& h0) override;
@@ -81,6 +82,7 @@ struct UnidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
                        ParameterCollection& model);
 
   Expression add_input(int id, std::vector<int> children, const Expression& x) override;
+  std::vector<ParameterStorage*> get_parameters() { return node_builder.get_parameters(); }
  protected:
   void new_graph_impl(ComputationGraph& cg) override;
   void start_new_sequence_impl(const std::vector<Expression>& h0) override;
@@ -101,6 +103,12 @@ struct BidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
                        ParameterCollection& model);
 
   Expression add_input(int id, std::vector<int> children, const Expression& x) override;
+  std::vector<ParameterStorage*> get_parameters() {
+    std::vector<ParameterStorage*> rl = fwd_node_builder.get_parameters();
+    auto rev_ps = rev_node_builder.get_parameters();
+    rl.insert(rl.end(), rev_ps.begin(), rev_ps.end());
+    return rl;
+  }
  protected:
   void new_graph_impl(ComputationGraph& cg) override;
   void start_new_sequence_impl(const std::vector<Expression>& h0) override;

--- a/dynet/treelstm.h
+++ b/dynet/treelstm.h
@@ -50,6 +50,7 @@ struct NaryTreeLSTMBuilder : public TreeLSTMBuilder {
   Expression Lookup(unsigned layer, unsigned p_type, unsigned value);
 
  public:
+  ParameterCollection local_model;
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;
   std::vector<std::vector<LookupParameter>> lparams;
@@ -88,6 +89,7 @@ struct UnidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
   void start_new_sequence_impl(const std::vector<Expression>& h0) override;
 
  public:
+  ParameterCollection local_model;
   LSTMBuilder node_builder;
   std::vector<Expression> h;
 
@@ -104,10 +106,7 @@ struct BidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
 
   Expression add_input(int id, std::vector<int> children, const Expression& x) override;
   std::vector<ParameterStorage*> get_parameters() {
-    std::vector<ParameterStorage*> rl = fwd_node_builder.get_parameters();
-    auto rev_ps = rev_node_builder.get_parameters();
-    rl.insert(rl.end(), rev_ps.begin(), rev_ps.end());
-    return rl;
+    return local_model.get_parameters();
   }
  protected:
   void new_graph_impl(ComputationGraph& cg) override;
@@ -118,6 +117,7 @@ struct BidirectionalTreeLSTMBuilder : public TreeLSTMBuilder {
   LSTMBuilder fwd_node_builder;
   LSTMBuilder rev_node_builder;
   std::vector<Expression> h;
+  ParameterCollection local_model;
 
 private:
   DYNET_SERIALIZE_DECLARE()

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -4,11 +4,13 @@
 #include <dynet/expr.h>
 #include <dynet/model.h>
 #include <dynet/param-init.h>
+#include <dynet/lstm.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <iostream>
 #include <fstream>
+#include <string>
 #include <stdexcept>
 #include "test.h"
 
@@ -40,6 +42,23 @@ struct ParamsTest {
     dynet::Dim d;
     std::vector<char*> av;
 };
+
+class testModel {
+ public:
+  testModel(dynet::ParameterCollection &model) {
+    lookup_param = model.add_lookup_parameters(1000, {128});
+    affine_params = model.add_subcollection("affine");
+    W_x = affine_params.add_parameters({40, 30});
+    b_x = affine_params.add_parameters({40});
+  }
+  std::string get_affine_model_name() { return affine_params.get_namespace(); }
+  dynet::ParameterCollection get_affine_model() const { return affine_params; }
+ private:
+  dynet::LookupParameter lookup_param;
+  dynet::Parameter W_x, b_x;
+  dynet::ParameterCollection affine_params;
+  dynet::LSTMBuilder lstm;
+}; // class testModel
 
 // define the test suite
 BOOST_FIXTURE_TEST_SUITE(params_test, ParamsTest);
@@ -79,6 +98,34 @@ BOOST_AUTO_TEST_CASE ( test_parameter_collection ) {
   DYNET_CHECK_EQUAL(c.get_fullname(), "/foo__0/__0");
   DYNET_CHECK_EQUAL(d.get_fullname(), "/foo__0/d__0");
   DYNET_CHECK_EQUAL(b3.get_fullname(), "/foo__0/b__0");
+}
+
+BOOST_AUTO_TEST_CASE ( test_parameter_class ) {
+  auto save_parameters_lambda = [] (const std::string & fname, dynet::ParameterCollection & m) -> size_t {
+    auto params = m.get_parameters();
+    auto lookup_params = m.get_lookup_parameters();
+    for (auto & param: params) {
+      std::cout << param->name << "saved in file " << fname << std::endl;
+    }
+    for (auto & lookup_param: lookup_params) {
+      std::cout << lookup_param->name << "saved in file " << fname << std::endl;
+    }
+    return params.size() + lookup_params.size();
+  };
+  auto save_parameters_lambda2 = [] (const std::string & fname, dynet::Parameter & p) -> std::string {
+    std::cout << p.get_storage().name << "saved in file " << fname << std::endl;
+    return p.get_storage().name;
+  };
+  ParameterCollection collec;
+  testModel spec(collec);
+  std::string affine_id_for_posterity = spec.get_affine_model_name();
+  DYNET_CHECK_EQUAL(affine_id_for_posterity, "/affine__0/");
+  DYNET_CHECK_EQUAL(save_parameters_lambda("model_file.txt", collec), 3);
+  auto affine_model = spec.get_affine_model();
+  DYNET_CHECK_EQUAL(save_parameters_lambda("affine_file.txt", affine_model), 2);
+  auto submodel = collec.add_subcollection("affine");
+  auto p = submodel.add_parameters({10});
+  DYNET_CHECK_EQUAL(save_parameters_lambda2("tuning_parameter_file.txt", p), "/affine__1/__0");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -9,8 +9,8 @@
 #include <boost/archive/text_oarchive.hpp>
 #include <iostream>
 #include <fstream>
-
 #include <stdexcept>
+#include "test.h"
 
 using namespace dynet;
 using namespace dynet::expr;
@@ -60,6 +60,25 @@ BOOST_AUTO_TEST_CASE( init_saxe ) {
     float diff = dynet::as_scalar(cg.forward((diff_expr_left + diff_expr_right) / 2.0));
     // Leave a margin of error of epsilon=10^-6
     BOOST_CHECK_LT(diff, epsilon);
+}
+
+BOOST_AUTO_TEST_CASE ( test_parameter_collection ) {
+  dynet::ParameterCollection model;
+  dynet::Parameter a = model.add_parameters({10});
+  dynet::Parameter b1 = model.add_parameters({1,2}, "b");
+  dynet::Parameter b2 = model.add_parameters({1,2}, "b");
+  dynet::ParameterCollection submodel = model.add_subcollection("foo");
+  dynet::Parameter c = submodel.add_parameters({10});
+  dynet::Parameter d = submodel.add_parameters({1, 2}, "d");
+  dynet::Parameter b3 = submodel.add_parameters({1, 2}, "b");
+  DYNET_CHECK_EQUAL(model.get_namespace(), "/");
+  DYNET_CHECK_EQUAL(a.get_fullname(), "/__0");
+  DYNET_CHECK_EQUAL(b1.get_fullname(), "/b__0");
+  DYNET_CHECK_EQUAL(b2.get_fullname(), "/b__1");
+  DYNET_CHECK_EQUAL(submodel.get_namespace(), "/foo__0/");
+  DYNET_CHECK_EQUAL(c.get_fullname(), "/foo__0/__0");
+  DYNET_CHECK_EQUAL(d.get_fullname(), "/foo__0/d__0");
+  DYNET_CHECK_EQUAL(b3.get_fullname(), "/foo__0/b__0");
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -5,6 +5,8 @@
 #include <dynet/model.h>
 #include <dynet/param-init.h>
 #include <dynet/lstm.h>
+#include <dynet/gru.h>
+#include <dynet/treelstm.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
@@ -166,6 +168,15 @@ BOOST_AUTO_TEST_CASE ( test_parameter_class_with_builder ) {
   testModel2 spec(collec);
   auto params = spec.get_lstm_parameters();
   save_parameters_lambda("lstm_file.txt", params);
+}
+
+BOOST_AUTO_TEST_CASE ( test_parametercollection_with_builder ) {
+  dynet::ParameterCollection collec;
+  auto gru_builder = dynet::GRUBuilder(3, 10, 2, collec);
+  DYNET_CHECK_EQUAL(gru_builder.get_parameters().size(), 9 * 3);
+  dynet::ParameterCollection collec2;
+  auto bi_treelstm_builder = BidirectionalTreeLSTMBuilder(3, 10, 2, collec2);
+  DYNET_CHECK_EQUAL(bi_treelstm_builder.get_parameters().size(), 11 * 3 * 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -105,16 +105,21 @@ BOOST_AUTO_TEST_CASE ( test_parameter_class ) {
     auto params = m.get_parameters();
     auto lookup_params = m.get_lookup_parameters();
     for (auto & param: params) {
-      std::cout << param->name << "saved in file " << fname << std::endl;
+      std::cout << param->name << " saved in file " << fname << std::endl;
     }
     for (auto & lookup_param: lookup_params) {
-      std::cout << lookup_param->name << "saved in file " << fname << std::endl;
+      std::cout << lookup_param->name << " saved in file " << fname << std::endl;
     }
     return params.size() + lookup_params.size();
   };
   auto save_parameters_lambda2 = [] (const std::string & fname, dynet::Parameter & p) -> std::string {
-    std::cout << p.get_storage().name << "saved in file " << fname << std::endl;
+    std::cout << p.get_storage().name << " saved in file " << fname << std::endl;
     return p.get_storage().name;
+  };
+  auto save_parameters_lambda3 = [] (const std::string & fname,
+                                     dynet::ParameterStorage *p) ->std::string {
+    std::cout << p->name << "saved in file " << fname << std::endl;
+    return p->name;
   };
   ParameterCollection collec;
   testModel spec(collec);
@@ -125,7 +130,10 @@ BOOST_AUTO_TEST_CASE ( test_parameter_class ) {
   DYNET_CHECK_EQUAL(save_parameters_lambda("affine_file.txt", affine_model), 2);
   auto submodel = collec.add_subcollection("affine");
   auto p = submodel.add_parameters({10});
+  std::cout << p.get_fullname() << std::endl;
   DYNET_CHECK_EQUAL(save_parameters_lambda2("tuning_parameter_file.txt", p), "/affine__1/__0");
+  DYNET_CHECK_EQUAL(save_parameters_lambda3("tuning_parameter_file.txt",
+                                            affine_model.get_parameter("/affine__0/__0")), "/affine__0/__0");
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
- [x] Implement get_fullname and get_namespace interfaces, add related tests.
- [x] Add interface for supporting m.add_parameters({10}, "a") and tests.
- [x] Add input parameter and add_subcollection verify.
- [x] Handle parameter copy logic: currently code treat copy as sharing objects with original ones while we might disable copy in the future.
- [x] Parameter retrieval interfaces implementation. By model, by name, etc.
- [x] Builder classes implementation and tests.