### PR TITLE
Batch manipulation operations

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -115,8 +115,10 @@ Expression pick(const Expression& x, const vector<unsigned> & v, unsigned d) { r
 Expression pick(const Expression& x, const unsigned* pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
 Expression pick(const Expression& x, const vector<unsigned> * pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
 
-Expression pick_batch(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickBatch>({x.i}, v)); }
-Expression pick_batches(const Expression & x, const std::vector<unsigned>& v) { return Expression(x.pg, x.pg->add_function<PickBatch>({x.i}, v)); }
+Expression pick_batch_elems(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, v)); }
+Expression pick_batch_elems(const Expression& x, const std::vector<unsigned>& v) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, v)); }
+Expression pick_batch_elems(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, pv)); }
+Expression pick_batch_elems(const Expression& x, const vector<unsigned> * pv) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, pv)); }
 
 Expression pickrange(const Expression& x, unsigned v, unsigned u) { return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u)); }
 

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -115,9 +115,9 @@ Expression pick(const Expression& x, const vector<unsigned> & v, unsigned d) { r
 Expression pick(const Expression& x, const unsigned* pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
 Expression pick(const Expression& x, const vector<unsigned> * pv, unsigned d) { return Expression(x.pg, x.pg->add_function<PickElement>({x.i}, pv, d)); }
 
-Expression pick_batch_elems(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, v)); }
+Expression pick_batch_elem(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, v)); }
 Expression pick_batch_elems(const Expression& x, const std::vector<unsigned>& v) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, v)); }
-Expression pick_batch_elems(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, pv)); }
+Expression pick_batch_elem(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, pv)); }
 Expression pick_batch_elems(const Expression& x, const vector<unsigned> * pv) { return Expression(x.pg, x.pg->add_function<PickBatchElements>({x.i}, pv)); }
 
 Expression pickrange(const Expression& x, unsigned v, unsigned u) { return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u)); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1354,8 +1354,8 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u);
 
 /**
  * \ingroup flowoperations
- * \brief Pick batch.
- * \details Pick a batch from an expression. For a Tensor with 3 batches:
+ * \brief (Modifiable) Pick batch element.
+ * \details Pick batch element from a batched expression. For a Tensor with 3 batch elements:
  *
  *    \f$
  *      \begin{pmatrix}
@@ -1372,7 +1372,7 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u);
  *      \end{pmatrix}
  *    \f$
  * 
- * pick_batch(t, 1) will return a Tensor of
+ * pick_batch_elems(t, 1) will return a Tensor of
  * 
  *    \f$
  *      \begin{pmatrix}
@@ -1382,17 +1382,17 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u);
  *    \f$
  *
  * \param x The input expression
- * \param v The index of the batch to be picked.
+ * \param v The index of the batch element to be picked.
  *
- * \return The expression of picked batch. The picked batch is a tensor
+ * \return The expression of picked batch element. The picked element is a tensor
  *         whose `bd` equals to one.
  */
-Expression pick_batch(const Expression& x, unsigned v);
+Expression pick_batch_elems(const Expression& x, unsigned v);
 
 /**
  * \ingroup flowoperations
- * \brief Pick batch.
- * \details Pick several batches from an expression. For a Tensor with 3 batches:
+ * \brief (Modifiable) Pick batch elements.
+ * \details Pick several batch elements from a batched expression. For a Tensor with 3 batch elements:
  *
  *    \f$
  *      \begin{pmatrix}
@@ -1409,7 +1409,7 @@ Expression pick_batch(const Expression& x, unsigned v);
  *      \end{pmatrix}
  *    \f$
  * 
- * pick_batch(t, {2, 3}) will return a Tensor of with 2 batches:
+ * pick_batch_elems(t, {2, 3}) will return a Tensor of with 2 batch elements:
  * 
  *    \f$
  *      \begin{pmatrix}
@@ -1423,12 +1423,50 @@ Expression pick_batch(const Expression& x, unsigned v);
  *    \f$
  *
  * \param x The input expression
- * \param v A vector of indicies of the batches to be picked.
+ * \param v A vector of indicies of the batch elements to be picked.
  *
- * \return The expression of picked batches. The picked batches is a tensor
+ * \return The expression of picked batch elements. The batch elements is a tensor
  *         whose `bd` equals to the size of vector `v`.
  */
-Expression pick_batches(const Expression& x, const std::vector<unsigned> & v);
+Expression pick_batch_elems(const Expression& x, const std::vector<unsigned> & v);
+
+/**
+ * \ingroup flowoperations
+ * \brief Pick batch element.
+ * \details Pick batch element from a batched expression. 
+ * \param x The input expression
+ * \param v A pointer to the index of the correct element to be picked.
+ *
+ * \return The expression of picked batch element. The picked element is a tensor
+ *         whose `bd` equals to one.
+ */
+Expression pick_batch_elems(const Expression& x, const unsigned* v);
+
+/**
+ * \ingroup flowoperations
+ * \brief Pick batch elements.
+ * \details Pick several batch elements from a batched expression. 
+ * \param x The input expression
+ * \param v A pointer to the indexes
+ *
+ * \return The expression of picked batch elements. The batch elements is a tensor
+ *         whose `bd` equals to the size of vector `v`.
+ */
+Expression pick_batch_elems(const Expression& x, const std::vector<unsigned> * pv);
+
+/**
+ * \ingroup flowoperations
+ * \brief Concatenate batch elements
+ * \details Perform a concatenation of several batched expressions along the batch dimension.
+ *          All expressions must have the same shape except for the batch dimension.
+ *
+ * \param xs The input expressions
+ *
+ * \return The expression with the batch dimensions concatenated
+ */
+inline Expression concatenate_batch_elems(const std::initializer_list<Expression>& xs) { return detail::f<ConcatenateBatchElements>(xs); }
+template <typename T>
+inline Expression concatenate_batch_elems(const T& xs) { return detail::f<ConcatenateBatchElements>(xs); }
 
 /**
  * \ingroup flowoperations

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1372,7 +1372,7 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u);
  *      \end{pmatrix}
  *    \f$
  * 
- * pick_batch_elems(t, 1) will return a Tensor of
+ * pick_batch_elem(t, 1) will return a Tensor of
  * 
  *    \f$
  *      \begin{pmatrix}
@@ -1387,7 +1387,7 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u);
  * \return The expression of picked batch element. The picked element is a tensor
  *         whose `bd` equals to one.
  */
-Expression pick_batch_elems(const Expression& x, unsigned v);
+Expression pick_batch_elem(const Expression& x, unsigned v);
 
 /**
  * \ingroup flowoperations
@@ -1440,7 +1440,7 @@ Expression pick_batch_elems(const Expression& x, const std::vector<unsigned> & v
  * \return The expression of picked batch element. The picked element is a tensor
  *         whose `bd` equals to one.
  */
-Expression pick_batch_elems(const Expression& x, const unsigned* v);
+Expression pick_batch_elem(const Expression& x, const unsigned* v);
 
 /**
  * \ingroup flowoperations

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -1,14 +1,14 @@
 /**
  * An implementation of [Document Modeling with Gated Recurrent Neural
  * Network for Sentiment Classification](http://aclweb.org/anthology/D15-1167)
- * using `pick_batch_elems`.
+ * using `pick_batch_elem`.
  * 
  * The model in use a bidirectional GRU to represents every sentence in the
  * document and feed the sentence representations into the another bi-GRU
  * to get the final representation of the document.
  *
  * This implementation compiles each i-th words in the sentences into a batch
- * (like that in the rnnlm-batch) and use `pick_batch_elems` to get last representation
+ * (like that in the rnnlm-batch) and use `pick_batch_elem` to get last representation
  * in corresponding batch.
  *
  * On a small proportion of the IMDB data (2500 for training, 500 for dev.), this
@@ -127,7 +127,7 @@ struct DocumentModel {
       for (unsigned b = 0; b < n_sents; ++b) {
         const std::vector<int> & sent = inst.first[b];
         if (i + 1 == sent.size()) {
-          sent_repr[b] = concatenate({ pick_batch_elems(fwd_output, b), pick_batch_elems(bwd_output, b) });
+          sent_repr[b] = concatenate({ pick_batch_elem(fwd_output, b), pick_batch_elem(bwd_output, b) });
         }
       }
     }

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -1,14 +1,14 @@
 /**
  * An implementation of [Document Modeling with Gated Recurrent Neural
  * Network for Sentiment Classification](http://aclweb.org/anthology/D15-1167)
- * using `pick_batch`.
+ * using `pick_batch_elems`.
  * 
  * The model in use a bidirectional GRU to represents every sentence in the
  * document and feed the sentence representations into the another bi-GRU
  * to get the final representation of the document.
  *
  * This implementation compiles each i-th words in the sentences into a batch
- * (like that in the rnnlm-batch) and use `pick_batch` to get last representation
+ * (like that in the rnnlm-batch) and use `pick_batch_elems` to get last representation
  * in corresponding batch.
  *
  * On a small proportion of the IMDB data (2500 for training, 500 for dev.), this
@@ -127,7 +127,7 @@ struct DocumentModel {
       for (unsigned b = 0; b < n_sents; ++b) {
         const std::vector<int> & sent = inst.first[b];
         if (i + 1 == sent.size()) {
-          sent_repr[b] = concatenate({ pick_batch(fwd_output, b), pick_batch(bwd_output, b) });
+          sent_repr[b] = concatenate({ pick_batch_elems(fwd_output, b), pick_batch_elems(bwd_output, b) });
         }
       }
     }

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -310,6 +310,8 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_pick "dynet::expr::pick" (CExpression& x, vector[unsigned]* pv) except + #
     CExpression c_pickrange "dynet::expr::pickrange" (CExpression& x, unsigned v, unsigned u) except + #
 
+    CExpression c_pick_batch_elems "dynet::expr::pick_batch_elems" (CExpression& x, vector[unsigned] vs) except + #
+
     CExpression c_pickneglogsoftmax "dynet::expr::pickneglogsoftmax" (CExpression& x, unsigned v) except + #
     CExpression c_pickneglogsoftmax "dynet::expr::pickneglogsoftmax" (CExpression& x, vector[unsigned] vs) except + #
 
@@ -317,6 +319,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_average     "dynet::expr::average" (vector[CExpression]& xs) except +
     CExpression c_concat_cols "dynet::expr::concatenate_cols" (vector[CExpression]& xs) except +
     CExpression c_concat      "dynet::expr::concatenate" (vector[CExpression]& xs) except +
+    CExpression c_concat_batch_elems      "dynet::expr::concatenate_batch_elems" (vector[CExpression]& xs) except +
 
     CExpression c_sum            "dynet::expr::sum" (vector[CExpression]& xs) except +
     CExpression c_max            "dynet::expr::vmax" (vector[CExpression]& xs) except +

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -311,7 +311,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_pickrange "dynet::expr::pickrange" (CExpression& x, unsigned v, unsigned u) except + #
 
     CExpression c_pick_batch_elems "dynet::expr::pick_batch_elems" (CExpression& x, vector[unsigned] vs) except + #
-
+    CExpression c_pick_batch_elem "dynet::expr::pick_batch_elem" (CExpression& x, unsigned v) except + #
     CExpression c_pickneglogsoftmax "dynet::expr::pickneglogsoftmax" (CExpression& x, unsigned v) except + #
     CExpression c_pickneglogsoftmax "dynet::expr::pickneglogsoftmax" (CExpression& x, vector[unsigned] vs) except + #
 

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -982,7 +982,7 @@ cdef class Expression: #{{{
         return arr
 
     cpdef value(self, recalculate=False):
-        """Gets the value of the expression in the msot relevant format
+        """Gets the value of the expression in the most relevant format
         
         this returns the same thing as `scalar_value`, `vec_value`, `npvalue` depending on whether the number of dimensions of the expression is 0, 1 or 2+
         
@@ -1507,6 +1507,7 @@ cpdef Expression pickneglogsoftmax_batch(Expression x, vector[unsigned] vs): ret
 
 cpdef Expression kmh_ngram(Expression x, unsigned v): return Expression.from_cexpr(x.cg_version, c_kmh_ngram(x.c(), v))
 cpdef Expression pickrange(Expression x, unsigned v, unsigned u): return Expression.from_cexpr(x.cg_version, c_pickrange(x.c(), v, u))
+cpdef Expression pick_batch_elems(Expression x, vector[unsigned] vs): return Expression.from_cexpr(x.cg_version, c_pick_batch_elems(x.c(), vs))
 #expr-float
 cpdef Expression noise(Expression x, float stddev): return Expression.from_cexpr(x.cg_version, c_noise(x.c(), stddev))
 cpdef Expression dropout(Expression x, float p): return Expression.from_cexpr(x.cg_version, c_dropout(x.c(), p))
@@ -1575,6 +1576,14 @@ cpdef Expression concatenate(list xs):
         cvec.push_back(x.c())
     return Expression.from_cexpr(x.cg_version, c_concat(cvec))
 
+cpdef Expression concat_batch_elems(list xs):
+    assert xs, 'List is empty, nothing to concatenate.'
+    cdef vector[CExpression] cvec
+    cdef Expression x
+    for x in xs:
+        ensure_freshness(x) 
+        cvec.push_back(x.c())
+    return Expression.from_cexpr(x.cg_version, c_concat_batch_elems(cvec))
 
 cpdef Expression affine_transform(list exprs):
     assert exprs, 'List input to affine_transform must not be empty.'

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1507,6 +1507,7 @@ cpdef Expression pickneglogsoftmax_batch(Expression x, vector[unsigned] vs): ret
 
 cpdef Expression kmh_ngram(Expression x, unsigned v): return Expression.from_cexpr(x.cg_version, c_kmh_ngram(x.c(), v))
 cpdef Expression pickrange(Expression x, unsigned v, unsigned u): return Expression.from_cexpr(x.cg_version, c_pickrange(x.c(), v, u))
+cpdef Expression pick_batch_elem(Expression x, unsigned v): return Expression.from_cexpr(x.cg_version, c_pick_batch_elem(x.c(), v))
 cpdef Expression pick_batch_elems(Expression x, vector[unsigned] vs): return Expression.from_cexpr(x.cg_version, c_pick_batch_elems(x.c(), vs))
 #expr-float
 cpdef Expression noise(Expression x, float stddev): return Expression.from_cexpr(x.cg_version, c_noise(x.c(), stddev))

--- a/python_tests/test_batch_manipulation.py
+++ b/python_tests/test_batch_manipulation.py
@@ -1,0 +1,26 @@
+import dynet as dy
+import numpy as np
+
+m = dy.Model()
+p = m.add_lookup_parameters((2,3))
+npp = np.asarray([[1,2,3],[4,5,6]], dtype=np.float32)
+p.init_from_array(npp)
+dy.renew_cg()
+
+x = dy.lookup_batch(p, [0,1])
+y = dy.pick_batch_elems(x, [0])
+z = dy.pick_batch_elems(x, [1])
+yz = dy.pick_batch_elems(x, [0, 1])
+w = dy.concat_batch_elems([y,z])
+
+print x.npvalue()
+print y.npvalue()
+print yz.npvalue()
+print w.npvalue()
+
+loss = dy.dot_product(y, z)
+loss.forward()
+
+loss.backward()
+
+print p.grad_as_array()

--- a/python_tests/test_batch_manipulation.py
+++ b/python_tests/test_batch_manipulation.py
@@ -9,7 +9,7 @@ dy.renew_cg()
 
 x = dy.lookup_batch(p, [0,1])
 y = dy.pick_batch_elems(x, [0])
-z = dy.pick_batch_elems(x, [1])
+z = dy.pick_batch_elem(x, 1)
 yz = dy.pick_batch_elems(x, [0, 1])
 w = dy.concat_batch_elems([y,z])
 

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -912,24 +912,24 @@ BOOST_AUTO_TEST_CASE( pick_batch_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
-// Expression pick_batch_elems(const Expression& x, unsigned v);
-BOOST_AUTO_TEST_CASE( pick_batch_elems_gradient0 ) {
+// Expression pick_batch_elem(const Expression& x, unsigned v);
+BOOST_AUTO_TEST_CASE( pick_batch_elem_gradient ) {
   unsigned idx = 0;
   dynet::ComputationGraph cg;
   Expression x1 = input(cg, Dim({ 3 }, 2), batch_vals);
-  Expression z = sum_rows(pick_batch_elems(x1, idx));
+  Expression z = sum_rows(pick_batch_elem(x1, idx));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression pick_batch_elems(const Expression& x, cosnt std::vector<unsigned> & v);
-BOOST_AUTO_TEST_CASE(  pick_batch_elems_gradient1 ) {
+BOOST_AUTO_TEST_CASE(  pick_batch_elems_gradient ) {
   dynet::ComputationGraph cg;
   std::vector<unsigned> indices = { 0, 1 };
   Expression x1 = input(cg, Dim({ 3 }, 2), batch_vals);
   Expression picked_x1 = pick_batch_elems(x1, indices);
   Expression z = sum({
-    sum_rows(pick_batch_elems(picked_x1, (unsigned) 0)),
-    sum_rows(pick_batch_elems(picked_x1, (unsigned) 1))
+    sum_rows(pick_batch_elem(picked_x1, (unsigned) 0)),
+    sum_rows(pick_batch_elem(picked_x1, (unsigned) 1))
   });
   BOOST_CHECK(check_grad(mod, z, 0));
 }

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -348,6 +348,16 @@ BOOST_AUTO_TEST_CASE( concatenate_cols_gradient ) {
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
+// Expression concatenate_batch_elems(const std::initializer_list<Expression>& xs);
+BOOST_AUTO_TEST_CASE( concatenate_batch_elems_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression xsquare = parameter(cg, param_square1);
+  Expression y = concatenate_batch_elems({x1, x2});
+  Expression z = sum_batches(sum_elems(xsquare*y));
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
 
 // Expression concatenate(const std::initializer_list<Expression>& xs);
 BOOST_AUTO_TEST_CASE( concatenate_gradient ) {
@@ -902,24 +912,24 @@ BOOST_AUTO_TEST_CASE( pick_batch_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
-// Expression pick_batch(const Expression& x, unsigned v);
-BOOST_AUTO_TEST_CASE( pick_batch_gradient1 ) {
+// Expression pick_batch_elems(const Expression& x, unsigned v);
+BOOST_AUTO_TEST_CASE( pick_batch_elems_gradient0 ) {
   unsigned idx = 0;
   dynet::ComputationGraph cg;
   Expression x1 = input(cg, Dim({ 3 }, 2), batch_vals);
-  Expression z = sum_rows(pick_batch(x1, idx));
+  Expression z = sum_rows(pick_batch_elems(x1, idx));
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
-// Expression pick_batches(const Expression& x, cosnt std::vector<unsigned> & v);
-BOOST_AUTO_TEST_CASE( pick_batches_gradient ) {
+// Expression pick_batch_elems(const Expression& x, cosnt std::vector<unsigned> & v);
+BOOST_AUTO_TEST_CASE(  pick_batch_elems_gradient1 ) {
   dynet::ComputationGraph cg;
   std::vector<unsigned> indices = { 0, 1 };
   Expression x1 = input(cg, Dim({ 3 }, 2), batch_vals);
-  Expression picked_x1 = pick_batches(x1, indices);
+  Expression picked_x1 = pick_batch_elems(x1, indices);
   Expression z = sum({
-    sum_rows(pick_batch(picked_x1, 0)),
-    sum_rows(pick_batch(picked_x1, 1))
+    sum_rows(pick_batch_elems(picked_x1, (unsigned) 0)),
+    sum_rows(pick_batch_elems(picked_x1, (unsigned) 1))
   });
   BOOST_CHECK(check_grad(mod, z, 0));
 }


### PR DESCRIPTION
1. Rename `pick_batch` (C++) to `pick_batch_elems`, and add the
corresponding python API.
2. Add `concat_batch_elems` for both Python and C++.
3. Fix some typos while reviewing other code.

Details:
`pick_batch_elems` allow user to pick a subset of  batch elements from
a batched expression.

`concat_batch_elems` allow user to concatenate several expressions
along the batch dimension.

EDIT: `pick_batch_elem` allow user to pick a single element from a batched expression.