### PR TITLE
rename `concat_batch_elems` to `concat_to_batch`

### DIFF
--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1456,17 +1456,17 @@ Expression pick_batch_elems(const Expression& x, const std::vector<unsigned> * p
 
 /**
  * \ingroup flowoperations
- * \brief Concatenate batch elements
- * \details Perform a concatenation of several batched expressions along the batch dimension.
+ * \brief Concatenate list of expressions to a single batched expression
+ * \details Perform a concatenation of several expressions along the batch dimension.
  *          All expressions must have the same shape except for the batch dimension.
  *
  * \param xs The input expressions
  *
  * \return The expression with the batch dimensions concatenated
  */
-inline Expression concatenate_batch_elems(const std::initializer_list<Expression>& xs) { return detail::f<ConcatenateBatchElements>(xs); }
+inline Expression concatenate_to_batch(const std::initializer_list<Expression>& xs) { return detail::f<ConcatenateToBatch>(xs); }
 template <typename T>
-inline Expression concatenate_batch_elems(const T& xs) { return detail::f<ConcatenateBatchElements>(xs); }
+inline Expression concatenate_to_batch(const T& xs) { return detail::f<ConcatenateToBatch>(xs); }
 
 /**
  * \ingroup flowoperations

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -467,7 +467,7 @@ Dim ConcatenateColumns::dim_forward(const vector<Dim>& xs) const {
   return Dim({rows, new_cols}, bd);
 }
 
-string ConcatenateBatchElements::as_string(const vector<string>& arg_names) const {
+string ConcatenateToBatch::as_string(const vector<string>& arg_names) const {
   ostringstream os;
   os << "concat_batch_elems(" << arg_names[0];
   for (unsigned i = 1; i < arg_names.size(); ++i) {
@@ -477,12 +477,12 @@ string ConcatenateBatchElements::as_string(const vector<string>& arg_names) cons
   return os.str();
 }
 
-Dim ConcatenateBatchElements::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ASSERT(xs.size() > 0, "Failed input count check in ConcatenateColumns")
+Dim ConcatenateToBatch::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ASSERT(xs.size() > 0, "Failed input count check in ConcatenateToBatch")
   Dim d(xs[0]);
   for (unsigned i = 1; i < xs.size(); ++i) {
     DYNET_ARG_CHECK(xs[0].single_batch() == xs[i].single_batch(),
-                            "Mismatched input dimensions in ConcatenateBatchElements: " << xs);
+                            "Mismatched input dimensions in ConcatenateToBatch: " << xs);
     d.bd += xs[i].bd;
   }
   return d;

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -523,7 +523,7 @@ void ConcatenateColumns::backward_dev_impl(const MyDevice & dev,
 DYNET_NODE_INST_DEV_IMPL(ConcatenateColumns)
 
 template<class MyDevice>
-void ConcatenateBatchElements::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const { 
+void ConcatenateToBatch::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const { 
   unsigned curr_e = 0;
   src_element_indices.resize(xs.size());
   Eigen::DSizes<ptrdiff_t, 2> indices(0,0);
@@ -538,18 +538,18 @@ void ConcatenateBatchElements::forward_dev_impl(const MyDevice & dev, const vect
 }
 
 template<class MyDevice>
-void ConcatenateBatchElements::backward_dev_impl(const MyDevice & dev,
+void ConcatenateToBatch::backward_dev_impl(const MyDevice & dev,
                              const vector<const Tensor*>& xs,
                              const Tensor& fx,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ASSERT(i < src_element_indices.size(), "Failed boundary check in ConcatenateBatchElements::backward: " << i << " >= " << src_element_indices.size());
+  DYNET_ASSERT(i < src_element_indices.size(), "Failed boundary check in ConcatenateToBatch::backward: " << i << " >= " << src_element_indices.size());
   Eigen::DSizes<ptrdiff_t, 2> indices(0, static_cast<ptrdiff_t>(src_element_indices[i]));
   Eigen::DSizes<ptrdiff_t, 2> sizes(static_cast<ptrdiff_t>(fx.d.batch_size()), static_cast<ptrdiff_t>(xs[i]->d.bd));
   dEdxi.tbvec().device(*dev.edevice) += dEdf.tbvec().slice(indices, sizes);
 }
-DYNET_NODE_INST_DEV_IMPL(ConcatenateBatchElements)
+DYNET_NODE_INST_DEV_IMPL(ConcatenateToBatch)
 
 template<class MyDevice>
 void BinaryLogLoss::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -252,8 +252,8 @@ struct ConcatenateColumns : public Node {
 };
 
 // concatenate different batched experssions into one single batched tensor
-struct ConcatenateBatchElements : public Node {
-  template <typename T> explicit ConcatenateBatchElements(const T& a) : Node(a) {}
+struct ConcatenateToBatch : public Node {
+  template <typename T> explicit ConcatenateToBatch(const T& a) : Node(a) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
   virtual bool supports_multibatch() const override {return true;}
   mutable std::vector<unsigned> src_element_indices;

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -319,7 +319,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_average     "dynet::expr::average" (vector[CExpression]& xs) except +
     CExpression c_concat_cols "dynet::expr::concatenate_cols" (vector[CExpression]& xs) except +
     CExpression c_concat      "dynet::expr::concatenate" (vector[CExpression]& xs) except +
-    CExpression c_concat_batch_elems      "dynet::expr::concatenate_batch_elems" (vector[CExpression]& xs) except +
+    CExpression c_concat_to_batch      "dynet::expr::concatenate_to_batch" (vector[CExpression]& xs) except +
 
     CExpression c_sum            "dynet::expr::sum" (vector[CExpression]& xs) except +
     CExpression c_max            "dynet::expr::vmax" (vector[CExpression]& xs) except +

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1581,14 +1581,14 @@ cpdef Expression concatenate(list xs):
         cvec.push_back(x.c())
     return Expression.from_cexpr(x.cg_version, c_concat(cvec))
 
-cpdef Expression concat_batch_elems(list xs):
+cpdef Expression concat_to_batch(list xs):
     assert xs, 'List is empty, nothing to concatenate.'
     cdef vector[CExpression] cvec
     cdef Expression x
     for x in xs:
         ensure_freshness(x) 
         cvec.push_back(x.c())
-    return Expression.from_cexpr(x.cg_version, c_concat_batch_elems(cvec))
+    return Expression.from_cexpr(x.cg_version, c_concat_to_batch(cvec))
 
 cpdef Expression affine_transform(list exprs):
     assert exprs, 'List input to affine_transform must not be empty.'

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1040,6 +1040,10 @@ cdef class Expression: #{{{
         if isinstance(self, Expression) and isinstance(other, (int,float)):
             return _cdiv(self, other)
         else: raise NotImplementedError()
+    def __truediv__(self, other):
+        if isinstance(self, Expression) and isinstance(other, (int,float)):
+            return _cdiv(self, other)
+        else: raise NotImplementedError()  
     def __neg__(self):        return _neg(self)
     def __sub__(self, other):
         if isinstance(self,Expression) and isinstance(other,Expression):

--- a/python_tests/test_batch_manipulation.py
+++ b/python_tests/test_batch_manipulation.py
@@ -11,7 +11,7 @@ x = dy.lookup_batch(p, [0,1])
 y = dy.pick_batch_elems(x, [0])
 z = dy.pick_batch_elem(x, 1)
 yz = dy.pick_batch_elems(x, [0, 1])
-w = dy.concat_batch_elems([y,z])
+w = dy.concat_to_batch([y,z])
 
 print x.npvalue()
 print y.npvalue()

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -348,13 +348,13 @@ BOOST_AUTO_TEST_CASE( concatenate_cols_gradient ) {
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }
-// Expression concatenate_batch_elems(const std::initializer_list<Expression>& xs);
-BOOST_AUTO_TEST_CASE( concatenate_batch_elems_gradient ) {
+// Expression concatenate_to_batch(const std::initializer_list<Expression>& xs);
+BOOST_AUTO_TEST_CASE( concatenate_to_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
   Expression x2 = input(cg, Dim({3}, 2), batch_vals);
   Expression xsquare = parameter(cg, param_square1);
-  Expression y = concatenate_batch_elems({x1, x2});
+  Expression y = concatenate_to_batch({x1, x2});
   Expression z = sum_batches(sum_elems(xsquare*y));
   BOOST_CHECK(check_grad(mod, z, 0));
 }


### PR DESCRIPTION
Concatenate list of expressions to a single batched expression.