### PR TITLE
Allow parameters scaling (c++ and python)

### DIFF
--- a/dynet/model.h
+++ b/dynet/model.h
@@ -262,6 +262,14 @@ struct Parameter {
    * @param b Update status
    */
   void set_updated(bool b);
+
+  /**
+   * @brief Scales the parameter (multiplies by `s`)
+   *
+   * @param s scale
+   */
+  void scale(float s){get()->scale_parameters(s);}
+
   /**
    * @brief Check the update status
    * @return Update status
@@ -313,6 +321,13 @@ struct LookupParameter {
    * \return Values as a `Tensor` object
    */
   std::vector<Tensor>* values() { return &(get()->values); }
+
+  /**
+   * @brief Scales the parameter (multiplies by `s`)
+   *
+   * @param s scale
+   */
+  void scale(float s){get()->scale_parameters(s);}
 
   /**
   * @brief Set the parameter as updated

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -67,6 +67,7 @@ cdef extern from "dynet/model.h" namespace "dynet":
         void zero()
         void set_updated(bool b)
         bool is_updated()
+        void scale(float s)
         unsigned index
 
     cdef cppclass CLookupParameters "dynet::LookupParameter":
@@ -77,6 +78,7 @@ cdef extern from "dynet/model.h" namespace "dynet":
         void zero()
         void set_updated(bool b)
         bool is_updated()
+        void scale(float s)
         unsigned index
 
     cdef cppclass CParameterInit "dynet::ParameterInit":

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -292,6 +292,15 @@ cdef class Parameters:
         """
         self.thisptr.zero()
 
+    cpdef scale(self,float s):
+        """Scales the parameter
+
+        Arguments:
+            s {float} -- Scale
+
+        """
+        self.thisptr.scale(s)
+
     cpdef bool is_updated(self):
         """check whether the parameter is updated or not
         
@@ -389,7 +398,16 @@ cdef class LookupParameters:
         cdef vector[CTensor] grads
         grads = self.thisptr.get().grads
         return np.vstack([c_tensor_as_np(t).reshape(1,-1,order='F') for t in grads])
+    
+    cpdef scale(self,float s):
+        """Scales the parameter
 
+        Arguments:
+            s {float} -- Scale
+
+        """
+        self.thisptr.scale(s)
+        
     cpdef Expression expr(self,bool update=True):
         if cg_version() != self._version:
             self._version = cg_version()

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -61,4 +61,19 @@ BOOST_AUTO_TEST_CASE( init_saxe ) {
     BOOST_CHECK_LT(diff, epsilon);
 }
 
+BOOST_AUTO_TEST_CASE( scale ) {
+    dynet::Model mod;
+    // Create parameter
+    dynet::Parameter w_p = mod.add_parameters({1}, ParameterInitConst(1));
+    // Initial value
+    float init_value= as_scalar(*(w_p.values()));
+    // Rescale
+    w_p.scale(0.3);
+    // Value after rescaling
+    float end_value=as_scalar(*(w_p.values()));
+    // Check with a margin of error
+    BOOST_CHECK_CLOSE(init_value * 0.3, end_value, 0.001);
+}
+
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This allows one to call `parameter.scale(s)` to efficiently scale a parameter `W:=W*s`

This is a neat low level method to have.