### PR TITLE
Fix y<<1 / x=0 issue (binary logloss)

### DIFF
--- a/dynet/functors.h
+++ b/dynet/functors.h
@@ -287,17 +287,17 @@ struct FL2SGDUpdate {
 struct FBinaryLogLoss {
   DYNET_DEVICE_FUNC inline float operator()(float x, float x_true) const {
     if (x_true == 1.f) {
-      if (x == 0.f) x = DYNET_DEVICE_MIN;
-      return -1.f * x_true * log(x);
+      if (x == 0.f) return -1.f * log(DYNET_DEVICE_MIN);
+      return -1.f * log(x);
     }
     else if (x_true == 0.f) {
       if (x == 1.f) return -1.f * log(DYNET_DEVICE_MIN);
       else return (x_true - 1.f) * log1p(-x);
     }
     else {
-      if (x == 0.f) x = DYNET_DEVICE_MIN;
-      if (x == 1.f) x = DYNET_DEVICE_MIN;
-      return -1.f * (x_true * log(x) + (1.f - x_true) * log1p(-x));
+      if (x == 0.f) return -1.f * log(DYNET_DEVICE_MIN);
+      else if (x == 1.f) return -1.f * log(DYNET_DEVICE_MIN);
+      else return -1.f * (x_true * log(x) + (1.f - x_true) * log1p(-x));
     }
   }
 };

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -805,10 +805,10 @@ BOOST_AUTO_TEST_CASE( binary_log_loss_edgecases ) {
       val = as_scalar(z.value());
       if(vx==0.5)
         BOOST_CHECK_CLOSE(val,log(2),0.1);
-      else if (vx==1.0)
-        BOOST_CHECK_CLOSE(val,((1-vy) * infinity),0.1);
-      else if (vx==0.0)
-        BOOST_CHECK_CLOSE(val,(vy * infinity),0.1);
+      else if (vx==vy)
+        BOOST_CHECK_CLOSE(val,0,0.1);
+      else
+        BOOST_CHECK_CLOSE(val,infinity,0.1);
     }
   }
 


### PR DESCRIPTION
Sorry to reopen this, something bothered me with the previous behaviour, ie when x=0,y=0.01, y * log(x) was < 1 which is weird.

The new behaviour is : 

    binary_log_loss(0,1) = infinity
    binary_log_loss(1,0) = infinity
    binary_log_loss(0,0.01) = infinity // was 87 * 0.01 before
    binary_log_loss(0.01,1) = log(0.01)

EDIT : here by infinity I mean -log(1e-38)=87