### PR TITLE
Implement native serialization and deserialization logic for ParameterCollection and support partial save/load.

### DIFF
--- a/dynet/CMakeLists.txt
+++ b/dynet/CMakeLists.txt
@@ -36,6 +36,7 @@ set(dynet_library_SRCS
     training.cc
     treelstm.cc
     weight-decay.cc
+    io.cc
 )
 
 # Headers:
@@ -80,6 +81,7 @@ set(dynet_library_HDRS
     nodes-macros.h
     weight-decay.h
     io-macros.h
+    io.h
 )
 
 file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tests/*.cc)

--- a/dynet/dim.cc
+++ b/dynet/dim.cc
@@ -7,7 +7,7 @@ using namespace std;
 namespace dynet {
 
 ostream& operator<<(ostream& os, const Dim& d) {
-  os << d.nd << '-' << '{';
+  os << '{';
   for (unsigned i = 0; i < d.nd; ++i) {
     if (i) os << ',';
     os << d.d[i];
@@ -26,18 +26,25 @@ ostream& operator<<(ostream& os, const vector<Dim>& ds) {
 istream& operator>>(istream& is, Dim& d) {
   char place_holder;
   int nd = 0;
-  is >> nd >> place_holder;
   is >> place_holder;
-  d.resize(nd);
-  for (unsigned i = 0; i < nd; ++i) {
-    if (i) is >> place_holder;
+  d.resize(DYNET_MAX_TENSOR_DIM);
+  bool batch_flag = false;
+  unsigned i = 0;
+  for (; i < DYNET_MAX_TENSOR_DIM + 1; ++i) {
+    if (i) {
+      is >> place_holder;
+      if (place_holder == 'X') {
+        batch_flag = true;
+        break;
+      } else if (place_holder == '}') {
+        break;
+      }
+    }
     is >> d.d[i];
   }
-  is >> place_holder;
-  if (place_holder == 'X') {
+  d.resize(i);
+  if (batch_flag) {
     is >> d.bd >> place_holder;
-  } else {
-    is >> place_holder;
   }
   return is;
 }

--- a/dynet/dim.cc
+++ b/dynet/dim.cc
@@ -7,7 +7,7 @@ using namespace std;
 namespace dynet {
 
 ostream& operator<<(ostream& os, const Dim& d) {
-  os << '{';
+  os << d.nd << '-' << '{';
   for (unsigned i = 0; i < d.nd; ++i) {
     if (i) os << ',';
     os << d.d[i];
@@ -21,6 +21,25 @@ ostream& operator<<(ostream& os, const vector<Dim>& ds) {
   for (unsigned i = 0; i < ds.size(); ++i)
     os << (i ? " " : "") << ds[i];
   return os << ']';
+}
+
+istream& operator>>(istream& is, Dim& d) {
+  char place_holder;
+  int nd = 0;
+  is >> nd >> place_holder;
+  is >> place_holder;
+  d.resize(nd);
+  for (unsigned i = 0; i < nd; ++i) {
+    if (i) is >> place_holder;
+    is >> d.d[i];
+  }
+  is >> place_holder;
+  if (place_holder == 'X') {
+    is >> d.bd >> place_holder;
+  } else {
+    is >> place_holder;
+  }
+  return is;
 }
 
 DYNET_SERIALIZE_COMMIT(Dim, DYNET_SERIALIZE_DEFINE(nd, d))

--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -254,6 +254,8 @@ std::ostream& operator<<(std::ostream& os, const Dim& d);
  */
 std::ostream& operator<<(std::ostream& os, const std::vector<Dim>& ds);
 
+std::istream& operator>>(std::istream& os, Dim& d);
+
 } // namespace dynet
 
 #endif

--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -3,7 +3,7 @@
 namespace dynet {
 
 void Pack::save(ParameterCollection & model,
-                std::string key, bool is_append) {
+                const std::string & key, bool is_append) {
   std::string key_str(key);
   if (key.size() == 0) {
     key_str = model.get_namespace();
@@ -24,8 +24,20 @@ void Pack::save(ParameterCollection & model,
   this->serialize(model, key, is_append);
 }
 
-void Pack::load(ParameterCollection & model, std::string key) {
+void Pack::save(ParameterCollection & model,
+                     const std::vector<std::string> & filter_lst,
+                     const std::string & key, bool is_append) {
+  // TODO
+}
+
+void Pack::load(ParameterCollection & model, const std::string & key) {
   this->deserialize(model, key);
+}
+
+void Pack::load(ParameterCollection & model,
+                const std::vector<std::string> & filter_lst,
+                const std::string & key) {
+  // TODO
 }
 
 bool Pack::duplicate_key_check(const std::string & key) {
@@ -39,7 +51,7 @@ bool Pack::duplicate_key_check(const std::string & key) {
   return true;
 }
 
-void Pack::serialize(ParameterCollection & model, std::string key, bool is_append) {
+void Pack::serialize(ParameterCollection & model, const std::string & key, bool is_append) {
   std::ofstream os;
   if (is_append) {
     os.open(fn, std::ofstream::app);
@@ -69,17 +81,23 @@ void Pack::serialize(ParameterCollection & model, std::string key, bool is_appen
   os.close();
 }
 
-void Pack::deserialize(ParameterCollection & model, std::string key) {
+void Pack::deserialize(ParameterCollection & model, const std::string & key) {
   std::ifstream meta_f(fn_meta);
   std::ifstream f(fn);
   // find the offset of the key
   long long local_offset = -1;
+
   std::string line;
-  while (std::getline(meta_f, line)) {
-    auto kv = dynet::str_split(line, ':');
-    if (kv[0] == key) {
-      local_offset = std::stoll(kv[1]);
-      break;
+  if (key.size() == 0) {
+    // case for no key specified
+    local_offset = 0;
+  } else {
+    while (std::getline(meta_f, line)) {
+      auto kv = dynet::str_split(line, ':');
+      if (kv[0] == key) {
+        local_offset = std::stoll(kv[1]);
+        break;
+      }
     }
   }
   if (local_offset == -1) {

--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -1,0 +1,221 @@
+#include "dynet/io.h"
+
+namespace dynet {
+
+void Pack::save(ParameterCollection & model,
+                std::string key, bool is_append) {
+  std::string key_str(key);
+  if (key.size() == 0) {
+    key_str = model.get_namespace();
+  }
+  if (duplicate_key_check(key_str) == false) {
+    DYNET_RUNTIME_ERR("You couldn't save ParameterCollections with the same key in file: " + fn);
+  }
+  // write offset info into meta file
+  std::ofstream os;
+  if (is_append) {
+    os.open(fn_meta, std::ofstream::app);
+  } else {
+    os.open(fn_meta);
+  }
+  os << key_str << ':' << offset << '\n';
+  os.close();
+  // write model into model file
+  this->serialize(model, key, is_append);
+}
+
+void Pack::load(ParameterCollection & model, std::string key) {
+  this->deserialize(model, key);
+}
+
+bool Pack::duplicate_key_check(const std::string & key) {
+  std::ifstream f(fn_meta);
+  std::string line;
+  while (std::getline(f, line)) {
+    auto kv = dynet::str_split(line, ':');
+    if (kv[0] == key) return false;
+  }
+  f.close();
+  return true;
+}
+
+void Pack::serialize(ParameterCollection & model, std::string key, bool is_append) {
+  std::ofstream os;
+  if (is_append) {
+    os.open(fn, std::ofstream::app);
+  } else {
+    os.open(fn);
+  }
+  os.seekp(this->offset);
+  os << '#' << std::endl; // identifier of beginning of the ParameterCollection
+  auto params = model.get_parameter_storages();
+  for (auto & param : params) {
+    os << "#Parameter#" << std::endl;
+    os << param->name << std::endl;
+    os << param->dim << std::endl;
+    os << param->values << std::endl;
+    os << param->g << std::endl;
+  }
+  auto lookup_params = model.get_lookup_parameter_storages();
+  for (auto & lookup_param: lookup_params) {
+    os << "#LookupParameter#" << std::endl;
+    os << lookup_param->name << std::endl;
+    os << lookup_param->all_dim << std::endl;
+    os << lookup_param->dim << std::endl;
+    os << lookup_param->all_values << std::endl;
+    os << lookup_param->all_grads << std::endl;
+  }
+  this->offset = os.tellp();
+  os.close();
+}
+
+void Pack::deserialize(ParameterCollection & model, std::string key) {
+  std::ifstream meta_f(fn_meta);
+  std::ifstream f(fn);
+  // find the offset of the key
+  long long local_offset = -1;
+  std::string line;
+  while (std::getline(meta_f, line)) {
+    auto kv = dynet::str_split(line, ':');
+    if (kv[0] == key) {
+      local_offset = std::stoll(kv[1]);
+      break;
+    }
+  }
+  if (local_offset == -1) {
+    DYNET_RUNTIME_ERR("Load error: no such key: " + key);
+  }
+
+  // check identifier
+  f.seekg(local_offset);
+  std::getline(f, line);
+  if (line != "#") {
+    DYNET_RUNTIME_ERR("Invalid model file format. Check this line: " + line);
+  }
+
+  // read parameters
+  std::getline(f, line);
+  while (line == "#Parameter#") {
+    std::getline(f, line);
+    auto name = dynet::str_split(line, '/').back();
+    name = name.substr(0, name.find_first_of("__"));
+
+    Dim d;
+    std::getline(f, line);
+    std::istringstream iss(line);
+    iss >> d;
+
+    // add param into input model
+    Parameter param = model.add_parameters(d, name);
+
+    // read param.get_storage().values
+    std::vector<float> params_lst;
+    auto deserialize_tensor_lambda = [&] () {
+      for (int k1 = 0; k1 < d.d[0]; ++k1) {
+        // TODO: check dimensions 
+        int sz = d.nd == 1 ? 1 : d.d[1];
+        std::vector<float> tmp(sz);
+        std::getline(f, line);
+        std::istringstream iss(line);
+        iss >> tmp;
+        params_lst.insert(params_lst.end(), tmp.begin(), tmp.end());
+      }
+    };
+    deserialize_tensor_lambda();
+    std::vector<float> params_order_lst = params_lst;
+    auto transpose_lambda = [&] () {
+      for (size_t k = 0; k < params_lst.size(); ++k) {
+        int i = k / d.d[1], j = k % d.d[1];
+        int indx = j * d.d[0] + i;
+        params_order_lst[indx] = params_lst[k];
+      }
+      params_lst.resize(0);
+    };
+    // TODO: high dimensions >=3
+    if (d.nd == 2) {
+      transpose_lambda();
+    }
+    TensorTools::SetElements(param.get_storage().values, params_order_lst);
+
+    // read param.get_storage().g
+    params_lst.resize(0);
+    deserialize_tensor_lambda();
+    params_order_lst = params_lst;
+    if (d.nd == 2) {
+      transpose_lambda();
+    }
+    TensorTools::SetElements(param.get_storage().g, params_order_lst);
+    std::getline(f, line);
+  } // while Parameter
+
+  // read lookup parameters
+  while (line == "#LookupParameter#") {
+    std::getline(f, line);
+    auto name = dynet::str_split(line, '/').back();
+    name = name.substr(0, name.find_first_of("__"));
+
+    Dim all_dim;
+    std::getline(f, line);
+    std::istringstream iss(line);
+    iss >> all_dim;
+    unsigned int N = all_dim.d[all_dim.nd - 1];
+
+    Dim d;
+    std::getline(f, line);
+    std::istringstream iss2(line);
+    iss2 >> d;
+
+    // add lookup_param into input model
+    LookupParameter lookup_param = model.add_lookup_parameters(N, d, name);
+
+    // read lookup_param.get_storage().all_values
+    std::vector<float> lookup_params_lst;
+    auto deserialize_tensor_lambda = [&] () {
+      for (int k1 = 0; k1 < all_dim.d[0]; ++k1) {
+        // TODO: check dimensions 
+        std::vector<float> tmp(all_dim.d[1]);
+        std::getline(f, line);
+        std::istringstream iss(line);
+        iss >> tmp;
+        lookup_params_lst.insert(lookup_params_lst.end(), tmp.begin(), tmp.end());
+      }
+    };
+    deserialize_tensor_lambda();
+    std::vector<float> lookup_params_order_lst = lookup_params_lst;
+    auto transpose_lambda = [&] () {
+      for (size_t k = 0; k < lookup_params_lst.size(); ++k) {
+        int i = k / all_dim.d[1], j = k % all_dim.d[1];
+        int indx = j * all_dim.d[0] + i;
+        lookup_params_order_lst[indx] = lookup_params_lst[k];
+      }
+      lookup_params_lst.resize(0);
+    };
+    if (all_dim.nd == 2) {
+      transpose_lambda();
+    }
+    TensorTools::SetElements(lookup_param.get_storage().all_values,
+                             lookup_params_order_lst);
+
+    // read lookup_param.get_storage().all_grads
+    lookup_params_lst.resize(0);
+    deserialize_tensor_lambda();
+    lookup_params_order_lst = lookup_params_lst;
+    // TODO: high dimensions >=3
+    if (all_dim.nd == 2) {
+      transpose_lambda();
+    }
+    TensorTools::SetElements(lookup_param.get_storage().all_grads,
+                             lookup_params_order_lst);
+    std::getline(f, line);
+  } // while LookupParameter
+
+  if (line.size()) {
+    if (line != "#") {
+      DYNET_RUNTIME_ERR("Invalid model file format. Check this line: " + line);
+    }
+  }
+  f.close();
+  meta_f.close();
+}
+
+} // namespace dynet

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -26,13 +26,56 @@ std::istream& operator>>(std::istream& is, std::vector<T> & v) {
 class Pack {
  public:
   Pack(std::string filename) : fn(filename), fn_meta(filename + ".meta") {}
-  void save(ParameterCollection & model, std::string key = "", bool is_append = false);
-  void load(ParameterCollection & model, std::string key = "");
+  /**
+   * @brief Save ParameterCollection with key.
+   *        use internal namespace if key is not given.
+   *
+   * @param model: input ParameterCollection object to save
+   * @param key: optional parameter, the key for model
+   * @param is_append: optional parameter
+   *                   to specify whether the model file should be appended or not
+   */
+  void save(ParameterCollection & model,
+            const std::string & key = "", bool is_append = false);
+  /**
+   * @brief Save ParameterCollection's parameters and lookup parameters with filter_lst and key.
+   *        use internal namespace if key is not given.
+   *
+   * @param model: input ParameterCollection object to save
+   * @param filter_lst: save parameters and lookup parameters satisfies the filter_lst condition
+   *                    each filter can be regex expression
+   * @param key: optional parameter, the key for model
+   * @param is_append: optional parameter
+   *                   to specify whether the model file should be appended or not
+   */
+  void save(ParameterCollection & model,
+            const std::vector<std::string> & filter_lst,
+            const std::string & key = "", bool is_append = false);
+  /**
+   * @brief Load ParameterCollection object with key equals to key.
+   * 
+   * @param model: input/output parameter, the ParameterCollection object to be loaded
+   * @param key: optional parameter, the key for loading model
+   *
+   */
+  void load(ParameterCollection & model, const std::string & key = "");
+  /**
+   * @brief Load ParameterCollection object with filter_lst and with key equals to key.
+   * 
+   * @param model: input/output parameter, the ParameterCollection object to be loaded
+   * @param filter_lst: load parameters and lookup parameters satisfies the filter_lst condition
+   *                    each filter can be regex expression
+   * @param key: optional parameter, the key for loading model
+   *
+   */
+  void load(ParameterCollection & model,
+            const std::vector<std::string> & filter_lst,
+            const std::string & key = "");
  
  private:
   bool duplicate_key_check(const std::string & key); 
-  void serialize(ParameterCollection & model, std::string key, bool is_append);
-  void deserialize(ParameterCollection & model, std::string key);
+  void serialize(ParameterCollection & model, const std::string & key, bool is_append);
+  void deserialize(ParameterCollection & model, const std::string & key);
 
  private:
   std::string fn, fn_meta;

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -1,0 +1,143 @@
+#ifndef DYNET_IO_H_
+#define DYNET_IO_H_
+
+#include <string>
+#include <vector>
+#include <sstream>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <unordered_map>
+
+#include "dynet/str_util.h"
+#include "dynet/dim.h"
+#include "dynet/tensor.h"
+
+namespace dynet {
+
+template <class T>
+std::istream& operator>>(std::istream& is, std::vector<T> & v) {
+  std::copy(std::istream_iterator<T>(is), std::istream_iterator<T>(), v.begin());
+  return is;
+}
+
+class Pack {
+ public:
+  Pack(std::string filename) : fn(filename), fn_meta(filename + ".meta") {}
+
+  void save(ParameterCollection & model, std::string key = "") {
+    std::string key_str(key);
+    if (key.size() == 0) {
+      key_str = model.get_namespace();
+    }
+
+    std::ofstream os;
+    os.open(fn_meta, std::ios::app);
+    os << key_str << ':' << offset << '\n';
+    os.close();
+
+    this->serialize(model, key);
+  }
+
+  void load(ParameterCollection & model, std::string key = "") {
+    this->deserialize(model, key);
+  }
+  
+ private:
+  void serialize(ParameterCollection & model, std::string key) {
+    std::ofstream os;
+    os.open(fn, std::ios::app);
+    os.seekp(this->offset);
+    os << '#' << std::endl;
+    auto params = model.get_parameter_storages();
+    for (auto & param : params) {
+      os << "#Parameter#" << std::endl;
+      os << param->name << std::endl;
+      os << param->dim << std::endl;
+      os << param->values << std::endl;
+      os << param->g << std::endl;
+    }
+    /*
+    auto lookup_params = model.get_lookup_parameter_storages();
+    for (auto & lookup_param: lookup_params) {
+    }
+    */
+    this->offset = os.tellp();
+    os.close();
+  }
+
+  void deserialize(ParameterCollection & model, std::string key) {
+    std::ifstream meta_f(fn_meta);
+    std::ifstream f(fn);
+    std::string key_str;
+    long long local_offset = -1;
+    std::string line;
+    while (std::getline(meta_f, line)) {
+      auto kv = dynet::str_split(line, ':');
+      if (kv[0] == key) {
+        local_offset = std::stoll(kv[1]);
+        break;
+      }
+    }
+    if (local_offset == -1) {
+      throw std::runtime_error("Load error: no such key");
+    }
+    f.seekg(local_offset);
+    std::getline(f, line);
+    if (line != "#") {
+      throw std::runtime_error("Invalid model file format.");
+    }
+
+    std::getline(f, line);
+    while (line == "#Parameter#") {
+      std::getline(f, line);
+      auto name = dynet::str_split(line, '/').back();
+      name = dynet::str_split(name, '_').front();
+
+      Dim d;
+      std::getline(f, line);
+      std::istringstream iss(line);
+      iss >> d;
+      Parameter param = model.add_parameters(d, name);
+
+      std::vector<float> params_lst;
+      auto deserialize_tensor_lambda = [&] () {
+        for (int k1 = 0; k1 < d.d[0]; ++k1) {
+          // CHECK DIMENSION
+          int sz = d.nd == 1 ? 1 : d.d[1];
+          std::vector<float> tmp(sz);
+          std::getline(f, line);
+          std::istringstream iss(line);
+          iss >> tmp;
+          params_lst.insert(tmp.end(), params_lst.begin(), params_lst.end());
+        }
+      };
+      deserialize_tensor_lambda();
+      TensorTools::SetElements(param.get_storage().values, params_lst);
+
+      params_lst.resize(0);
+      deserialize_tensor_lambda();
+      TensorTools::SetElements(param.get_storage().g, params_lst);
+      std::getline(f, line);
+    } // while Parameter
+    
+    while (line == "#LookupParameter#") {
+      // TODO
+    }
+    if (line.size()) {
+      if (line != "#") {
+        throw std::runtime_error("Invalid model file format.");
+      }
+    }
+    f.close();
+    meta_f.close();
+  }
+
+ private:
+  std::string fn, fn_meta;
+  long long offset = 0;
+}; // class Pack
+
+} // namespace dynet
+
+#endif

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -81,6 +81,8 @@ class Pack {
   bool duplicate_key_check(const std::string & key); 
   void serialize(const ParameterCollection & model, const std::string & key, bool is_append);
   void deserialize(ParameterCollection & model, const std::string & key);
+  void deserialize_tensor(std::ifstream & f, const Dim & d,
+                          std::vector<float> & params_order_lst);
 
  private:
   std::string fn, fn_meta;

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -9,10 +9,11 @@
 #include <stdexcept>
 #include <unordered_map>
 
-#include "dynet/str_util.h"
 #include "dynet/dim.h"
+#include "dynet/model.h"
 #include "dynet/tensor.h"
 #include "dynet/except.h"
+#include "dynet/str_util.h"
 
 namespace dynet {
 
@@ -25,223 +26,13 @@ std::istream& operator>>(std::istream& is, std::vector<T> & v) {
 class Pack {
  public:
   Pack(std::string filename) : fn(filename), fn_meta(filename + ".meta") {}
-
-  void save(ParameterCollection & model, std::string key = "",
-            bool is_append = false) {
-    std::string key_str(key);
-    if (key.size() == 0) {
-      key_str = model.get_namespace();
-    }
-    if (duplicate_key_check(key_str) == false) {
-        DYNET_RUNTIME_ERR("You couldn't save ParameterCollections with the same key in file: " + fn);
-    }
-    // write offset info into meta file
-    std::ofstream os;
-    if (is_append) {
-      os.open(fn_meta, std::ofstream::app);
-    } else {
-      os.open(fn_meta);
-    }
-    os << key_str << ':' << offset << '\n';
-    os.close();
-    // write model into model file
-    this->serialize(model, key, is_append);
-  }
-
-  void load(ParameterCollection & model, std::string key = "") {
-    this->deserialize(model, key);
-  }
+  void save(ParameterCollection & model, std::string key = "", bool is_append = false);
+  void load(ParameterCollection & model, std::string key = "");
  
  private:
-  bool duplicate_key_check(const std::string & key) {
-    std::ifstream f(fn_meta);
-    std::string line;
-    while (std::getline(f, line)) {
-      auto kv = dynet::str_split(line, ':');
-      if (kv[0] == key) return false;
-    }
-    f.close();
-    return true;
-  }
-
-  void serialize(ParameterCollection & model, std::string key, bool is_append) {
-    std::ofstream os;
-    if (is_append) {
-      os.open(fn, std::ofstream::app);
-    } else {
-      os.open(fn);
-    }
-    os.seekp(this->offset);
-    os << '#' << std::endl; // identifier of beginning of the ParameterCollection
-    auto params = model.get_parameter_storages();
-    for (auto & param : params) {
-      os << "#Parameter#" << std::endl;
-      os << param->name << std::endl;
-      os << param->dim << std::endl;
-      os << param->values << std::endl;
-      os << param->g << std::endl;
-    }
-    auto lookup_params = model.get_lookup_parameter_storages();
-    for (auto & lookup_param: lookup_params) {
-      os << "#LookupParameter#" << std::endl;
-      os << lookup_param->name << std::endl;
-      os << lookup_param->all_dim << std::endl;
-      os << lookup_param->dim << std::endl;
-      os << lookup_param->all_values << std::endl;
-      os << lookup_param->all_grads << std::endl;
-    }
-    this->offset = os.tellp();
-    os.close();
-  }
-
-  void deserialize(ParameterCollection & model, std::string key) {
-    std::ifstream meta_f(fn_meta);
-    std::ifstream f(fn);
-    // find the offset of the key
-    long long local_offset = -1;
-    std::string line;
-    while (std::getline(meta_f, line)) {
-      auto kv = dynet::str_split(line, ':');
-      if (kv[0] == key) {
-        local_offset = std::stoll(kv[1]);
-        break;
-      }
-    }
-    if (local_offset == -1) {
-      DYNET_RUNTIME_ERR("Load error: no such key: " + key);
-    }
-
-    // check identifier
-    f.seekg(local_offset);
-    std::getline(f, line);
-    if (line != "#") {
-      DYNET_RUNTIME_ERR("Invalid model file format. Check this line: " + line);
-    }
-
-    // read parameters
-    std::getline(f, line);
-    while (line == "#Parameter#") {
-      std::getline(f, line);
-      auto name = dynet::str_split(line, '/').back();
-      name = name.substr(0, name.find_first_of("__"));
-
-      Dim d;
-      std::getline(f, line);
-      std::istringstream iss(line);
-      iss >> d;
-
-      // add param into input model
-      Parameter param = model.add_parameters(d, name);
-
-      // read param.get_storage().values
-      std::vector<float> params_lst;
-      auto deserialize_tensor_lambda = [&] () {
-        for (int k1 = 0; k1 < d.d[0]; ++k1) {
-          // TODO: check dimensions 
-          int sz = d.nd == 1 ? 1 : d.d[1];
-          std::vector<float> tmp(sz);
-          std::getline(f, line);
-          std::istringstream iss(line);
-          iss >> tmp;
-          params_lst.insert(params_lst.end(), tmp.begin(), tmp.end());
-        }
-      };
-      deserialize_tensor_lambda();
-      std::vector<float> params_order_lst = params_lst;
-      auto transpose_lambda = [&] () {
-        for (size_t k = 0; k < params_lst.size(); ++k) {
-          int i = k / d.d[1], j = k % d.d[1];
-          int indx = j * d.d[0] + i;
-          params_order_lst[indx] = params_lst[k];
-        }
-        params_lst.resize(0);
-      };
-      // TODO: high dimensions >=3
-      if (d.nd == 2) {
-        transpose_lambda();
-      }
-      TensorTools::SetElements(param.get_storage().values, params_order_lst);
-
-      // read param.get_storage().g
-      params_lst.resize(0);
-      deserialize_tensor_lambda();
-      params_order_lst = params_lst;
-      if (d.nd == 2) {
-        transpose_lambda();
-      }
-      TensorTools::SetElements(param.get_storage().g, params_order_lst);
-      std::getline(f, line);
-    } // while Parameter
-    
-    // read lookup parameters
-    while (line == "#LookupParameter#") {
-      std::getline(f, line);
-      auto name = dynet::str_split(line, '/').back();
-      name = name.substr(0, name.find_first_of("__"));
-
-      Dim all_dim;
-      std::getline(f, line);
-      std::istringstream iss(line);
-      iss >> all_dim;
-      unsigned int N = all_dim.d[all_dim.nd - 1];
-
-      Dim d;
-      std::getline(f, line);
-      std::istringstream iss2(line);
-      iss2 >> d;
-
-      // add lookup_param into input model
-      LookupParameter lookup_param = model.add_lookup_parameters(N, d, name);
-
-      // read lookup_param.get_storage().all_values
-      std::vector<float> lookup_params_lst;
-      auto deserialize_tensor_lambda = [&] () {
-        for (int k1 = 0; k1 < all_dim.d[0]; ++k1) {
-          // TODO: check dimensions 
-          std::vector<float> tmp(all_dim.d[1]);
-          std::getline(f, line);
-          std::istringstream iss(line);
-          iss >> tmp;
-          lookup_params_lst.insert(lookup_params_lst.end(), tmp.begin(), tmp.end());
-        }
-      };
-      deserialize_tensor_lambda();
-      std::vector<float> lookup_params_order_lst = lookup_params_lst;
-      auto transpose_lambda = [&] () {
-        for (size_t k = 0; k < lookup_params_lst.size(); ++k) {
-          int i = k / all_dim.d[1], j = k % all_dim.d[1];
-          int indx = j * all_dim.d[0] + i;
-          lookup_params_order_lst[indx] = lookup_params_lst[k];
-        }
-        lookup_params_lst.resize(0);
-      };
-      if (all_dim.nd == 2) {
-        transpose_lambda();
-      }
-      TensorTools::SetElements(lookup_param.get_storage().all_values,
-                               lookup_params_order_lst);
-
-      // read lookup_param.get_storage().all_grads
-      lookup_params_lst.resize(0);
-      deserialize_tensor_lambda();
-      lookup_params_order_lst = lookup_params_lst;
-      // TODO: high dimensions >=3
-      if (all_dim.nd == 2) {
-        transpose_lambda();
-      }
-      TensorTools::SetElements(lookup_param.get_storage().all_grads,
-                               lookup_params_order_lst);
-      std::getline(f, line);
-    } // while LookupParameter
-
-    if (line.size()) {
-      if (line != "#") {
-        DYNET_RUNTIME_ERR("Invalid model file format. Check this line: " + line);
-      }
-    }
-    f.close();
-    meta_f.close();
-  }
+  bool duplicate_key_check(const std::string & key); 
+  void serialize(ParameterCollection & model, std::string key, bool is_append);
+  void deserialize(ParameterCollection & model, std::string key);
 
  private:
   std::string fn, fn_meta;

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -26,6 +26,11 @@ std::istream& operator>>(std::istream& is, std::vector<T> & v) {
 class Pack {
  public:
   Pack(std::string filename) : fn(filename), fn_meta(filename + ".meta") {}
+  void reinit(std::string filename) {
+    fn = filename;
+    fn_meta = filename + ".meta";
+    offset = 0;
+  }
   /**
    * @brief Save ParameterCollection with key.
    *        use internal namespace if key is not given.
@@ -35,7 +40,7 @@ class Pack {
    * @param is_append: optional parameter
    *                   to specify whether the model file should be appended or not
    */
-  void save(ParameterCollection & model,
+  void save(const ParameterCollection & model,
             const std::string & key = "", bool is_append = false);
   /**
    * @brief Save ParameterCollection's parameters and lookup parameters with filter_lst and key.
@@ -48,7 +53,7 @@ class Pack {
    * @param is_append: optional parameter
    *                   to specify whether the model file should be appended or not
    */
-  void save(ParameterCollection & model,
+  void save(const ParameterCollection & model,
             const std::vector<std::string> & filter_lst,
             const std::string & key = "", bool is_append = false);
   /**
@@ -74,7 +79,7 @@ class Pack {
  
  private:
   bool duplicate_key_check(const std::string & key); 
-  void serialize(ParameterCollection & model, const std::string & key, bool is_append);
+  void serialize(const ParameterCollection & model, const std::string & key, bool is_append);
   void deserialize(ParameterCollection & model, const std::string & key);
 
  private:

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -321,9 +321,9 @@ ParameterStorage* ParameterCollection::get_parameter_storage(const std::string &
   throw std::runtime_error(errMsg);
 }
 
-std::vector<ParameterStorage*> ParameterCollection::get_parameter_storages() {
+std::vector<ParameterStorage*> ParameterCollection::get_parameter_storages() const {
   std::vector<ParameterStorage*> params;
-  ParameterCollection *t = this;
+  ParameterCollection *t = const_cast<ParameterCollection*>(this);
   while (t->parent != nullptr) { t = t->parent; }
   for (auto & param : t->get_storage().params) {
     if (param->name.find(name) == 0) {
@@ -374,9 +374,10 @@ LookupParameterStorage* ParameterCollection::get_lookup_parameter_storage(const 
   throw std::runtime_error(errMsg);
 }
 
-std::vector<LookupParameterStorage*> ParameterCollection::get_lookup_parameter_storages() {
+std::vector<LookupParameterStorage*>
+ParameterCollection::get_lookup_parameter_storages() const {
   std::vector<LookupParameterStorage*> lookup_params;
-  ParameterCollection *t = this;
+  ParameterCollection *t = const_cast<ParameterCollection*>(this);
   while (t->parent != nullptr) { t = t->parent; }
   for (auto & lookup_param: t->get_storage().lookup_params) {
     if (lookup_param->name.find(name) == 0) {

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -273,6 +273,13 @@ struct Parameter {
   Tensor* values() { return &(get_storage().values); }
 
   /**
+   * \brief gradients of the parameter
+   *
+   * \return gradients as a `Tensor` object
+   */
+  Tensor* gradients() { return &(get_storage().g); }
+
+  /**
    * \brief Get the current weight decay for the parameters
    */
   float current_weight_decay() const;

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -465,7 +465,7 @@ public:
    *
    * \return list of points to ParameterStorage objects
    */
-  std::vector<ParameterStorage*> get_parameter_storages();
+  std::vector<ParameterStorage*> get_parameter_storages() const;
   /**
    * \brief Add lookup parameter to model
    * \details Same as add_parameters. Initializes with Glorot
@@ -498,7 +498,7 @@ public:
    *
    * \return list of points to LookupParameterStorage objects
    */
-  std::vector<LookupParameterStorage*> get_lookup_parameter_storages();
+  std::vector<LookupParameterStorage*> get_lookup_parameter_storages() const;
   //
   /**
    * \brief project weights so their L2 norm = radius
@@ -594,7 +594,7 @@ public:
   /**
    * @brief get namespace of current ParameterCollection object(end with a slash)
    */
-  std::string get_namespace() { return name; }
+  std::string get_namespace() const { return name; }
 
   /**
    * \brief Get the weight decay object

--- a/dynet/str_util.h
+++ b/dynet/str_util.h
@@ -1,0 +1,33 @@
+#ifndef DYNET_STR_UTIL_H_
+#define DYNET_STR_UTIL_H_
+
+#include <vector>
+#include <string>
+
+namespace dynet {
+
+bool startswith(const std::string & str, const std::string & key) {
+  return str.find(key) == 0;
+}
+
+bool endswith(const std::string & str, const std::string & key) {
+  if (str.size() < key.size()) return false;
+  return str.rfind(key) == (str.size() - key.size());
+}
+
+std::vector<std::string> str_split(const std::string & str, const char sep) {
+  std::vector<std::string> lst;
+  size_t st = 0, en = 0;
+  while (1) {
+    en = str.find(sep, st);
+    auto s = str.substr(st, en - st);
+    if(s.size()) lst.push_back(s);
+    if(en == std::string::npos) break;
+    st = en + 1;
+  }
+  return lst;
+}
+
+} // namespace dynet
+
+#endif

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -7,6 +7,7 @@
 #include <dynet/lstm.h>
 #include <dynet/gru.h>
 #include <dynet/treelstm.h>
+#include <dynet/io.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
@@ -177,6 +178,34 @@ BOOST_AUTO_TEST_CASE ( test_parametercollection_with_builder ) {
   dynet::ParameterCollection collec2;
   auto bi_treelstm_builder = BidirectionalTreeLSTMBuilder(3, 10, 2, collec2);
   DYNET_CHECK_EQUAL(bi_treelstm_builder.get_parameters().size(), 11 * 3 * 2);
+}
+
+BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
+  ParameterCollection m;
+  Parameter a = m.add_parameters({10}, "a");
+  //Parameter b = m.add_parameters({3,7});
+  dynet::Pack s("test.model");
+  s.save(m, "model1");
+  s.save(m);
+
+  ParameterCollection m2;
+  s.load(m2, "model1");
+  auto params1 = m2.get_parameter_storages();
+  for(auto & x : params1) {
+    std::cout << x->name << std::endl;
+    std::cout << x->dim << std::endl;
+    std::cout << x->values << std::endl;
+    std::cout << x->g << std::endl;
+  }
+  ParameterCollection m3;
+  s.load(m3, "/");
+  auto params2 = m3.get_parameter_storages();
+  for(auto & x : params2) {
+    std::cout << x->name << std::endl;
+    std::cout << x->dim << std::endl;
+    std::cout << x->values << std::endl;
+    std::cout << x->g << std::endl;
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -187,7 +187,7 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
   LookupParameter c = m.add_lookup_parameters(10, {2});
   dynet::Pack s("test.model");
   s.save(m, "model1");
-  s.save(m);
+  s.save(m, m.get_namespace(), true);
 
   ParameterCollection m2;
   s.load(m2, "model1");

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -1,5 +1,15 @@
 #define BOOST_TEST_MODULE TEST_PARAMS
 
+#include <cstdio>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <stdexcept>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+
 #include <dynet/dynet.h>
 #include <dynet/expr.h>
 #include <dynet/model.h>
@@ -8,13 +18,7 @@
 #include <dynet/gru.h>
 #include <dynet/treelstm.h>
 #include <dynet/io.h>
-#include <boost/test/unit_test.hpp>
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <iostream>
-#include <fstream>
-#include <string>
-#include <stdexcept>
+
 #include "test.h"
 
 using namespace dynet;
@@ -79,7 +83,7 @@ class testModel2 {
   dynet::Parameter W_x, b_x;
   dynet::ParameterCollection affine_params;
   dynet::LSTMBuilder lstm;
-}; // class testModel
+}; // class testModel2
 
 // define the test suite
 BOOST_FIXTURE_TEST_SUITE(params_test, ParamsTest);
@@ -180,11 +184,12 @@ BOOST_AUTO_TEST_CASE ( test_parametercollection_with_builder ) {
   DYNET_CHECK_EQUAL(bi_treelstm_builder.get_parameters().size(), 11 * 3 * 2);
 }
 
-BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
+BOOST_AUTO_TEST_CASE ( test_save_load_parameter_collection ) {
   ParameterCollection m;
   Parameter a = m.add_parameters({10}, "a");
   Parameter b = m.add_parameters({3,7});
   LookupParameter c = m.add_lookup_parameters(10, {2});
+  std::remove("test.model"); std::remove("test.model.meta");
   dynet::Pack s("test.model");
   s.save(m, "model1");
   s.save(m, m.get_namespace(), true);
@@ -233,6 +238,55 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
     std::cout << x->all_grads << std::endl;
     std::cout << x->values[0] << std::endl;
     std::cout << x->grads[0] << std::endl;
+  }
+}
+
+BOOST_AUTO_TEST_CASE ( test_save_load_parameter_collections ) {
+  {
+    ParameterCollection collec;
+    testModel2 spec(collec);
+    std::remove("a.model"); std::remove("a.model.meta");
+    Pack s1("a.model");
+    s1.save(collec, "all");
+    ParameterCollection collec2;
+    s1.load(collec2);
+    DYNET_CHECK_EQUAL(collec2.size(), collec.size());
+  
+    std::remove("b.model"); std::remove("b.model.meta");
+    Pack s2("b.model");
+    s2.save(collec, "all");
+    s2.save(spec.get_lstm_model(), "lstm", true);
+    s2.save(spec.get_affine_model(), "affine", true);
+    ParameterCollection collec3, lstm2, affine2;
+    s2.load(affine2, "affine");
+    s2.load(collec3, "all");
+    s2.load(lstm2, "lstm");
+    DYNET_CHECK_EQUAL(affine2.size(), spec.get_affine_model().size());
+    DYNET_CHECK_EQUAL(collec3.size(), collec.size());
+    DYNET_CHECK_EQUAL(lstm2.size(), spec.get_lstm_model().size());
+
+    std::remove("c.model"); std::remove("c.model.meta");
+    s2.reinit("c.model");
+    s2.save(lstm2, "lstm");
+    s2.save(collec3, "all", true);
+    s2.save(affine2, "affine", true);
+  }
+
+  {
+    ParameterCollection cc;
+    auto cc2 = cc.add_subcollection("xx");
+    cc2.add_parameters({10});
+    std::remove("d.model"); std::remove("d.model.meta");
+    Pack s3("d.model");
+    s3.save(cc, "key");
+
+    ParameterCollection ccc;
+    s3.load(ccc, "key");
+    DYNET_CHECK_EQUAL(ccc.size(), cc.size());
+
+    std::remove("e.model"); std::remove("e.model.meta");
+    s3.reinit("e.model");
+    s3.save(ccc);
   }
 }
 

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -198,6 +198,13 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
     std::cout << x->values << std::endl;
     std::cout << x->g << std::endl;
   }
+  auto params11 = m.get_parameter_storages();
+  for(auto & x : params11) {
+    std::cout << x->name << std::endl;
+    std::cout << x->dim << std::endl;
+    std::cout << x->values << std::endl;
+    std::cout << x->g << std::endl;
+  }
   ParameterCollection m3;
   s.load(m3, "/");
   auto params2 = m3.get_parameter_storages();
@@ -207,8 +214,18 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
     std::cout << x->values << std::endl;
     std::cout << x->g << std::endl;
   }
-  auto lookup_params = m3.get_lookup_parameter_storages();
+  auto lookup_params = m2.get_lookup_parameter_storages();
   for(auto & x : lookup_params) {
+    std::cout << x->name << std::endl;
+    std::cout << x->dim << std::endl;
+    std::cout << x->all_dim << std::endl;
+    std::cout << x->all_values << std::endl;
+    std::cout << x->all_grads << std::endl;
+    std::cout << x->values[0] << std::endl;
+    std::cout << x->grads[0] << std::endl;
+  }
+  auto lookup_paramss = m.get_lookup_parameter_storages();
+  for(auto & x : lookup_paramss) {
     std::cout << x->name << std::endl;
     std::cout << x->dim << std::endl;
     std::cout << x->all_dim << std::endl;

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -183,7 +183,8 @@ BOOST_AUTO_TEST_CASE ( test_parametercollection_with_builder ) {
 BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
   ParameterCollection m;
   Parameter a = m.add_parameters({10}, "a");
-  //Parameter b = m.add_parameters({3,7});
+  Parameter b = m.add_parameters({3,7});
+  LookupParameter c = m.add_lookup_parameters(10, {2});
   dynet::Pack s("test.model");
   s.save(m, "model1");
   s.save(m);
@@ -205,6 +206,16 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
     std::cout << x->dim << std::endl;
     std::cout << x->values << std::endl;
     std::cout << x->g << std::endl;
+  }
+  auto lookup_params = m3.get_lookup_parameter_storages();
+  for(auto & x : lookup_params) {
+    std::cout << x->name << std::endl;
+    std::cout << x->dim << std::endl;
+    std::cout << x->all_dim << std::endl;
+    std::cout << x->all_values << std::endl;
+    std::cout << x->all_grads << std::endl;
+    std::cout << x->values[0] << std::endl;
+    std::cout << x->grads[0] << std::endl;
   }
 }
 


### PR DESCRIPTION
This pull request means to implement native save/load serialization and deserialization logic without Boost. https://github.com/clab/dynet/issues/230 https://github.com/clab/dynet/issues/84

There are still some commits need to be finished in this pull request.
- [x] Checking existing model file to avoid confliction.
- [x] Add more save and load interfaces.
- [x] Refactor and add more tests.

Moreover, there are still some ideas need to be discussed.
1. Do we need to support save/load a single `Parameter` and `LookupParameter`? If yes, although current mechanism can also apply while some existing code(exclude pull request) need to be refactored a lot.
2. Current implementation doesn't support Builder load which is supported in current version.
3. Current format is text based one considering readability, it is kind of a mimic version of JSON/YAML, but this will take more space and might lose some precision.