### PR TITLE
Fixed dimensions of affine transform (#400)

### DIFF
--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -766,7 +766,9 @@ Dim AffineTransform::dim_forward(const vector<Dim>& xs) const {
   if(xs.size() == 1) return xs[0];
   DYNET_ARG_CHECK(xs[0].rows() == xs[1].rows() && xs[1].cols() == xs[2].rows(),
                           "Bad dimensions for AffineTransform: " << xs);
-  Dim d({xs[0].rows(), xs[2].cols()}, max(max(xs[0].bd, xs[1].bd), xs[2].bd));
+  Dim d = (xs[2].cols() != 1 ?
+           Dim({xs[0].rows(), xs[2].cols()}, max(max(xs[0].bd, xs[1].bd), xs[2].bd)) :
+           Dim({xs[0].rows()}, max(max(xs[0].bd, xs[1].bd), xs[2].bd)));
   for (unsigned i = 3; i < xs.size(); i += 2) {
     DYNET_ARG_CHECK(xs[i].cols() == xs[i+1].rows() && d.rows() == xs[i].rows() && d.cols() == xs[i+1].cols(),
                             "Bad dimensions for AffineTransform: " << xs);

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -215,6 +215,7 @@ BOOST_AUTO_TEST_CASE( affine_gradient ) {
   Expression y = sqrt(affine_transform({x1, x2, scalar}));
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
+  BOOST_CHECK(y.dim() == x1.dim());
 }
 
 // Expression operator*(const Expression& x, const Expression& y);


### PR DESCRIPTION
Maintained the dimensions of affine transform to be 1 if the number of columns is 1, fixing
https://github.com/clab/dynet/issues/400