### PR TITLE
Add max_dim and min_dim functions

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -138,8 +138,8 @@ Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_
 
 Expression kmh_ngram(const Expression& x, unsigned n) { return Expression(x.pg, x.pg->add_function<KMHNGram>({x.i}, n)); }
 
-Expression maxout(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MaxOut>({x.i}, d)); }
-Expression minout(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MinOut>({x.i}, d)); }
+Expression max_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MaxDimension>({x.i}, d)); }
+Expression min_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MinDimension>({x.i}, d)); }
 
 }
 }

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -139,6 +139,7 @@ Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_
 Expression kmh_ngram(const Expression& x, unsigned n) { return Expression(x.pg, x.pg->add_function<KMHNGram>({x.i}, n)); }
 
 Expression maxout(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MaxOut>({x.i}, d)); }
+Expression minout(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MinOut>({x.i}, d)); }
 
 }
 }

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -138,6 +138,7 @@ Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_
 
 Expression kmh_ngram(const Expression& x, unsigned n) { return Expression(x.pg, x.pg->add_function<KMHNGram>({x.i}, n)); }
 
+Expression maxout(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MaxOut>({x.i}, d)); }
 
 }
 }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1512,7 +1512,7 @@ inline Expression concatenate(const T& xs) { return detail::f<Concatenate>(xs); 
 
 /**
  * \ingroup flowoperations
- * \brief Max out
+ * \brief Max out through a dimension
  * \details Select out a element/row/column/sub-tensor from an expression, 
  *          with maximum value along a given dimension.
  *          This will result in the dimension of the tensor being reduced
@@ -1523,11 +1523,11 @@ inline Expression concatenate(const T& xs) { return detail::f<Concatenate>(xs); 
  *
  * \return An expression of sub-tensor with max value along dimension d
  */
-Expression maxout(const Expression& x, unsigned d = 0);
+Expression max_dim(const Expression& x, unsigned d = 0);
 
 /**
  * \ingroup flowoperations
- * \brief Min out
+ * \brief Min out through a dimension
  * \details Select out a element/row/column/sub-tensor from an expression, 
  *          with minimum value along a given dimension.
  *          This will result in the dimension of the tensor being reduced
@@ -1538,7 +1538,7 @@ Expression maxout(const Expression& x, unsigned d = 0);
  *
  * \return An expression of sub-tensor with min value along dimension d
  */
-Expression minout(const Expression& x, unsigned d = 0);
+Expression min_dim(const Expression& x, unsigned d = 0);
 
 ////////////////////////////////////////////////
 // Noise operations                           //

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1525,6 +1525,21 @@ inline Expression concatenate(const T& xs) { return detail::f<Concatenate>(xs); 
  */
 Expression maxout(const Expression& x, unsigned d = 0);
 
+/**
+ * \ingroup flowoperations
+ * \brief Min out
+ * \details Select out a element/row/column/sub-tensor from an expression, 
+ *          with minimum value along a given dimension.
+ *          This will result in the dimension of the tensor being reduced
+ *          by 1.
+ *
+ * \param x The input expression
+ * \param d The dimension along which to choose the element
+ *
+ * \return An expression of sub-tensor with min value along dimension d
+ */
+Expression minout(const Expression& x, unsigned d = 0);
+
 ////////////////////////////////////////////////
 // Noise operations                           //
 ////////////////////////////////////////////////

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1510,6 +1510,21 @@ inline Expression concatenate(const std::initializer_list<Expression>& xs) { ret
 template <typename T>
 inline Expression concatenate(const T& xs) { return detail::f<Concatenate>(xs); }
 
+/**
+ * \ingroup flowoperations
+ * \brief Max out
+ * \details Select out a element/row/column/sub-tensor from an expression, 
+ *          with maximum value along a given dimension.
+ *          This will result in the dimension of the tensor being reduced
+ *          by 1.
+ *
+ * \param x The input expression
+ * \param d The dimension along which to choose the element
+ *
+ * \return An expression of sub-tensor with max value along dimension d
+ */
+Expression maxout(const Expression& x, unsigned d = 0);
+
 ////////////////////////////////////////////////
 // Noise operations                           //
 ////////////////////////////////////////////////

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -954,4 +954,21 @@ Dim MaxOut::dim_forward(const vector<Dim>& xs) const {
   return ret;
 }
 
+string MinOut::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "minout(" << arg_names[0] << ", reduced_dim=" << reduced_dim << ')';
+  return s.str();
+}
+
+Dim MinOut::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in MinOut");
+  DYNET_ARG_CHECK(reduced_dim < xs[0].nd,
+                          "Tried to Minout on dimension " << reduced_dim << " bigger than input " << xs[0]);
+  DYNET_ARG_CHECK(xs[0].nd < 4,
+                          "MinOut not currently supported for tensors of 4 or more dimensions.");
+  Dim ret(xs[0]);
+  ret.delete_dim(reduced_dim);
+  return ret;
+}
+
 } // namespace dynet

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -937,4 +937,21 @@ Dim RandomGumbel::dim_forward(const vector<Dim>& xs) const {
   return dim;
 }
 
+string MaxOut::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "maxout(" << arg_names[0] << ", reduced_dim=" << reduced_dim << ')';
+  return s.str();
+}
+
+Dim MaxOut::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in MaxOut");
+  DYNET_ARG_CHECK(reduced_dim < xs[0].nd,
+                          "Tried to Maxout on dimension " << reduced_dim << " bigger than input " << xs[0]);
+  DYNET_ARG_CHECK(xs[0].nd < 4,
+                          "MaxOut not currently supported for tensors of 4 or more dimensions.");
+  Dim ret(xs[0]);
+  ret.delete_dim(reduced_dim);
+  return ret;
+}
+
 } // namespace dynet

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -937,35 +937,35 @@ Dim RandomGumbel::dim_forward(const vector<Dim>& xs) const {
   return dim;
 }
 
-string MaxOut::as_string(const vector<string>& arg_names) const {
+string MaxDimension::as_string(const vector<string>& arg_names) const {
   ostringstream s;
-  s << "maxout(" << arg_names[0] << ", reduced_dim=" << reduced_dim << ')';
+  s << "max_dim(" << arg_names[0] << ", reduced_dim=" << reduced_dim << ')';
   return s.str();
 }
 
-Dim MaxOut::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in MaxOut");
+Dim MaxDimension::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in MaxDimension");
   DYNET_ARG_CHECK(reduced_dim < xs[0].nd,
-                          "Tried to Maxout on dimension " << reduced_dim << " bigger than input " << xs[0]);
+                          "Tried to MaxDimension on dimension " << reduced_dim << " bigger than input " << xs[0]);
   DYNET_ARG_CHECK(xs[0].nd < 4,
-                          "MaxOut not currently supported for tensors of 4 or more dimensions.");
+                          "MaxDimension not currently supported for tensors of 4 or more dimensions.");
   Dim ret(xs[0]);
   ret.delete_dim(reduced_dim);
   return ret;
 }
 
-string MinOut::as_string(const vector<string>& arg_names) const {
+string MinDimension::as_string(const vector<string>& arg_names) const {
   ostringstream s;
-  s << "minout(" << arg_names[0] << ", reduced_dim=" << reduced_dim << ')';
+  s << "min_dim(" << arg_names[0] << ", reduced_dim=" << reduced_dim << ')';
   return s.str();
 }
 
-Dim MinOut::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in MinOut");
+Dim MinDimension::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in MinDimension");
   DYNET_ARG_CHECK(reduced_dim < xs[0].nd,
-                          "Tried to Minout on dimension " << reduced_dim << " bigger than input " << xs[0]);
+                          "Tried to MinDimension on dimension " << reduced_dim << " bigger than input " << xs[0]);
   DYNET_ARG_CHECK(xs[0].nd < 4,
-                          "MinOut not currently supported for tensors of 4 or more dimensions.");
+                          "MinDimension not currently supported for tensors of 4 or more dimensions.");
   Dim ret(xs[0]);
   ret.delete_dim(reduced_dim);
   return ret;

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -155,6 +155,10 @@ size_t MaxOut::aux_storage_size() const {
   return sizeof(Eigen::DenseIndex) * dim.size();
 }
 
+size_t MinOut::aux_storage_size() const {
+  return sizeof(Eigen::DenseIndex) * dim.size();
+}
+
 #endif // Finish CPU only functions
 
 // ===== Auxiliary functions for both CPU and GPU
@@ -2356,5 +2360,54 @@ void MaxOut::backward_dev_impl(const MyDevice & dev,
   }
 }
 DYNET_NODE_INST_DEV_IMPL(MaxOut)
+
+template<class MyDevice>
+void MinOut::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
+  Eigen::DenseIndex* minmap = static_cast<Eigen::DenseIndex*>(aux_mem);
+  const unsigned batch_size = dim.batch_elems();
+  const unsigned first_dim_size = dim[0];
+  const unsigned second_dim_size = dim[1];
+  Eigen::TensorMap<Eigen::Tensor<Eigen::DenseIndex, 3>> locs(minmap, first_dim_size, second_dim_size, batch_size);
+  const Eigen::array<Eigen::DenseIndex, 1> reduction_axis = {reduced_dim};
+  locs.device(*dev.edevice) = xs[0]->tb<3>().argmin(reduced_dim);
+  fx.tb<2>().device(*dev.edevice) = xs[0]->tb<3>().minimum(reduction_axis);
+}
+
+template<class MyDevice>
+void MinOut::backward_dev_impl(const MyDevice & dev,
+                             const vector<const Tensor*>& xs,
+                             const Tensor& fx,
+                             const Tensor& dEdf,
+                             unsigned i,
+                             Tensor& dEdxi) const {
+  DYNET_ARG_CHECK(i == 0, "Failed dimension check in MinOut::backward");
+#ifdef __CUDACC__
+  vector<Eigen::DenseIndex> indices(dim.size());
+  Eigen::DenseIndex* minmap = &indices[0];
+  CUDA_CHECK(cudaMemcpy((void*)minmap, aux_mem, sizeof(Eigen::DenseIndex) * dim.size(), cudaMemcpyDeviceToHost));
+#else
+  Eigen::DenseIndex* minmap = static_cast<Eigen::DenseIndex*>(aux_mem);
+#endif
+  const unsigned batch_size = dim.batch_elems();
+  const unsigned first_dim_size = dim[0];
+  const unsigned second_dim_size = dim[1];
+  Eigen::TensorMap<Eigen::Tensor<Eigen::DenseIndex, 3>> locs(minmap, first_dim_size, second_dim_size, batch_size);
+  for(unsigned b = 0; b < batch_size; ++b){
+    for(unsigned j = 0; j < second_dim_size; ++j){
+      for(unsigned i = 0; i < first_dim_size; ++i){
+        if (reduced_dim > second_dim)
+          dEdxi.tb<3>().chip<3>(b).chip(locs(i, j, b), reduced_dim).chip(j, second_dim).chip(i, first_dim).device(*dev.edevice) 
+            += dEdf.tb<2>().chip<2>(b).chip<1>(j).chip<0>(i);
+        else if (reduced_dim > first_dim)
+          dEdxi.tb<3>().chip<3>(b).chip(j, second_dim).chip(locs(i, j, b), reduced_dim).chip(i, first_dim).device(*dev.edevice) 
+            += dEdf.tb<2>().chip<2>(b).chip<1>(j).chip<0>(i);
+        else
+          dEdxi.tb<3>().chip<3>(b).chip(j, second_dim).chip(i, first_dim).chip(locs(i, j, b), reduced_dim).device(*dev.edevice) 
+            += dEdf.tb<2>().chip<2>(b).chip<1>(j).chip<0>(i);
+      }
+    }
+  }
+}
+DYNET_NODE_INST_DEV_IMPL(MinOut)
 
 } // namespace dynet

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -151,11 +151,11 @@ size_t SparsemaxLoss::aux_storage_size() const {
   return rows * sizeof(float);
 }
 
-size_t MaxOut::aux_storage_size() const {
+size_t MaxDimension::aux_storage_size() const {
   return sizeof(Eigen::DenseIndex) * dim.size();
 }
 
-size_t MinOut::aux_storage_size() const {
+size_t MinDimension::aux_storage_size() const {
   return sizeof(Eigen::DenseIndex) * dim.size();
 }
 
@@ -2313,7 +2313,7 @@ void RandomGumbel::backward_dev_impl(const MyDevice & dev,
 DYNET_NODE_INST_DEV_IMPL(RandomGumbel)
 
 template<class MyDevice>
-void MaxOut::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
+void MaxDimension::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   Eigen::DenseIndex* maxmap = static_cast<Eigen::DenseIndex*>(aux_mem);
   const unsigned batch_size = dim.batch_elems();
   const unsigned first_dim_size = dim[0];
@@ -2325,13 +2325,13 @@ void MaxOut::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>&
 }
 
 template<class MyDevice>
-void MaxOut::backward_dev_impl(const MyDevice & dev,
+void MaxDimension::backward_dev_impl(const MyDevice & dev,
                              const vector<const Tensor*>& xs,
                              const Tensor& fx,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ARG_CHECK(i == 0, "Failed dimension check in MaxOut::backward");
+  DYNET_ARG_CHECK(i == 0, "Failed dimension check in MaxDimension::backward");
 #ifdef __CUDACC__
   vector<Eigen::DenseIndex> indices(dim.size());
   Eigen::DenseIndex* maxmap = &indices[0];
@@ -2359,10 +2359,10 @@ void MaxOut::backward_dev_impl(const MyDevice & dev,
     }
   }
 }
-DYNET_NODE_INST_DEV_IMPL(MaxOut)
+DYNET_NODE_INST_DEV_IMPL(MaxDimension)
 
 template<class MyDevice>
-void MinOut::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
+void MinDimension::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   Eigen::DenseIndex* minmap = static_cast<Eigen::DenseIndex*>(aux_mem);
   const unsigned batch_size = dim.batch_elems();
   const unsigned first_dim_size = dim[0];
@@ -2374,13 +2374,13 @@ void MinOut::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>&
 }
 
 template<class MyDevice>
-void MinOut::backward_dev_impl(const MyDevice & dev,
+void MinDimension::backward_dev_impl(const MyDevice & dev,
                              const vector<const Tensor*>& xs,
                              const Tensor& fx,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  DYNET_ARG_CHECK(i == 0, "Failed dimension check in MinOut::backward");
+  DYNET_ARG_CHECK(i == 0, "Failed dimension check in MinDimension::backward");
 #ifdef __CUDACC__
   vector<Eigen::DenseIndex> indices(dim.size());
   Eigen::DenseIndex* minmap = &indices[0];
@@ -2408,6 +2408,6 @@ void MinOut::backward_dev_impl(const MyDevice & dev,
     }
   }
 }
-DYNET_NODE_INST_DEV_IMPL(MinOut)
+DYNET_NODE_INST_DEV_IMPL(MinDimension)
 
 } // namespace dynet

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -601,6 +601,18 @@ struct RandomGumbel : public Node {
   real mu, beta;
 };
 
+struct MaxOut : public Node {
+  explicit MaxOut(const std::initializer_list<VariableIndex>& a, unsigned dimension = 0) : Node(a), reduced_dim(dimension) {
+    first_dim = reduced_dim == 0 ? 1 : 0;
+    second_dim = first_dim + 1 == reduced_dim ? first_dim + 2 : first_dim + 1;
+  }
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+  size_t aux_storage_size() const override;
+  unsigned reduced_dim;
+  unsigned first_dim;
+  unsigned second_dim;
+};
 
 } // namespace dynet
 

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -601,8 +601,8 @@ struct RandomGumbel : public Node {
   real mu, beta;
 };
 
-struct MaxOut : public Node {
-  explicit MaxOut(const std::initializer_list<VariableIndex>& a, unsigned dimension = 0) : Node(a), reduced_dim(dimension) {
+struct MaxDimension : public Node {
+  explicit MaxDimension(const std::initializer_list<VariableIndex>& a, unsigned dimension = 0) : Node(a), reduced_dim(dimension) {
     first_dim = reduced_dim == 0 ? 1 : 0;
     second_dim = first_dim + 1 == reduced_dim ? first_dim + 2 : first_dim + 1;
   }
@@ -614,8 +614,8 @@ struct MaxOut : public Node {
   unsigned second_dim;
 };
 
-struct MinOut : public Node {
-  explicit MinOut(const std::initializer_list<VariableIndex>& a, unsigned dimension = 0) : Node(a), reduced_dim(dimension) {
+struct MinDimension : public Node {
+  explicit MinDimension(const std::initializer_list<VariableIndex>& a, unsigned dimension = 0) : Node(a), reduced_dim(dimension) {
     first_dim = reduced_dim == 0 ? 1 : 0;
     second_dim = first_dim + 1 == reduced_dim ? first_dim + 2 : first_dim + 1;
   }

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -614,6 +614,19 @@ struct MaxOut : public Node {
   unsigned second_dim;
 };
 
+struct MinOut : public Node {
+  explicit MinOut(const std::initializer_list<VariableIndex>& a, unsigned dimension = 0) : Node(a), reduced_dim(dimension) {
+    first_dim = reduced_dim == 0 ? 1 : 0;
+    second_dim = first_dim + 1 == reduced_dim ? first_dim + 2 : first_dim + 1;
+  }
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+  size_t aux_storage_size() const override;
+  unsigned reduced_dim;
+  unsigned first_dim;
+  unsigned second_dim;
+};
+
 } // namespace dynet
 
 #endif

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -354,8 +354,8 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_max            "dynet::expr::vmax" (vector[CExpression]& xs) except +
     CExpression c_logsumexp      "dynet::expr::logsumexp" (vector[CExpression]& xs) except +
 
-    CExpression c_maxout "dynet::expr::maxout" (CExpression& x, unsigned d) except + #
-    CExpression c_minout "dynet::expr::minout" (CExpression& x, unsigned d) except + #
+    CExpression c_max_dim "dynet::expr::max_dim" (CExpression& x, unsigned d) except + #
+    CExpression c_min_dim "dynet::expr::min_dim" (CExpression& x, unsigned d) except + #
 
 
 #cdef extern from "dynet/model.h" namespace "dynet":

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -354,6 +354,8 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_max            "dynet::expr::vmax" (vector[CExpression]& xs) except +
     CExpression c_logsumexp      "dynet::expr::logsumexp" (vector[CExpression]& xs) except +
 
+    CExpression c_maxout "dynet::expr::maxout" (CExpression& x, unsigned d) except + #
+
 
 #cdef extern from "dynet/model.h" namespace "dynet":
 #    cdef cppclass Model:

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -355,6 +355,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_logsumexp      "dynet::expr::logsumexp" (vector[CExpression]& xs) except +
 
     CExpression c_maxout "dynet::expr::maxout" (CExpression& x, unsigned d) except + #
+    CExpression c_minout "dynet::expr::minout" (CExpression& x, unsigned d) except + #
 
 
 #cdef extern from "dynet/model.h" namespace "dynet":

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1728,6 +1728,8 @@ cpdef Expression block_dropout(Expression x, float p): return Expression.from_ce
 #expr-dim
 cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1): return Expression.from_cexpr(x.cg_version, c_reshape(x.c(),Dim(d, batch_size)))
 
+cpdef Expression maxout(Expression x, unsigned d=0): return Expression.from_cexpr(x.cg_version, c_maxout(x.c(), d))
+
 cpdef Expression esum(list xs):
     assert xs, 'List is empty, nothing to esum.'
     cdef vector[CExpression] cvec

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1728,8 +1728,8 @@ cpdef Expression block_dropout(Expression x, float p): return Expression.from_ce
 #expr-dim
 cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1): return Expression.from_cexpr(x.cg_version, c_reshape(x.c(),Dim(d, batch_size)))
 
-cpdef Expression maxout(Expression x, unsigned d=0): return Expression.from_cexpr(x.cg_version, c_maxout(x.c(), d))
-cpdef Expression minout(Expression x, unsigned d=0): return Expression.from_cexpr(x.cg_version, c_minout(x.c(), d))
+cpdef Expression max_dim(Expression x, unsigned d=0): return Expression.from_cexpr(x.cg_version, c_max_dim(x.c(), d))
+cpdef Expression min_dim(Expression x, unsigned d=0): return Expression.from_cexpr(x.cg_version, c_min_dim(x.c(), d))
 
 cpdef Expression esum(list xs):
     assert xs, 'List is empty, nothing to esum.'

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1729,6 +1729,7 @@ cpdef Expression block_dropout(Expression x, float p): return Expression.from_ce
 cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1): return Expression.from_cexpr(x.cg_version, c_reshape(x.c(),Dim(d, batch_size)))
 
 cpdef Expression maxout(Expression x, unsigned d=0): return Expression.from_cexpr(x.cg_version, c_maxout(x.c(), d))
+cpdef Expression minout(Expression x, unsigned d=0): return Expression.from_cexpr(x.cg_version, c_minout(x.c(), d))
 
 cpdef Expression esum(list xs):
     assert xs, 'List is empty, nothing to esum.'

--- a/python/dynet_viz.py
+++ b/python/dynet_viz.py
@@ -251,6 +251,7 @@ def pick(a, index=0, dim=0): return GVExpr('pick', [a, index], make_dim(1, infer
 def pick_batch(a, indices, dim=0): return GVExpr('pick_batch', [a, indices], make_dim(len(indices), inferred=True))
 def hinge(x, index, m=1.0): return GVExpr('hinge', [x, index, m], copy_dim(x))
 def maxout(a, d=0): return GVExpr('maxout', [a, d], make_dim(1, inferred=True))
+def minout(a, d=0): return GVExpr('minout', [a, d], make_dim(1, inferred=True))
 
 def nobackprop(x): return GVExpr('nobackprop', [x], copy_dim(x))
 def flip_gradient(x): return GVExpr('flip_gradient', [x], copy_dim(x))

--- a/python/dynet_viz.py
+++ b/python/dynet_viz.py
@@ -250,8 +250,8 @@ def lookup_batch(p, indices, update=True): return GVExpr('lookup_batch', [p, ind
 def pick(a, index=0, dim=0): return GVExpr('pick', [a, index], make_dim(1, inferred=True))
 def pick_batch(a, indices, dim=0): return GVExpr('pick_batch', [a, indices], make_dim(len(indices), inferred=True))
 def hinge(x, index, m=1.0): return GVExpr('hinge', [x, index, m], copy_dim(x))
-def maxout(a, d=0): return GVExpr('maxout', [a, d], make_dim(1, inferred=True))
-def minout(a, d=0): return GVExpr('minout', [a, d], make_dim(1, inferred=True))
+def max_dim(a, d=0): return GVExpr('max_dim', [a, d], make_dim(1, inferred=True))
+def min_dim(a, d=0): return GVExpr('min_dim', [a, d], make_dim(1, inferred=True))
 
 def nobackprop(x): return GVExpr('nobackprop', [x], copy_dim(x))
 def flip_gradient(x): return GVExpr('flip_gradient', [x], copy_dim(x))

--- a/python/dynet_viz.py
+++ b/python/dynet_viz.py
@@ -250,6 +250,7 @@ def lookup_batch(p, indices, update=True): return GVExpr('lookup_batch', [p, ind
 def pick(a, index=0, dim=0): return GVExpr('pick', [a, index], make_dim(1, inferred=True))
 def pick_batch(a, indices, dim=0): return GVExpr('pick_batch', [a, indices], make_dim(len(indices), inferred=True))
 def hinge(x, index, m=1.0): return GVExpr('hinge', [x, index, m], copy_dim(x))
+def maxout(a, d=0): return GVExpr('maxout', [a, d], make_dim(1, inferred=True))
 
 def nobackprop(x): return GVExpr('nobackprop', [x], copy_dim(x))
 def flip_gradient(x): return GVExpr('flip_gradient', [x], copy_dim(x))


### PR DESCRIPTION
This PR solves #177 and part of #442 . I add two functions `max_dim` and `min_dim` to support dimension-wise reductions by max/min values towards a given dimension. (Since there are already `max` and `min` functions for expression-wise comparison I don't use the same name. Are there any more intuitive function names for these dimension-wise reduction functions?) 

In detail, `max_dim` and `min_dim` can support up to 3-d tensor and batching (like PickElement), and the output will be an expression of sub-tensor with max/min values along a given dimension. 

Sample usage:
(Python) `expr = max_dim(batch_emb, 1)`
(C++) `Expression expr = max_dim(batch_emb, 1)`
The second parameter is the dimension to perform reduction on. (default value is 0, i.e., the first dimension)