### PR TITLE
fix bug in delete_dim function 

### DIFF
--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -184,7 +184,7 @@ struct Dim {
    * \param i index of the dimension to be removed
    */
   inline void delete_dim(unsigned int i) {
-    DYNET_ARG_CHECK(i <= nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << d);
+    DYNET_ARG_CHECK(i <= nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << "({" << d << "}," << bd << ')' );
     if(i == nd){
       bd = 1;
     }

--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -184,12 +184,22 @@ struct Dim {
    * \param i index of the dimension to be removed
    */
   inline void delete_dim(unsigned int i) {
-    DYNET_ARG_CHECK(i < nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << d);
-    if (nd == 1) {
-      d[0] = 1;
-    } else {
-      for (; i + 1 < nd; ++i)
+    DYNET_ARG_CHECK(i <= nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << d);
+    if(i == nd){
+      bd = 1;
+    }
+    else if(i == nd-1){
+      if(nd == 1){
+        d[0] = 1;
+      }
+      else{
+        --nd;
+      }
+    }
+    else{
+      for(; i + 1 < nd; ++i){
         d[i] = d[i + 1];
+      }
       --nd;
     }
   }

--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -184,11 +184,8 @@ struct Dim {
    * \param i index of the dimension to be removed
    */
   inline void delete_dim(unsigned int i) {
-    DYNET_ARG_CHECK(i <= nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << "({" << d << "}," << bd << ')' );
-    if(i == nd){
-      bd = 1;
-    }
-    else if(i == nd-1){
+    DYNET_ARG_CHECK(i < nd, "Out of bounds exception in Dim::delete_dim(" << i << ") for node of size " << d );
+    if(i == nd-1){
       if(nd == 1){
         d[0] = 1;
       }


### PR DESCRIPTION
This PR solves part of #445. I modify the function delete_dim to make it able to handle some edge cases. Now this function can delete batch dimension and work as expected  when i==nd-1. 