### PR TITLE
Initializing biases to zero

### DIFF
--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -22,6 +22,7 @@ StandardSoftmaxBuilder::StandardSoftmaxBuilder() {}
 StandardSoftmaxBuilder::StandardSoftmaxBuilder(unsigned rep_dim, unsigned vocab_size, Model& model) {
   p_w = model.add_parameters({vocab_size, rep_dim});
   p_b = model.add_parameters({vocab_size});
+  p_b.zero();
 }
 
 void StandardSoftmaxBuilder::new_graph(ComputationGraph& cg) {
@@ -66,6 +67,7 @@ ClassFactoredSoftmaxBuilder::ClassFactoredSoftmaxBuilder(unsigned rep_dim,
   const unsigned num_clusters = cdict.size();
   p_r2c = model.add_parameters({num_clusters, rep_dim});
   p_cbias = model.add_parameters({num_clusters});
+  p_cbias.zero();
   p_rc2ws.resize(num_clusters);
   p_rcwbiases.resize(num_clusters);
   for (unsigned i = 0; i < num_clusters; ++i) {
@@ -76,6 +78,7 @@ ClassFactoredSoftmaxBuilder::ClassFactoredSoftmaxBuilder(unsigned rep_dim,
       // we don't create them
       p_rc2ws[i] = model.add_parameters({num_words_in_cluster, rep_dim});
       p_rcwbiases[i] = model.add_parameters({num_words_in_cluster});
+      p_rcwbiases[i].zero();
     }
   }
 }

--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -21,8 +21,7 @@ StandardSoftmaxBuilder::StandardSoftmaxBuilder() {}
 
 StandardSoftmaxBuilder::StandardSoftmaxBuilder(unsigned rep_dim, unsigned vocab_size, Model& model) {
   p_w = model.add_parameters({vocab_size, rep_dim});
-  p_b = model.add_parameters({vocab_size});
-  p_b.zero();
+  p_b = model.add_parameters({vocab_size}, ParameterInitConst(0.f));
 }
 
 void StandardSoftmaxBuilder::new_graph(ComputationGraph& cg) {
@@ -66,8 +65,7 @@ ClassFactoredSoftmaxBuilder::ClassFactoredSoftmaxBuilder(unsigned rep_dim,
   read_cluster_file(cluster_file, word_dict);
   const unsigned num_clusters = cdict.size();
   p_r2c = model.add_parameters({num_clusters, rep_dim});
-  p_cbias = model.add_parameters({num_clusters});
-  p_cbias.zero();
+  p_cbias = model.add_parameters({num_clusters}, ParameterInitConst(0.f));
   p_rc2ws.resize(num_clusters);
   p_rcwbiases.resize(num_clusters);
   for (unsigned i = 0; i < num_clusters; ++i) {
@@ -77,8 +75,7 @@ ClassFactoredSoftmaxBuilder::ClassFactoredSoftmaxBuilder(unsigned rep_dim,
       // for singleton clusters, we don't need these parameters, so
       // we don't create them
       p_rc2ws[i] = model.add_parameters({num_words_in_cluster, rep_dim});
-      p_rcwbiases[i] = model.add_parameters({num_words_in_cluster});
-      p_rcwbiases[i].zero();
+      p_rcwbiases[i] = model.add_parameters({num_words_in_cluster}, ParameterInitConst(0.f));
     }
   }
 }

--- a/dynet/deep-lstm.cc
+++ b/dynet/deep-lstm.cc
@@ -23,21 +23,18 @@ DeepLSTMBuilder::DeepLSTMBuilder(unsigned layers,
     Parameter p_x2i = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bi = model.add_parameters({hidden_dim});
-    p_bi.zero();
+    Parameter p_bi = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // o
     Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2o = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bo = model.add_parameters({hidden_dim});
-    p_bo.zero();
+    Parameter p_bo = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // c
     Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bc = model.add_parameters({hidden_dim});
-    p_bc.zero();
+    Parameter p_bc = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     layer_input_dim = hidden_dim + input_dim;  // output (hidden) from 1st layer is input to next
 

--- a/dynet/deep-lstm.cc
+++ b/dynet/deep-lstm.cc
@@ -24,17 +24,21 @@ DeepLSTMBuilder::DeepLSTMBuilder(unsigned layers,
     Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bi = model.add_parameters({hidden_dim});
+    p_bi.zero();
 
     // o
     Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2o = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bo = model.add_parameters({hidden_dim});
+    p_bo.zero();
 
     // c
     Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bc = model.add_parameters({hidden_dim});
+    p_bc.zero();
+
     layer_input_dim = hidden_dim + input_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_h2i, p_c2i, p_bi, p_x2o, p_h2o, p_c2o, p_bo, p_x2c, p_h2c, p_bc};

--- a/dynet/fast-lstm.cc
+++ b/dynet/fast-lstm.cc
@@ -28,21 +28,18 @@ FastLSTMBuilder::FastLSTMBuilder(unsigned layers,
     Parameter p_x2i = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2i = model.add_parameters({hidden_dim, 1});
-    Parameter p_bi = model.add_parameters({hidden_dim});
-    p_bi.zero();
+    Parameter p_bi = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // o
     Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2o = model.add_parameters({hidden_dim, 1});
-    Parameter p_bo = model.add_parameters({hidden_dim});
-    p_bo.zero();
+    Parameter p_bo = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // c
     Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bc = model.add_parameters({hidden_dim});
-    p_bc.zero();
+    Parameter p_bc = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 

--- a/dynet/fast-lstm.cc
+++ b/dynet/fast-lstm.cc
@@ -29,17 +29,21 @@ FastLSTMBuilder::FastLSTMBuilder(unsigned layers,
     Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2i = model.add_parameters({hidden_dim, 1});
     Parameter p_bi = model.add_parameters({hidden_dim});
+    p_bi.zero();
 
     // o
     Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2o = model.add_parameters({hidden_dim, 1});
     Parameter p_bo = model.add_parameters({hidden_dim});
+    p_bo.zero();
 
     // c
     Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bc = model.add_parameters({hidden_dim});
+    p_bc.zero();
+
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_h2i, p_c2i, p_bi, p_x2o, p_h2o, p_c2o, p_bo, p_x2c, p_h2c, p_bc};

--- a/dynet/gru.cc
+++ b/dynet/gru.cc
@@ -22,20 +22,17 @@ GRUBuilder::GRUBuilder(unsigned layers,
     // z
     Parameter p_x2z = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2z = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bz = model.add_parameters({hidden_dim});
-    p_bz.zero();
+    Parameter p_bz = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // r
     Parameter p_x2r = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2r = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_br = model.add_parameters({hidden_dim});
-    p_br.zero();
+    Parameter p_br = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // h
     Parameter p_x2h = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2h = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bh = model.add_parameters({hidden_dim});
-    p_bh.zero();
+    Parameter p_bh = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 

--- a/dynet/gru.cc
+++ b/dynet/gru.cc
@@ -23,16 +23,20 @@ GRUBuilder::GRUBuilder(unsigned layers,
     Parameter p_x2z = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2z = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bz = model.add_parameters({hidden_dim});
+    p_bz.zero();
 
     // r
     Parameter p_x2r = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2r = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_br = model.add_parameters({hidden_dim});
+    p_br.zero();
 
     // h
     Parameter p_x2h = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2h = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bh = model.add_parameters({hidden_dim});
+    p_bh.zero();
+
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2z, p_h2z, p_bz, p_x2r, p_h2r, p_br, p_x2h, p_h2h, p_bh};

--- a/dynet/hsm-builder.cc
+++ b/dynet/hsm-builder.cc
@@ -55,10 +55,12 @@ void Cluster::initialize(Model& model) {
   else if (output_size == 2) {
     p_weights = model.add_parameters({1, rep_dim});
     p_bias = model.add_parameters({1});
+    p_bias.zero();
   }
   else {
     p_weights = model.add_parameters({output_size, rep_dim});
     p_bias = model.add_parameters({output_size});
+    p_bias.zero();
   }
 
   for (Cluster* child : children) {

--- a/dynet/hsm-builder.cc
+++ b/dynet/hsm-builder.cc
@@ -54,13 +54,11 @@ void Cluster::initialize(Model& model) {
   }
   else if (output_size == 2) {
     p_weights = model.add_parameters({1, rep_dim});
-    p_bias = model.add_parameters({1});
-    p_bias.zero();
+    p_bias = model.add_parameters({1}, ParameterInitConst(0.f));
   }
   else {
     p_weights = model.add_parameters({output_size, rep_dim});
-    p_bias = model.add_parameters({output_size});
-    p_bias.zero();
+    p_bias = model.add_parameters({output_size}, ParameterInitConst(0.f));
   }
 
   for (Cluster* child : children) {

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -25,17 +25,21 @@ LSTMBuilder::LSTMBuilder(unsigned layers,
     Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bi = model.add_parameters({hidden_dim});
+    p_bi.zero();
 
     // o
     Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2o = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bo = model.add_parameters({hidden_dim});
+    p_bo.zero();
 
     // c
     Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bc = model.add_parameters({hidden_dim});
+    p_bc.zero();
+
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_h2i, p_c2i, p_bi, p_x2o, p_h2o, p_c2o, p_bo, p_x2c, p_h2c, p_bc};
@@ -338,11 +342,12 @@ VanillaLSTMBuilder::VanillaLSTMBuilder(unsigned layers,
                                        Model& model) : layers(layers), input_dim(input_dim), hid(hidden_dim) {
   unsigned layer_input_dim = input_dim;
   for (unsigned i = 0; i < layers; ++i) {
-    // i
+    // [i; f; o; g]
     Parameter p_x2i = model.add_parameters({hidden_dim * 4, layer_input_dim});
     Parameter p_h2i = model.add_parameters({hidden_dim * 4, hidden_dim});
     //Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bi = model.add_parameters({hidden_dim * 4});
+    p_bi.zero();
 
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -492,7 +492,8 @@ Expression VanillaLSTMBuilder::add_input_impl(int prev, const Expression& x) {
     i_aot = pickrange(tmp, hid * 2, hid * 3);
     i_agt = pickrange(tmp, hid * 3, hid * 4);
     Expression i_it = logistic(i_ait);
-    Expression i_ft = logistic(i_aft);
+    // TODO(odashi): Should the forget bias be a hyperparameter?
+    Expression i_ft = logistic(i_aft + 1.f);
     Expression i_ot = logistic(i_aot);
     Expression i_gt = tanh(i_agt);
 

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -24,21 +24,18 @@ LSTMBuilder::LSTMBuilder(unsigned layers,
     Parameter p_x2i = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bi = model.add_parameters({hidden_dim});
-    p_bi.zero();
+    Parameter p_bi = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // o
     Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2o = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_c2o = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bo = model.add_parameters({hidden_dim});
-    p_bo.zero();
+    Parameter p_bo = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // c
     Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2c = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bc = model.add_parameters({hidden_dim});
-    p_bc.zero();
+    Parameter p_bc = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
@@ -346,8 +343,7 @@ VanillaLSTMBuilder::VanillaLSTMBuilder(unsigned layers,
     Parameter p_x2i = model.add_parameters({hidden_dim * 4, layer_input_dim});
     Parameter p_h2i = model.add_parameters({hidden_dim * 4, hidden_dim});
     //Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_bi = model.add_parameters({hidden_dim * 4});
-    p_bi.zero();
+    Parameter p_bi = model.add_parameters({hidden_dim * 4}, ParameterInitConst(0.f));
 
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -175,7 +175,7 @@ private:
  * \f$
  * \begin{split}
     i_t & =\sigma(W_{ix}x_t+W_{ih}h_{t-1}+b_i)\\
-    f_t & = \sigma(W_{fx}x_t+W_{fh}h_{t-1}+b_f)\\
+    f_t & = \sigma(W_{fx}x_t+W_{fh}h_{t-1}+b_f+1)\\
     o_t & = \sigma(W_{ox}x_t+W_{oh}h_{t-1}+b_o)\\
     \tilde{c_t} & = \tanh(W_{cx}x_t+W_{ch}h_{t-1}+b_c)\\
     c_t & = c_{t-1}\circ f_t + \tilde{c_t}\circ i_t\\

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -39,6 +39,8 @@ SimpleRNNBuilder::SimpleRNNBuilder(unsigned layers,
     Parameter p_x2h = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2h = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_hb = model.add_parameters({hidden_dim});
+    p_hb.zero();
+
     vector<Parameter> ps = {p_x2h, p_h2h, p_hb};
     if (lagging)
         ps.push_back(model.add_parameters({hidden_dim, hidden_dim}));

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -38,8 +38,7 @@ SimpleRNNBuilder::SimpleRNNBuilder(unsigned layers,
   for (unsigned i = 0; i < layers; ++i) {
     Parameter p_x2h = model.add_parameters({hidden_dim, layer_input_dim});
     Parameter p_h2h = model.add_parameters({hidden_dim, hidden_dim});
-    Parameter p_hb = model.add_parameters({hidden_dim});
-    p_hb.zero();
+    Parameter p_hb = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     vector<Parameter> ps = {p_x2h, p_h2h, p_hb};
     if (lagging)

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -41,28 +41,24 @@ NaryTreeLSTMBuilder::NaryTreeLSTMBuilder(unsigned N,
     Parameter p_x2i = model.add_parameters({hidden_dim, layer_input_dim});
     LookupParameter p_h2i = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
     LookupParameter p_c2i = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
-    Parameter p_bi = model.add_parameters({hidden_dim});
-    p_bi.zero();
+    Parameter p_bi = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // f
     Parameter p_x2f = model.add_parameters({hidden_dim, layer_input_dim});
     LookupParameter p_h2f = model.add_lookup_parameters(N*N, {hidden_dim, hidden_dim});
     LookupParameter p_c2f = model.add_lookup_parameters(N*N, {hidden_dim, hidden_dim});
-    Parameter p_bf = model.add_parameters({hidden_dim});
-    p_bf.zero();
+    Parameter p_bf = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // o
     Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
     LookupParameter p_h2o = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
     LookupParameter p_c2o = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
-    Parameter p_bo = model.add_parameters({hidden_dim});
-    p_bo.zero();
+    Parameter p_bo = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     // c (a.k.a. u)
     Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
     LookupParameter p_h2c = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
-    Parameter p_bc = model.add_parameters({hidden_dim});
-    p_bc.zero();
+    Parameter p_bc = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
 
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -212,7 +212,7 @@ Expression NaryTreeLSTMBuilder::add_input(int id, vector<int> children, const Ex
       }
       else
         i_aft = affine_transform({vars[BF], vars[X2F], in});
-      i_ft.push_back(logistic(i_aft));
+      i_ft.push_back(logistic(i_aft + 1.f));
     }
 
     // write memory cell

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -42,23 +42,28 @@ NaryTreeLSTMBuilder::NaryTreeLSTMBuilder(unsigned N,
     LookupParameter p_h2i = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
     LookupParameter p_c2i = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
     Parameter p_bi = model.add_parameters({hidden_dim});
+    p_bi.zero();
 
     // f
     Parameter p_x2f = model.add_parameters({hidden_dim, layer_input_dim});
     LookupParameter p_h2f = model.add_lookup_parameters(N*N, {hidden_dim, hidden_dim});
     LookupParameter p_c2f = model.add_lookup_parameters(N*N, {hidden_dim, hidden_dim});
     Parameter p_bf = model.add_parameters({hidden_dim});
+    p_bf.zero();
 
     // o
     Parameter p_x2o = model.add_parameters({hidden_dim, layer_input_dim});
     LookupParameter p_h2o = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
     LookupParameter p_c2o = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
     Parameter p_bo = model.add_parameters({hidden_dim});
+    p_bo.zero();
 
     // c (a.k.a. u)
     Parameter p_x2c = model.add_parameters({hidden_dim, layer_input_dim});
     LookupParameter p_h2c = model.add_lookup_parameters(N, {hidden_dim, hidden_dim});
     Parameter p_bc = model.add_parameters({hidden_dim});
+    p_bc.zero();
+
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_bi, p_x2f, p_bf, p_x2o, p_bo, p_x2c, p_bc};


### PR DESCRIPTION
Bias parameters are generally initialized to zero when no prior knowledge for data is available. This behavior keeps compatibility with some matrix initialization schema (cf. Goodfellow's "Deep Learning", pp.296-).
This PR naively adds the zero() function just after creating bias parameters.