### PR TITLE
Add tensor contraction to python + document c++ and python api

### DIFF
--- a/doc/source/python_ref.rst
+++ b/doc/source/python_ref.rst
@@ -295,6 +295,17 @@ Convolution/Pooling operations
 
 .. autofunction:: dynet.kmax_pooling
 
+Tensor operations
+^^^^^^^^^^^^^^^^^
+
+.. autofunction:: dynet.contract3d_1d
+
+.. autofunction:: dynet.contract3d_1d_bias
+
+.. autofunction:: dynet.contract3d_1d_1d
+
+.. autofunction:: dynet.contract3d_1d_1d_bias
+
 Recurrent Neural Networks
 -------------------------
 

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1692,12 +1692,56 @@ Expression conv2d(const Expression& x, const Expression& f, const Expression& b,
 // Tensor operations                          //
 ////////////////////////////////////////////////
 
-// z_ij = x_ijk * y_k
+/**
+ * \ingroup tensoroperations
+ * \brief Contracts a rank 3 tensor and a rank 1 tensor into a rank 2 tensor
+ * \details The resulting tensor \f$z\f$ has coordinates \f$z_ij = \sum_k x_{ijk} y_k\f$
+ * 
+ * \param x Rank 3 tensor
+ * \param y Vector
+ * 
+ * \return Matrix
+ */
 Expression contract3d_1d(const Expression& x, const Expression& y);
 // z_i = x_ijk * y_k * z_j (+ b_i)
+/**
+ * \ingroup tensoroperations
+ * \brief Contracts a rank 3 tensor and two rank 1 tensor into a rank 1 tensor
+ * \details This is the equivalent of calling `contract3d_1d` and then performing a matrix vector multiplication.
+ * 
+ * The resulting tensor \f$t\f$ has coordinates \f$t_i = \sum_{j,k} x_{ijk} y_k z_j\f$
+ * 
+ * \param x Rank 3 tensor
+ * \param y Vector
+ * \param z Vector
+ * \return Vector
+ */
 Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z);
+/**
+ * \ingroup tensoroperations
+ * \brief Same as `contract3d_1d_1d` with an additional bias parameter
+ * \details This is the equivalent of calling `contract3d_1d` and then performing an affine transform.
+ * 
+ * The resulting tensor \f$t\f$ has coordinates \f$t_i = b_i + \sum_{j,k} x_{ijk} y_k z_j\f$
+ * 
+ * \param x Rank 3 tensor
+ * \param y Vector
+ * \param z Vector
+ * \param b Bias vector
+ * \return Vector
+ */
 Expression contract3d_1d_1d(const Expression& x, const Expression& y, const Expression& z, const Expression& b);
 // z_ij = x_ijk * y_k + b_ij
+/**
+ * \ingroup tensoroperations
+ * \brief Same as `contract3d_1d` with an additional bias parameter
+ * \details The resulting tensor \f$z\f$ has coordinates \f$z_{ij} = b_{ij}+\sum_k x_{ijk} y_k\f$
+ * 
+ * \param x Rank 3 tensor
+ * \param y Vector
+ * \param b Bias matrix
+ * \return Matrix
+ */
 Expression contract3d_1d(const Expression& x, const Expression& y, const Expression& b);
 
 

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -346,6 +346,11 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_pickneglogsoftmax "dynet::expr::pickneglogsoftmax" (CExpression& x, unsigned v) except + #
     CExpression c_pickneglogsoftmax "dynet::expr::pickneglogsoftmax" (CExpression& x, vector[unsigned] vs) except + #
 
+    CExpression c_contract3d_1d "dynet::expr::contract3d_1d" (CExpression& x, CExpression& y) except + #
+    CExpression c_contract3d_1d "dynet::expr::contract3d_1d" (CExpression& x, CExpression& y, CExpression& b) except + #
+    CExpression c_contract3d_1d_1d "dynet::expr::contract3d_1d_1d" (CExpression& x, CExpression& y, CExpression& z) except + #
+    CExpression c_contract3d_1d_1d "dynet::expr::contract3d_1d_1d" (CExpression& x, CExpression& y, CExpression& z, CExpression& b) except + #
+    
     # expecting a vector of CExpression
     CExpression c_average     "dynet::expr::average" (vector[CExpression]& xs) except +
     CExpression c_concat_cols "dynet::expr::concatenate_cols" (vector[CExpression]& xs) except +

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -2654,6 +2654,83 @@ cpdef Expression min_dim(Expression x, unsigned d=0):
     """
     return Expression.from_cexpr(x.cg_version, c_min_dim(x.c(), d))
 
+def contract3d_1d(Expression x, Expression y):
+    """Contracts a rank 3 tensor and a rank 1 tensor into a rank 2 tensor
+    
+    The resulting tensor :math:`z` has coordinates :math:`z_ij = \sum_k x_{ijk} y_k`
+    
+    Args:
+        x (dynet.Expression): Rank 3 tensor
+        y (dynet.Expression): Vector
+    
+    Returns:
+        Matrix
+        dynet.Expression
+    """
+    ensure_freshness(y)
+    return Expression.from_cexpr(x.cg_version, c_contract3d_1d(x.c(),y.c()))
+
+def contract3d_1d_bias(Expression x, Expression y, Expression b):
+    """Same as :code:`contract3d_1d` with an additional bias parameter
+
+    The resulting tensor :math:`z` has coordinates :math:`z_{ij} = b_{ij}+\sum_k x_{ijk} y_k`
+
+    Args:
+        x (dynet.Expression): Rank 3 tensor
+        y (dynet.Expression): Vector
+        b (dynet.Expression): Bias vector
+    
+    Returns:
+        Matrix
+        dynet.Expression
+    """
+    ensure_freshness(y)
+    ensure_freshness(b)
+    return Expression.from_cexpr(x.cg_version, c_contract3d_1d(x.c(),y.c(),b.c()))
+
+def contract3d_1d_1d(Expression x, Expression y, Expression z):
+    """Contracts a rank 3 tensor and two rank 1 tensor into a rank 1 tensor
+
+    This is the equivalent of calling :code:`contract3d_1d` and then performing a matrix vector multiplication.
+
+    The resulting tensor :math:`t` has coordinates :math:`t_i = \sum_{j,k} x_{ijk} y_k z_j`
+    
+    Args:
+        x (dynet.Expression): Rank 3 tensor
+        y (dynet.Expression): Vector
+        z (dynet.Expression): Vector
+    
+    Returns:
+        Vector
+        dynet.Expression
+    """
+    ensure_freshness(y)
+    ensure_freshness(z)
+    return Expression.from_cexpr(x.cg_version, c_contract3d_1d_1d(x.c(),y.c(),z.c()))
+
+def contract3d_1d_1d_bias(Expression x, Expression y, Expression z, Expression b):
+    """Same as :code:`contract3d_1d_1d` with an additional bias parameter
+ 
+    This is the equivalent of calling :code:`contract3d_1d` and then performing an affine transform.
+
+    The resulting tensor :math:`t` has coordinates :math:`t_i = b_i + \sum_{j,k} x_{ijk} y_k z_j`
+
+    Args:
+        x (dynet.Expression): Rank 3 tensor
+        y (dynet.Expression): Vector
+        z (dynet.Expression): Vector
+        b (dynet.Expression): Bias vector
+    
+    Returns:
+        Vector
+        dynet.Expression
+    """
+    ensure_freshness(y)
+    ensure_freshness(z)
+    ensure_freshness(b)
+    return Expression.from_cexpr(x.cg_version, c_contract3d_1d_1d(x.c(),y.c(),z.c(),b.c()))
+
+
 cpdef Expression esum(list xs):
     """Sum
     


### PR DESCRIPTION
Everything is in the title.

Did some command line testing of the python api (on cpu), here's the code to reproduce : 

    import dynet as dy                         
    m=dy.Model()
    x_p=m.parameters_from_numpy(np.ones((4,4,4)))
    y_p=m.parameters_from_numpy(np.ones(4))
    z_p=m.parameters_from_numpy(np.ones(4))
    b_p=m.parameters_from_numpy(-np.ones(4))
    B_p=m.parameters_from_numpy(-np.ones((4,4)))
    dy.renew_cg()
    y=y_p.expr()
    z=z_p.expr()
    x=x_p.expr()
    b=b_p.expr()
    B=B_p.expr()
    print dy.contract3d_1d(x,y).npvalue()
    print dy.contract3d_1d_bias(x,y,B).npvalue()
    print dy.contract3d_1d_1d(x,y,z).npvalue()
    print dy.contract3d_1d_1d_bias(x,y,z,b).npvalue()