### PR TITLE
Add cyclical learning rate SGD trainer

### DIFF
--- a/doc/source/python_ref.rst
+++ b/doc/source/python_ref.rst
@@ -352,6 +352,10 @@ Optimizers
    :members:
    :show-inheritance:
 
+.. autoclass:: dynet.CyclicalSGDTrainer
+   :members:
+   :show-inheritance:
+
 .. autoclass:: dynet.MomentumSGDTrainer
    :members:
    :show-inheritance:

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -2,11 +2,11 @@
  * \file training.h
  * \defgroup optimizers
  * \brief Training procedures
- * 
- * The various trainers are defined here. 
+ *
+ * The various trainers are defined here.
  * All trainers are structures inheriting from the `Trainer` struct.
- * 
- * 
+ *
+ *
  */
 
 #ifndef DYNET_TRAINING_H_
@@ -32,15 +32,15 @@ namespace dynet {
 
 /**
  * \ingroup optimizers
- * 
+ *
  * \struct Trainer
  * \brief General trainer struct
- * 
+ *
  */
 struct Trainer {
   /**
    * \brief General constructor for a Trainer
-   * 
+   *
    * \param m Model to be trained
    * \param e0 Initial learning rate
    * \param edecay Learning rate decay
@@ -53,7 +53,7 @@ struct Trainer {
   /**
    * \brief Update parameters
    * \details Update the parameters according to the appropriate update rule
-   * 
+   *
    * \param scale The scaling factor for the gradients
    */
   void update(real scale = 1.0);
@@ -65,7 +65,7 @@ struct Trainer {
    *        parameters to be updated are specified by index, which can be found
    *        for Parameter and LookupParameter objects through the "index" variable
    *        (or the get_index() function in the Python bindings).
-   * 
+   *
    * \param updated_params The parameter indices to be updated
    * \param updated_lookup_params The lookup parameter indices to be updated
    * \param scale The scaling factor for the gradients
@@ -82,7 +82,7 @@ struct Trainer {
    * \details If clipping is enabled and the gradient is too big, return the amount to
    *          scale the gradient by (otherwise 1)
    *
-   * 
+   *
    * \param scale The clipping limit
    * \return The appropriate scaling factor
    */
@@ -130,12 +130,12 @@ struct Trainer {
 
   Model* model;  // parameters and gradients live here
 
- protected:
+protected:
   Trainer() {}
   virtual void alloc_impl() { }
   /**
    * \brief The actual rule to update the parameters
-   * 
+   *
    * \param scale Scale of the update (i.e. learning rate)
    * \param gscale Gradient scale based on clipping
    * \param values Values specific to the particular update rule being implemented
@@ -143,7 +143,7 @@ struct Trainer {
   virtual void update_rule(real scale, real gscale, const std::vector<Tensor*> & values) = 0;
   /**
    * \brief Parameter update function
-   * 
+   *
    * \param scale Scale of the update (i.e. learning rate)
    * \param gscale Gradient scale based on clipping
    * \param idx Index of the parameter
@@ -151,7 +151,7 @@ struct Trainer {
   virtual void update_params(real scale, real gscale, size_t idx) = 0;
   /**
    * \brief Sparse lookup parameter update function
-   * 
+   *
    * \param scale Scale of the update (i.e. learning rate)
    * \param gscale Gradient scale based on clipping
    * \param idx Index of the lookup parameter object
@@ -160,57 +160,111 @@ struct Trainer {
   virtual void update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) = 0;
   /**
    * \brief Dense lookup parameter update function
-   * 
+   *
    * \param scale Scale of the update (i.e. learning rate)
    * \param gscale Gradient scale based on clipping
    * \param idx Index of the lookup parameter object
    */
   virtual void update_lookup_params(real scale, real gscale, size_t idx) = 0;
 
- private:
+private:
   DYNET_SERIALIZE_DECLARE()
 };
 
 /**
  * \ingroup optimizers
- * 
+ *
  * \brief Stochastic gradient descent trainer
  * \details This trainer performs stochastic gradient descent, the goto optimization procedure for neural networks.
  * In the standard setting, the learning rate at epoch \f$t\f$ is \f$\eta_t=\frac{\eta_0}{1+\eta_{\mathrm{decay}}t}\f$
- * 
+ *
  * Reference : [reference needed](ref.need.ed)
- *  
+ *
  */
 struct SimpleSGDTrainer : public Trainer {
   /**
    * \brief Constructor
-   * 
+   *
    * \param m Model to be trained
    * \param e0 Initial learning rate
    * \param edecay Learning rate decay parameter.
    */
   explicit SimpleSGDTrainer(Model& m, real e0 = 0.1, real edecay = 0.0) : Trainer(m, e0, edecay) {}
- protected:
+protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
- private:
+private:
   SimpleSGDTrainer() {}
   DYNET_SERIALIZE_DECLARE()
 };
 
 /**
  * \ingroup optimizers
- * 
+ *
+ * \brief Cyclical learning rate SGD
+ * \details This trainer performs stochastic gradient descent with a cyclical learning rate as proposed in [Smith, 2015](https://arxiv.org/abs/1506.01186).
+ *
+ * This uses a triangular function with optional exponential decay.
+ *
+ * More specifically, at each update, the learning rate \f$\eta\f$ is updated according to :
+ *
+ * \f$
+ * \begin{split}
+ * \text{cycle} &= \left\lfloor 1 + \frac{\texttt{it}}{2 \times\texttt{step_size}} \right\rfloor\\
+ * x &= \left\vert \frac{\texttt{it}}{\texttt{step_size}} - 2 \times \text{cycle} + 1\right\vert\\
+ * \eta &= \eta_{\text{min}} + (\eta_{\text{max}} - \eta_{\text{min}}) \times \max(0, 1 - x) \times \gamma^{\texttt{it}}\\
+ * \end{split}
+ * \f$
+ *
+ *
+ * Reference : [Cyclical Learning Rates for Training Neural Networks](https://arxiv.org/abs/1506.01186)
+ *
+ */
+struct CyclicalSGDTrainer : public Trainer {
+  /**
+   * \brief Constructor
+   *
+   * \param m Model to be trained
+   * \param e0_min Lower learning rate
+   * \param e0_max Upper learning rate
+   * \param step_size Period of the triangular function in number of iterations (__not__ epochs). According to the original paper, this should be set around (2-8) x (training iterations in epoch)
+   * \param gamma Learning rate upper bound decay parameter
+   * \param edecay Learning rate decay parameter. Ideally you shouldn't use this with cyclical learning rate since decay is already handled by \f$\gamma\f$
+   */
+  explicit CyclicalSGDTrainer(Model& m, float e0_min = 0.01, float e0_max = 0.1, float step_size = 2000, float gamma = 0.0, float edecay = 0.0) : Trainer(m, e0_min, edecay), e_min(e0_min), e_max(e0_max), step_size(step_size), gamma(gamma), it(0) {}
+  void update(real scale = 1.0) { Trainer::update(scale);cyclic_update_eta();}
+protected:
+  DYNET_TRAINER_DEFINE_DEV_IMPL()
+  void cyclic_update_eta() {
+    float cycle = std::floor(1 + ((float) it)  / (2 * step_size));
+    float x = std::abs( ((float) it) / step_size - 2 * cycle + 1);
+    eta = e_min + ((1 - x) > 0 ? (e_max - e_min) * (1 - x) * std::pow(gamma, it) : 0);
+    it++;
+  }
+  float e_min;
+  float e_max;
+  float step_size;
+  float gamma;
+  unsigned it;
+private:
+  CyclicalSGDTrainer() {}
+  DYNET_SERIALIZE_DECLARE()
+};
+
+
+/**
+ * \ingroup optimizers
+ *
  * \brief Stochastic gradient descent with momentum
- * \details This is a modified version of the SGD algorithm with momentum to stablize the gradient trajectory. 
+ * \details This is a modified version of the SGD algorithm with momentum to stablize the gradient trajectory.
  * The modified gradient is \f$\theta_{t+1}=\mu\theta_{t}+\nabla_{t+1}\f$ where \f$\mu\f$ is the momentum.
- * 
+ *
  * Reference : [reference needed](ref.need.ed)
- * 
+ *
  */
 struct MomentumSGDTrainer : public Trainer {
   /**
    * \brief Constructor
-   * 
+   *
    * \param m Model to be trained
    * \param e0 Initial learning rate
    * \param mom Momentum
@@ -219,7 +273,7 @@ struct MomentumSGDTrainer : public Trainer {
   explicit MomentumSGDTrainer(Model& m, real e0 = 0.01, real mom = 0.9, real edecay = 0.0) :
     Trainer(m, e0, edecay), momentum(mom) {}
 
- protected:
+protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual void alloc_impl() override;
 
@@ -230,25 +284,25 @@ struct MomentumSGDTrainer : public Trainer {
   std::vector<ShadowLookupParameters> vlp;
   //std::unordered_map<ParameterStorage*, Tensor> vp;
   //std::unordered_map<LookupParameterStorage*, std::unordered_map<unsigned, Tensor>> vl;
- private:
+private:
   MomentumSGDTrainer() {}
   DYNET_SERIALIZE_DECLARE()
 };
 
 /**
  * \ingroup optimizers
- * 
+ *
  * \brief Adagrad optimizer
  * \details The adagrad algorithm assigns a different learning rate to each parameter according to the following formula :
  * \f$\delta_\theta^{(t)}=-\frac{\eta_0}{\epsilon+\sum_{i=0}^{t-1}(\nabla_\theta^{(i)})^2}\nabla_\theta^{(t)}\f$
- * 
+ *
  * Reference : [Duchi et al., 2011](http://www.jmlr.org/papers/volume12/duchi11a/duchi11a.pdf)
- *  
+ *
  */
 struct AdagradTrainer : public Trainer {
   /**
    * \brief Constructor
-   * 
+   *
    * \param m Model to be trained
    * \param e0 Initial learning rate
    * \param eps Bias parameter \f$\epsilon\f$ in the adagrad formula
@@ -256,34 +310,34 @@ struct AdagradTrainer : public Trainer {
    */
   explicit AdagradTrainer(Model& m, real e0 = 0.1, real eps = 1e-20, real edecay = 0.0) :
     Trainer(m, e0, edecay), epsilon(eps) {}
- protected:
+protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual void alloc_impl() override;
 
   real epsilon;
   std::vector<ShadowParameters> vp;
   std::vector<ShadowLookupParameters> vlp;
- private:
+private:
   AdagradTrainer() {}
   DYNET_SERIALIZE_DECLARE()
 };
 
 /**
  * \ingroup optimizers
- * 
+ *
  * \brief AdaDelta optimizer
  * \details The AdaDelta optimizer is a variant of Adagrad where
- * \f$\frac{\eta_0}{\sqrt{\epsilon+\sum_{i=0}^{t-1}(\nabla_\theta^{(i)})^2}}\f$ is replaced by 
+ * \f$\frac{\eta_0}{\sqrt{\epsilon+\sum_{i=0}^{t-1}(\nabla_\theta^{(i)})^2}}\f$ is replaced by
  * \f$\frac{\sqrt{\epsilon+\sum_{i=0}^{t-1}\rho^{t-i-1}(1-\rho)(\delta_\theta^{(i)})^2}}{\sqrt{\epsilon+\sum_{i=0}^{t-1}(\nabla_\theta^{(i)})^2}}\f$,
  * hence eliminating the need for an initial learning rate.
- * 
+ *
  * Reference : [ADADELTA: An Adaptive Learning Rate Method](https://arxiv.org/pdf/1212.5701v1)
- *  
+ *
  */
 struct AdadeltaTrainer : public Trainer {
   /**
    * \brief Constructor
-   * 
+   *
    * \param m Model to be trained
    * \param eps Bias parameter \f$\epsilon\f$ in the adagrad formula
    * \param rho Update parameter for the moving average of updates in the numerator
@@ -291,7 +345,7 @@ struct AdadeltaTrainer : public Trainer {
    */
   explicit AdadeltaTrainer(Model& m, real eps = 1e-6, real rho = 0.95, real edecay = 0.0) :
     Trainer(m, 1.0, edecay), epsilon(eps), rho(rho) {}
- protected:
+protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual void alloc_impl() override;
 
@@ -301,24 +355,24 @@ struct AdadeltaTrainer : public Trainer {
   std::vector<ShadowLookupParameters> hlg;
   std::vector<ShadowParameters> hd; // History of deltas
   std::vector<ShadowLookupParameters> hld;
- private:
+private:
   AdadeltaTrainer() {}
   DYNET_SERIALIZE_DECLARE()
 };
 
 /**
  * \ingroup optimizers
- * 
+ *
  * \brief RMSProp optimizer
  * \details The RMSProp optimizer is a variant of Adagrad where the squared sum of previous gradients is replaced with a moving average with parameter \f$\rho\f$.
- * 
+ *
  * Reference : [reference needed](ref.need.ed)
- *  
+ *
  */
 struct RMSPropTrainer : public Trainer {
   /**
    * \brief Constructor
-   * 
+   *
    * \param m Model to be trained
    * \param e0 Initial learning rate
    * \param eps Bias parameter \f$\epsilon\f$ in the adagrad formula
@@ -327,7 +381,7 @@ struct RMSPropTrainer : public Trainer {
    */
   explicit RMSPropTrainer(Model& m, real e0 = 0.001, real eps = 1e-08, real rho = 0.9, real edecay = 0.0) :
     Trainer(m, e0, edecay), epsilon(eps), rho(rho) {}
- protected:
+protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual void alloc_impl() override;
 
@@ -335,25 +389,25 @@ struct RMSPropTrainer : public Trainer {
   real rho;
   std::vector<ShadowParameters> hmsg; // History of gradients
   std::vector<ShadowLookupParameters> hlmsg;
- private:
+private:
   RMSPropTrainer() {}
   DYNET_SERIALIZE_DECLARE()
 };
 
 /**
  * \ingroup optimizers
- * 
+ *
  * \brief Adam optimizer
  * \details The Adam optimizer is similar to RMSProp but uses unbiased estimates
  * of the first and second moments of the gradient
- * 
+ *
  * Reference : [Adam: A Method for Stochastic Optimization](https://arxiv.org/pdf/1412.6980v8)
- *  
+ *
  */
 struct AdamTrainer : public Trainer {
   /**
    * \brief Constructor
-   * 
+   *
    * \param m Model to be trained
    * \param e0 Initial learning rate
    * \param beta_1 Moving average parameter for the mean
@@ -364,7 +418,7 @@ struct AdamTrainer : public Trainer {
   explicit AdamTrainer(Model& m, float e0 = 0.001, float beta_1 = 0.9, float beta_2 = 0.999, float eps = 1e-8, real edecay = 0.0) :
     Trainer(m, e0, edecay), beta_1(beta_1), beta_2(beta_2), epsilon(eps) {}
 
- protected:
+protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual void alloc_impl() override;
 
@@ -375,7 +429,7 @@ struct AdamTrainer : public Trainer {
   std::vector<ShadowLookupParameters> lm;
   std::vector<ShadowParameters> v; // History of deltas
   std::vector<ShadowLookupParameters> lv;
- private:
+private:
   AdamTrainer() {}
   DYNET_SERIALIZE_DECLARE()
 };
@@ -383,6 +437,7 @@ struct AdamTrainer : public Trainer {
 } // namespace dynet
 
 BOOST_CLASS_EXPORT_KEY(dynet::SimpleSGDTrainer)
+BOOST_CLASS_EXPORT_KEY(dynet::CyclicalSGDTrainer)
 BOOST_CLASS_EXPORT_KEY(dynet::MomentumSGDTrainer)
 BOOST_CLASS_EXPORT_KEY(dynet::AdagradTrainer)
 BOOST_CLASS_EXPORT_KEY(dynet::AdadeltaTrainer)

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -182,6 +182,17 @@ cdef extern from "dynet/training.h" namespace "dynet":
         # void update_epoch(float r)
         # void status()
 
+    cdef cppclass CCyclicalSGDTrainer "dynet::CyclicalSGDTrainer" (CTrainer):
+        #CCyclicalSGDTrainer(CModel& m, float lam, float e0)
+        CCyclicalSGDTrainer(CModel& m, float e0_min, float e0_max, float step_size, float gamma, float edecay) # TODO removed lam, update docs.
+        # float clip_threshold
+        # bool clipping_enabled
+        # bool sparse_updates_enabled
+        void update(float s)
+        # void update(vector[unsigned]& uparam, vector[unsigned]& ulookup, float s)
+        # void update_epoch(float r)
+        # void status()
+
     cdef cppclass CMomentumSGDTrainer "dynet::MomentumSGDTrainer" (CTrainer):
         CMomentumSGDTrainer(CModel& m, float e0, float mom, float edecay) # TODO removed lam, update docs
         # float clip_threshold

--- a/tests/test-trainers.cc
+++ b/tests/test-trainers.cc
@@ -87,6 +87,22 @@ BOOST_AUTO_TEST_CASE( simple_sgd_update_subset ) {
     BOOST_CHECK_EQUAL(param2_vals[i], param2_after[i]);
 }
 
+BOOST_AUTO_TEST_CASE( cyclical_sgd_direction ) {
+  dynet::Model mod;
+  dynet::Parameter param = mod.add_parameters({3});
+  TensorTools::set_elements(param.get()->values,param_vals);
+  CyclicalSGDTrainer trainer(mod);
+  dynet::ComputationGraph cg;
+  Expression x = parameter(cg, param);
+  Expression y = input(cg, {1,3}, ones_vals);
+  Expression z = y*x;
+  float before = as_scalar(cg.forward(z));
+  cg.backward(z);
+  trainer.update(0.1);
+  float after = as_scalar(cg.forward(z));
+  BOOST_CHECK_LT(after, before);
+}
+
 BOOST_AUTO_TEST_CASE( momentum_sgd_direction ) {
   dynet::Model mod;
   dynet::Parameter param = mod.add_parameters({3});


### PR DESCRIPTION
Adds a fun new optimizer from [Cyclical Learning Rates for Training Neural Networks](https://arxiv.org/abs/1506.01186) where the learning rate oscillates according to : 

![screenshot from 2017-04-20 17-50-30](https://cloud.githubusercontent.com/assets/10391785/25254264/ad557126-25f2-11e7-992d-80160ee2b210.png)
