### PR TITLE
Add support for mini-batch and dimensionwise kmaxpooling

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -109,7 +109,7 @@ Expression poisson_loss(const Expression& x, const unsigned* py) { return Expres
 //Expression conv1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DNarrow>({x.i, f.i})); }
 //Expression conv1d_wide(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Conv1DWide>({x.i, f.i})); }
 Expression filter1d_narrow(const Expression& x, const Expression& f) { return Expression(x.pg, x.pg->add_function<Filter1DNarrow>({x.i, f.i})); }
-Expression kmax_pooling(const Expression& x, unsigned k) { return Expression(x.pg, x.pg->add_function<KMaxPooling>({x.i}, k)); }
+Expression kmax_pooling(const Expression& x, unsigned k, unsigned d) { return Expression(x.pg, x.pg->add_function<KMaxPooling>({x.i}, k, d)); }
 Expression fold_rows(const Expression& x, unsigned nrows) { return Expression(x.pg, x.pg->add_function<FoldRows>({x.i}, nrows)); }
 Expression conv2d(const Expression& x, const Expression& f, const std::vector<unsigned>& stride, bool is_valid) { return Expression(x.pg, x.pg->add_function<Conv2D>({x.i, f.i}, stride, is_valid)); }
 Expression conv2d(const Expression& x, const Expression& f, const Expression& b, const std::vector<unsigned>& stride, bool is_valid) {

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1614,7 +1614,7 @@ Expression block_dropout(const Expression& x, real p);
 //Expression conv1d_narrow(const Expression& x, const Expression& f);
 //Expression conv1d_wide(const Expression& x, const Expression& f);
 Expression filter1d_narrow(const Expression& x, const Expression& f);
-Expression kmax_pooling(const Expression& x, unsigned k);
+Expression kmax_pooling(const Expression& x, unsigned k, unsigned d = 1);
 Expression fold_rows(const Expression& x, unsigned nrows = 2);
 Expression sum_dim(const Expression& x, unsigned d);
 Expression sum_cols(const Expression& x);

--- a/dynet/nodes-conv.h
+++ b/dynet/nodes-conv.h
@@ -51,10 +51,17 @@ struct FoldRows : public Node {
 };
 
 struct KMaxPooling : public Node {
-  explicit KMaxPooling(const std::initializer_list<VariableIndex>& a, unsigned k = 1) : Node(a), k(k) {}
+  explicit KMaxPooling(const std::initializer_list<VariableIndex>& a, unsigned k = 1, unsigned dimension = 1) : Node(a), k(k), pooled_dim(dimension) {
+    first_dim = pooled_dim == 0 ? 1 : 0;
+    second_dim = first_dim + 1 == pooled_dim ? first_dim + 2 : first_dim + 1;
+  }
   size_t aux_storage_size() const override;
+  virtual bool supports_multibatch() const override { return true; }
   DYNET_NODE_DEFINE_DEV_IMPL()
   unsigned k;
+  unsigned pooled_dim;
+  unsigned first_dim;
+  unsigned second_dim;
 };
 
 // sum along a single dimension

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -347,7 +347,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     #CExpression c_conv1d_narrow "dynet::expr::conv1d_narrow" (CExpression& x, CExpression& f) except + #
     #CExpression c_conv1d_wide "dynet::expr::conv1d_wide" (CExpression& x, CExpression& f) except + #
     CExpression c_filter1d_narrow "dynet::expr::filter1d_narrow" (CExpression& x, CExpression& f) except + #
-    CExpression c_kmax_pooling "dynet::expr::kmax_pooling" (CExpression& x, unsigned k) except + #
+    CExpression c_kmax_pooling "dynet::expr::kmax_pooling" (CExpression& x, unsigned k, unsigned d) except + #
     CExpression c_fold_rows "dynet::expr::fold_rows" (CExpression& x, unsigned nrows) except + #
     CExpression c_sum_cols "dynet::expr::sum_cols" (CExpression& x) except +               #
     CExpression c_kmh_ngram "dynet::expr::kmh_ngram" (CExpression& x, unsigned n) except + #

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -2509,7 +2509,7 @@ cpdef Expression huber_distance(Expression x, Expression y, float c=1.345):
     ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_huber_distance(x.c(), y.c(), c))
 #expr-unsigned
-cpdef Expression kmax_pooling(Expression x, unsigned k):
+cpdef Expression kmax_pooling(Expression x, unsigned k, unsigned d=1):
     """[summary]
     
     [description]
@@ -2517,11 +2517,12 @@ cpdef Expression kmax_pooling(Expression x, unsigned k):
     Args:
         x (dynet.Expression): 
         unsigned k (dynet.Expression): 
+        unsigned d (int): pooled dimension
     
     Returns:
         dynet.Expression: 
     """
-    return Expression.from_cexpr(x.cg_version, c_kmax_pooling(x.c(), k))
+    return Expression.from_cexpr(x.cg_version, c_kmax_pooling(x.c(), k, d))
 cpdef Expression pickneglogsoftmax(Expression x, unsigned v):
     """Negative softmax log likelihood
     

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -2510,14 +2510,16 @@ cpdef Expression huber_distance(Expression x, Expression y, float c=1.345):
     return Expression.from_cexpr(x.cg_version, c_huber_distance(x.c(), y.c(), c))
 #expr-unsigned
 cpdef Expression kmax_pooling(Expression x, unsigned k, unsigned d=1):
-    """[summary]
+    """Kmax-pooling operation
     
-    [description]
+    Select out k maximum values along a given dimension, in the same order as they appear. This will result in the size of the given dimension being changed to k.
     
     Args:
         x (dynet.Expression): 
-        unsigned k (dynet.Expression): 
-        unsigned d (int): pooled dimension
+        unsigned k (dynet.Expression): Number of maximum values to retrieve along the given dimension
+
+    Keyword Arguments:
+        unsigned d (int): Dimension on which to perform kmax-pooling (default: (1))
     
     Returns:
         dynet.Expression: 

--- a/python/dynet_viz.py
+++ b/python/dynet_viz.py
@@ -333,7 +333,7 @@ def pairwise_rank_loss(x, y, m=1.0): return GVExpr('pairwise_rank_loss', [x,y,m]
 def poisson_loss(x, y): return GVExpr('poisson_loss', [x,y], copy_dim(x))
 def huber_distance(x, y, c=1.345): return GVExpr('huber_distance', [x,y,c], ensure_same_dim(x,y))
 #expr-unsigned
-def kmax_pooling(x, k): return GVExpr('kmax_pooling', [x,k], make_dim(x.dim[0], k) if x.dim.isvalid() else InvalidDim)
+def kmax_pooling(x, k, d=1): return GVExpr('kmax_pooling', [x,k,d], make_dim(x.dim[0], k) if x.dim.isvalid() else InvalidDim)
 def pickneglogsoftmax(x, v): return GVExpr('pickneglogsoftmax', [x,v], make_dim(1, inferred=True))
 def pickneglogsoftmax_batch(x, vs): return GVExpr('pickneglogsoftmax_batch', [x,vs], make_dim(len(vs), inferred=True))
 


### PR DESCRIPTION
This PR extends `kmax_pooling` to 3-d tensor, and allows mini-batching and dimension selection on `kmax_pooling`,  which solves #442 and #457. (However this code doesn't work on GPU either, as the original version)

Sample usage:
(Python) `expr = kmax_pooling(batch_emb, 2, 0)`
(C++) `Expression expr = kmax_pooling(batch_emb, 2, 0)`
The second prameter is k, and the third parameter is the selected dimension with default value 1 (which is the original `kmax_pooling`)

Note that for k=1, the result of `kmax_pooling` is not the same as `max_dim` since `kmax_pooling` will not reduce dimensions. For example, if input dimension is (2, 3, 4) and the selected dimension is 0, the output dimension of `max_dim` is (3, 4), while `kmax_pooling` will output dimension (1, 3, 4).