### PR TITLE
Fixed concatenate_to_batch to be consistent with other functions

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -2971,7 +2971,7 @@ cpdef Expression concatenate(list xs, unsigned d=0):
         cvec.push_back(x.c())
     return Expression.from_cexpr(x.cg_version, c_concat(cvec, d))
 
-cpdef Expression concat_to_batch(list xs):
+cpdef Expression concatenate_to_batch(list xs):
     """Concatenate list of expressions to a single batched expression
     
     Perform a concatenation of several expressions along the batch dimension. All expressions must have the same shape except for the batch dimension.

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -184,12 +184,12 @@ class TestBatchManipulation(unittest.TestCase):
         z = dy.pick_batch_elems(x, [0, 1])
         self.assertTrue(np.allclose(z.npvalue(), self.pval.T))
 
-    def test_concat_to_batch(self):
+    def test_concatenate_to_batch(self):
         dy.renew_cg()
         x = dy.lookup_batch(self.p, [0, 1])
         y = dy.pick_batch_elem(x, 0)
         z = dy.pick_batch_elem(x, 1)
-        w = dy.concat_to_batch([y, z])
+        w = dy.concatenate_to_batch([y, z])
         self.assertTrue(np.allclose(w.npvalue(), self.pval.T))
 
 


### PR DESCRIPTION
Other functions are `concatenate` and `concatenate_cols`, so to_batch should be the same.