### PR TITLE
Add access to gradient w.r.t. arbitrary expressions

### DIFF
--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -319,9 +319,11 @@ const Tensor& ComputationGraph::incremental_forward(VariableIndex last) { return
 const Tensor& ComputationGraph::forward(VariableIndex last) { return ee->forward(last); }
 const Tensor& ComputationGraph::get_value(VariableIndex i) { return ee->get_value(i); }
 const Tensor& ComputationGraph::get_value(const expr::Expression& e) { return this->get_value(e.i); }
+const Tensor& ComputationGraph::get_gradient(VariableIndex i) { return ee->get_gradient(i); }
+const Tensor& ComputationGraph::get_gradient(const expr::Expression& e) { return this->get_gradient(e.i); }
 void ComputationGraph::invalidate() { ee->invalidate(); }
-void ComputationGraph::backward(const expr::Expression& last) { ee->backward(last.i); }
-void ComputationGraph::backward(VariableIndex i) { ee->backward(i); }
+void ComputationGraph::backward(const expr::Expression& last, bool full) { ee->backward(last.i, full); }
+void ComputationGraph::backward(VariableIndex i, bool full) { ee->backward(i, full); }
 
 void ComputationGraph::set_immediate_compute(bool ic) {
   immediate_compute = ic;

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -345,22 +345,63 @@ struct ComputationGraph {
    * \return Requested value
    */
   const Tensor& get_value(const expr::Expression& e);
+
+  /**
+   * \brief Get gradient for node at index i.
+   * \details Performs backward pass if not available (may compute more than strictly what is needed).
+   *
+   * \param i Index of the variable from which you want the gradient
+   * \return Requested gradient
+   */
+  const Tensor& get_gradient(VariableIndex i);
+  /**
+   * \brief Get forward gradient for the given expression
+   * \details Performs backward pass if not available (may compute more than strictly what is needed).
+   *
+   * \param e Expression from which you want the gradient
+   * \return Requested gradient
+   */
+  const Tensor& get_gradient(const expr::Expression& e);
   /**
    * \brief Clears forward caches (for get_value etc).
    */
   void invalidate();
   /**
    * \brief Computes backward gradients from the front-most evaluated node.
+   * 
+   * \details The parameter `full` specifies whether the gradients should be computed for all nodes (`true`) or only non-constant nodes.
+   * 
+   * By default, a node is constant unless
+   * 
+   * 1. it is a parameter node
+   * 2. it depends on a non-constant node
+   * 
+   * Thus, functions of constants and inputs are considered as constants.
+   * 
+   * Turn `full` on if you want to retrieve gradients w.r.t. inputs for instance. By default this is turned off, so that the backward pass ignores nodes which have no influence on gradients w.r.t. parameters for efficiency.
    *
    * \param last Expression from which to compute the gradient
+   * \param full Whether to compute all gradients (including with respect to constant nodes). 
    */
-  void backward(const expr::Expression& last);
+  void backward(const expr::Expression& last, bool full = false);
   /**
    * \brief Computes backward gradients from node i (assuming it already been evaluated).
+   * 
+   * \details The parameter `full` specifies whether the gradients should be computed for all nodes (`true`) or only non-constant nodes.
+   * 
+   * By default, a node is constant unless
+   * 
+   * 1. it is a parameter node
+   * 2. it depends on a non-constant node
+   * 
+   * Thus, functions of constants and inputs are considered as constants.
+   * 
+   * Turn `full` on if you want to retrieve gradients w.r.t. inputs for instance. By default this is turned off, so that the backward pass ignores nodes which have no influence on gradients w.r.t. parameters for efficiency.
    *
    * \param i Index of the node from which to compute the gradient
+   * \param full Whether to compute all gradients (including with respect to constant nodes). Turn this on if you want to retrieve gradients w.r.t. inputs for instance. By default this is turned off, so that the backward pass ignores nodes which have no influence on gradients w.r.t. parameters for efficiency.
    */
-  void backward(VariableIndex i);
+  void backward(VariableIndex i, bool full = false);
   // set immediate_compute variable
   void set_immediate_compute(bool ic);
   // set check_validity variable

--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -11,6 +11,7 @@ ExecutionEngine::~ExecutionEngine() {}
 
 void SimpleExecutionEngine::invalidate() {
   num_nodes_evaluated = 0;
+  backward_computed = 0;
 }
 
 void SimpleExecutionEngine::invalidate(unsigned i) {
@@ -33,6 +34,14 @@ const Tensor& SimpleExecutionEngine::get_value(VariableIndex i) {
     incremental_forward();
   }
   return nfxs[i];
+}
+
+const Tensor& SimpleExecutionEngine::get_gradient(VariableIndex i) {
+  DYNET_ASSERT(i < cg.nodes.size(), "Out-of-bounds variable access in SimpleExecutionEngine::get_value()");
+  if (i >= backward_computed) {
+    DYNET_RUNTIME_ERR("Requested gradient for node " << i << ", but backward pass was computed from node " << backward_computed);
+  }
+  return ndEdfs[i];
 }
 
 const Tensor& SimpleExecutionEngine::incremental_forward() {
@@ -85,13 +94,13 @@ const Tensor& SimpleExecutionEngine::incremental_forward(VariableIndex i) {
   return nfxs[i];
 }
 
-void SimpleExecutionEngine::backward() {
+void SimpleExecutionEngine::backward(bool full) {
   DYNET_ASSERT(nfxs.size() >= cg.nodes.size(), "Mismatched array sizes in SimpleExecutionEngine::backward");
-  backward((VariableIndex)(cg.nodes.size()-1));
+  backward((VariableIndex)(cg.nodes.size()-1),full);
 }
 
 // TODO what is happening with parameter nodes if from_where > param_node_id ?
-void SimpleExecutionEngine::backward(VariableIndex from_where) {
+void SimpleExecutionEngine::backward(VariableIndex from_where, bool full) {
   if(!(from_where < nfxs.size()))
     incremental_forward(from_where);
   if (nfxs[from_where].d.size() != 1)
@@ -121,15 +130,17 @@ void SimpleExecutionEngine::backward(VariableIndex from_where) {
   //   2) it depends on a non-constant node
   // (thus, functions of constants and inputs end up being
   //  false in this computation)
-  vector<bool> needs_derivative(num_nodes, false);
-  for (auto i : cg.parameter_nodes)
-    needs_derivative[i] = true;
+  vector<bool> needs_derivative(num_nodes, full);
+  if (!full) {
+    for (auto i : cg.parameter_nodes)
+      needs_derivative[i] = true;
 
-  for (unsigned ni = 0; ni < num_nodes; ++ni) {
-    bool nd = needs_derivative[ni];
-    for (auto arg : cg.nodes[ni]->args)
-      nd |= needs_derivative[arg];
-    needs_derivative[ni] = nd;
+    for (unsigned ni = 0; ni < num_nodes; ++ni) {
+      bool nd = needs_derivative[ni];
+      for (auto arg : cg.nodes[ni]->args)
+        nd |= needs_derivative[arg];
+      needs_derivative[ni] = nd;
+    }
   }
 
   // loop in reverse topological order
@@ -162,6 +173,7 @@ void SimpleExecutionEngine::backward(VariableIndex from_where) {
   // that returns the current value of the parameters
   for (VariableIndex i : cg.parameter_nodes)
     static_cast<ParameterNodeBase*>(cg.nodes[i])->accumulate_grad(ndEdfs[i]);
+  backward_computed = from_where;
 }
 
 } // namespace dynet

--- a/dynet/exec.h
+++ b/dynet/exec.h
@@ -15,11 +15,13 @@ class ExecutionEngine {
   virtual const Tensor& incremental_forward() = 0;  // if you want to add nodes and evaluate just the new parts
   virtual const Tensor& incremental_forward(VariableIndex i) = 0;
   virtual const Tensor& get_value(VariableIndex i) = 0;
-  virtual void backward() = 0;
-  virtual void backward(VariableIndex i) = 0;
+  virtual const Tensor& get_gradient(VariableIndex i) = 0;
+  virtual void backward(bool full = false) = 0;
+  virtual void backward(VariableIndex i, bool full = false) = 0;
  protected:
   explicit ExecutionEngine(const ComputationGraph& cg) : cg(cg) {}
   const ComputationGraph& cg;
+  VariableIndex backward_computed;
 };
 
 class SimpleExecutionEngine : public ExecutionEngine {
@@ -32,8 +34,9 @@ class SimpleExecutionEngine : public ExecutionEngine {
   const Tensor& incremental_forward() override;  // if you want to add nodes and evaluate just the new parts
   const Tensor& incremental_forward(VariableIndex i) override;
   const Tensor& get_value(VariableIndex i) override;
-  void backward() override;
-  void backward(VariableIndex i) override;
+  const Tensor& get_gradient(VariableIndex i) override;
+  void backward(bool full = false) override;
+  void backward(VariableIndex i, bool full = false) override;
  private:
   std::vector<Tensor> nfxs;
   std::vector<Tensor> ndEdfs;

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -58,6 +58,17 @@ struct Expression {
     return pg->get_value(i);
   }
   /**
+   * \brief Get gradient of the expression
+   * \details Throws a tuntime_error exception if no computation graph is available
+   * \return Value of the expression as a tensor
+   */
+  const Tensor& gradient() const {
+    if (this->is_stale()) {
+      throw std::runtime_error("Attempt to use a stale expression.");
+    }
+    return pg->get_gradient(i);
+  }
+  /**
    * \brief Get dimension of the expression
    * \details Throws a tuntime_error exception if no computation graph is available
    * \return Dimension of the expression

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -60,6 +60,11 @@ struct Expression {
   /**
    * \brief Get gradient of the expression
    * \details Throws a tuntime_error exception if no computation graph is available
+   * 
+   * Make sure to call `backward` on a downstream expression before calling this.
+   * 
+   * If the expression is a constant expression (meaning it's not a function of a parameter), dynet won't compute it's gradient for the sake of efficiency. You need to manually force the gradient computation by adding the agument `full=true` to `backward`
+        
    * \return Value of the expression as a tensor
    */
   const Tensor& gradient() const {

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -157,7 +157,7 @@ cdef extern from "dynet/dynet.h" namespace "dynet":
         const CTensor& incremental_forward(VariableIndex index) except +
         const CTensor& get_value(VariableIndex i) except +
         void invalidate()
-        void backward(VariableIndex i)
+        void backward(VariableIndex i, bool full)
 
         # checkpointing
         void checkpoint()
@@ -262,6 +262,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
         CComputationGraph *pg
         long i
         CDim dim() except +
+        const CTensor& gradient() except +
     #CExpression c_input "dynet::expr::input" (CComputationGraph& g, float s)   #
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, float *ps) except + #
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, CDim& d, vector[float]* pdata) except +

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1303,7 +1303,11 @@ cdef class Expression: #(((
     cpdef gradient(self):
         """Returns the value of the expression as a numpy array
         
-        The last dimension is the batch size (if it's > 1)
+        The last dimension is the batch size (if it's > 1).
+
+        Make sure to call :code:`backward` on a downstream expression before calling this.
+
+        If the Expression is a constant expression (meaning it's not a function of a parameter), dynet won't compute it's gradient for the sake of efficiency. You need to manually force the gradient computation by adding the agument :code:`full=True` to :code:`backward`
         
         Returns:
             np.ndarray: numpy array of values

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -3,6 +3,13 @@ import numpy as np
 import unittest
 
 
+def npvalue_callable(x):
+    return x.npvalue()
+
+def gradient_callable(x):
+    return x.gradient()
+    
+
 class TestInput(unittest.TestCase):
 
     def setUp(self):
@@ -206,6 +213,41 @@ class TestIO(unittest.TestCase):
     def test_save_load(self):
         self.m.save(self.file, [self.b])
         self.m2.load(self.file)
+
+class TestExpression(unittest.TestCase):
+
+    def setUp(self):
+
+        self.v1 = np.arange(10)
+        self.v2 = np.arange(10)[::-1]
+
+    def test_value(self):
+        dy.renew_cg()
+        x=dy.inputTensor(self.v1)
+        self.assertTrue(np.allclose(x.npvalue(), self.v1))
+
+    def test_value_sanity(self):
+        dy.renew_cg()
+        x=dy.inputTensor(self.v1)
+        dy.renew_cg()
+        self.assertRaises(RuntimeError, npvalue_callable, x)
+
+    def test_gradient(self):
+        dy.renew_cg()
+        x=dy.inputTensor(self.v1)
+        y=dy.inputTensor(self.v2)
+        l = dy.dot_product(x,y)
+        l.forward()
+        l.backward(full=True)
+        self.assertTrue(np.allclose(x.gradient(), self.v2),msg="{}\n{}\n{}".format(l.value(),x.gradient(),self.v2,y.gradient(),self.v2))
+
+    def test_gradient_sanity(self):
+        dy.renew_cg()
+        x=dy.inputTensor(self.v1)
+        y=dy.inputTensor(self.v2)
+        l = dy.dot_product(x,y)
+        l.forward()
+        self.assertRaises(RuntimeError, gradient_callable, x)
 
 
 if __name__ == '__main__':

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1203,6 +1203,31 @@ BOOST_AUTO_TEST_CASE( backward_test ) {
   cg.backward(z);
 }
 
+BOOST_AUTO_TEST_CASE( gradient_value_test ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression x2 = parameter(cg, param2);
+  Expression l = dot_product(x1,x2);
+  cg.backward(l);
+  vector<float> x1_g1 = as_vector(x1.gradient());
+  vector<float> x1_g2 = as_vector(param1.get()->g);
+
+  for(unsigned i=0;i<3;i++){
+    BOOST_CHECK_CLOSE(x1_g1[i],x1_g2[i],0.001);
+  }
+
+}
+
+BOOST_AUTO_TEST_CASE( gradient_sanity_test ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression x2 = parameter(cg, param2);
+  Expression l = dot_product(x1,x2);
+  cg.forward(l);
+  BOOST_CHECK_THROW(x1.gradient() , std::runtime_error);
+
+}
+
 // This just makes sure that nothing crashes
 BOOST_AUTO_TEST_CASE( random_gumbel_test ) {
   dynet::ComputationGraph cg;


### PR DESCRIPTION
Addresses #476 

This does 2 main things : 

- add an optional `full` parameter to `backward` which, if set to `true`, forces the execution engine to compute the gradient for each node (including input node)
- Add a `gradient` method to `Expression`

All of this in c++ and python with test + doc

Edge cases : 

-  `gradient`  raises an expression if backward hasn't been computed/has been computed w.r.t. an upstream node.
- Gradients of constant nodes are 0 if `full=false` (default)