### PR TITLE
Access RNN parameters from python

### DIFF
--- a/dynet/gru.h
+++ b/dynet/gru.h
@@ -22,6 +22,12 @@ struct GRUBuilder : public RNNBuilder {
   unsigned num_h0_components() const override { return layers; }
   void copy(const RNNBuilder & params) override;
 
+  // first index is layer, then ...
+  std::vector<std::vector<Parameter>> params;
+
+  // first index is layer, then ...
+  std::vector<std::vector<Expression>> param_vars;
+
 
  protected:
   void new_graph_impl(ComputationGraph& cg) override;
@@ -29,12 +35,6 @@ struct GRUBuilder : public RNNBuilder {
   Expression add_input_impl(int prev, const Expression& x) override;
   Expression set_h_impl(int prev, const std::vector<Expression>& h_new) override;
   Expression set_s_impl(int prev, const std::vector<Expression>& s_new) override;
-
-  // first index is layer, then ...
-  std::vector<std::vector<Parameter>> params;
-
-  // first index is layer, then ...
-  std::vector<std::vector<Expression>> param_vars;
 
   // first index is time, second is layer
   std::vector<std::vector<Expression>> h;

--- a/dynet/rnn.h
+++ b/dynet/rnn.h
@@ -346,13 +346,14 @@ public:
 
   void save_parameters_pretraining(const std::string& fname) const override;
   void load_parameters_pretraining(const std::string& fname) override;
-
-private:
+  
   // first index is layer, then x2h h2h hb
   std::vector<std::vector<Parameter>> params;
 
   // first index is layer, then x2h h2h hb
   std::vector<std::vector<Expression>> param_vars;
+
+private:
 
   // first index is time, second is layer
   std::vector<std::vector<Expression>> h;

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -262,6 +262,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
         CComputationGraph *pg
         long i
         CDim dim() except +
+        bool is_stale()
     #CExpression c_input "dynet::expr::input" (CComputationGraph& g, float s)   #
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, float *ps) except + #
     CExpression c_input "dynet::expr::input" (CComputationGraph& g, CDim& d, vector[float]* pdata) except +
@@ -421,6 +422,8 @@ cdef extern from "dynet/rnn.h" namespace "dynet":
     cdef cppclass CSimpleRNNBuilder  "dynet::SimpleRNNBuilder" (CRNNBuilder):
         CSimpleRNNBuilder()
         CSimpleRNNBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model)
+        vector[vector[CParameters]] params
+        vector[vector[CExpression]] param_vars
         #void new_graph(CComputationGraph &cg)
         #void start_new_sequence(vector[CExpression] ces)
         #CExpression add_input(CExpression &x)
@@ -437,6 +440,8 @@ cdef extern from "dynet/gru.h" namespace "dynet":
     cdef cppclass CGRUBuilder "dynet::GRUBuilder" (CRNNBuilder):
         CGRUBuilder()
         CGRUBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model)
+        vector[vector[CParameters]] params
+        vector[vector[CExpression]] param_vars
         #void new_graph(CComputationGraph &cg)
         #void start_new_sequence(vector[CExpression] ces)
         #CExpression add_input(CExpression &x)
@@ -453,6 +458,8 @@ cdef extern from "dynet/lstm.h" namespace "dynet":
     cdef cppclass CLSTMBuilder "dynet::LSTMBuilder" (CRNNBuilder):
         CLSTMBuilder()
         CLSTMBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model)
+        vector[vector[CParameters]] params
+        vector[vector[CExpression]] param_vars
         #void new_graph(CComputationGraph &cg)
         #void start_new_sequence(vector[CExpression] ces)
         #CExpression add_input(CExpression &x)
@@ -470,10 +477,14 @@ cdef extern from "dynet/lstm.h" namespace "dynet":
         CVanillaLSTMBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model)
         void set_dropout(float d, float d_r)
         void set_dropout_masks(unsigned batch_size)
+        vector[vector[CParameters]] params
+        vector[vector[CExpression]] param_vars
 
 cdef extern from "dynet/fast-lstm.h" namespace "dynet":
     cdef cppclass CFastLSTMBuilder "dynet::FastLSTMBuilder" (CRNNBuilder):
         CFastLSTMBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model)
+        vector[vector[CParameters]] params
+        vector[vector[CExpression]] param_vars
         #void new_graph(CComputationGraph &cg)
         #void start_new_sequence(vector[CExpression] ces)
         #CExpression add_input(CExpression &x)

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3212,12 +3212,54 @@ cdef class SimpleRNNBuilder(_RNNBuilder): # (((
     
     [description]
     """
+    cdef CSimpleRNNBuilder* thissimpleptr
     def __cinit__(self, unsigned layers, unsigned input_dim, unsigned hidden_dim, Model model):
         if layers > 0:
-            self.thisptr = new CSimpleRNNBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
+            self.thissimpleptr = self.thisptr = new CSimpleRNNBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
         else:
-            self.thisptr = new CSimpleRNNBuilder()
+            self.thissimpleptr = self.thisptr = new CSimpleRNNBuilder()
         self.cg_version = -1
+
+    cpdef get_parameters(self):
+        """Retrieve the internal parameters of the RNN
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_{hx},W_{hh},b_h`
+        
+        Returns:
+            List of parameters for each layer
+            list
+        """
+        params = []
+        for l in self.thissimpleptr.params:
+            layer_params=[]
+            for w in l:
+                layer_params.append(Parameters.wrap_ptr(w))
+            params.append(layer_params)
+        return params
+
+
+    cpdef get_parameter_expressions(self):
+        """Retrieve the internal parameters expressions of the RNN
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_{hx},W_{hh},b_h`
+        
+        Returns:
+            List of parameter expressions for each layer
+            list
+
+        Raises:
+            ValueError: This raises an expression if initial_state hasn't been called because it requires thr parameters to be loaded in the computation graph. However it prevents the parameters to be loaded twice in the computation graph (compared to :code:`dynet.parameter(rnn.get_parameters()[0][0])` for example).
+        """
+        if self.thissimpleptr.param_vars.size() == 0 or self.thissimpleptr.param_vars[0][0].is_stale():
+            raise ValueError("Attempt to use a stale expression, renew CG and/or call initial_state before accessing SimpleRNNBuilder internal parameters expression")
+
+        exprs = []
+        for l in self.thissimpleptr.param_vars:
+            layer_exprs=[]
+            for w in l:
+                layer_exprs.append(Expression.from_cexpr(_cg.version(),w))
+            exprs.append(layer_exprs)
+        return exprs
 
     def whoami(self): return "SimpleRNNBuilder"
 #)
@@ -3227,12 +3269,54 @@ cdef class GRUBuilder(_RNNBuilder): # (((
     
     [description]
     """
+    cdef CGRUBuilder* thisgruptr
     def __cinit__(self, unsigned layers, unsigned input_dim, unsigned hidden_dim, Model model):
         if layers > 0:
-            self.thisptr = new CGRUBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
+            self.thisgruptr = self.thisptr = new CGRUBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
         else:
-            self.thisptr = new CGRUBuilder()
+            self.thisgruptr = self.thisptr = new CGRUBuilder()
         self.cg_version = -1
+
+    cpdef get_parameters(self):
+        """Retrieve the internal parameters of the GRU
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_{zx},W_{zh},b_z,W_{rx},W_{rh},b_r,W_{hx},W_{hh},b_h`
+        
+        Returns:
+            List of parameters for each layer
+            list
+        """
+        params = []
+        for l in self.thisgruptr.params:
+            layer_params=[]
+            for w in l:
+                layer_params.append(Parameters.wrap_ptr(w))
+            params.append(layer_params)
+        return params
+
+
+    cpdef get_parameter_expressions(self):
+        """Retrieve the internal parameters expressions of the GRU
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_{zx},W_{zh},b_z,W_{rx},W_{rh},b_r,W_{hx},W_{hh},b_h`
+        
+        Returns:
+            List of parameter expressions for each layer
+            list
+
+        Raises:
+            ValueError: This raises an expression if initial_state hasn't been called because it requires thr parameters to be loaded in the computation graph. However it prevents the parameters to be loaded twice in the computation graph (compared to :code:`dynet.parameter(rnn.get_parameters()[0][0])` for example).
+        """
+        if self.thisgruptr.param_vars.size() == 0 or self.thisgruptr.param_vars[0][0].is_stale():
+            raise ValueError("Attempt to use a stale expression, renew CG and/or call initial_state before accessing GRUBuilder internal parameters expression")
+
+        exprs = []
+        for l in self.thisgruptr.param_vars:
+            layer_exprs=[]
+            for w in l:
+                layer_exprs.append(Expression.from_cexpr(_cg.version(),w))
+            exprs.append(layer_exprs)
+        return exprs
 
     def whoami(self): return "GRUBuilder"
 # )
@@ -3242,12 +3326,54 @@ cdef class LSTMBuilder(_RNNBuilder): # (((
     
     [description]
     """
+    cdef CLSTMBuilder* thislstmptr
     def __cinit__(self, unsigned layers, unsigned input_dim, unsigned hidden_dim, Model model):
         if layers > 0:
-            self.thisptr = new CLSTMBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
+            self.thislstmptr = self.thisptr = new CLSTMBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
         else:
-            self.thisptr = new CLSTMBuilder()
+            self.thislstmptr = self.thisptr = new CLSTMBuilder()
         self.cg_version = -1
+
+    cpdef get_parameters(self):
+        """Retrieve the internal parameters of the LSTM
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_{ix},W_{ih},W_{ic},b_i,W_{ox},W_{oh},W_{oc},b_o,W_{cx},W_{ch},b_c`
+        
+        Returns:
+            List of parameters for each layer
+            list
+        """
+        params = []
+        for l in self.thislstmptr.params:
+            layer_params=[]
+            for w in l:
+                layer_params.append(Parameters.wrap_ptr(w))
+            params.append(layer_params)
+        return params
+
+
+    cpdef get_parameter_expressions(self):
+        """Retrieve the internal parameters expressions of the LSTM
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_{ix},W_{ih},W_{ic},b_i,W_{ox},W_{oh},W_{oc},b_o,W_{cx},W_{ch},b_c`
+        
+        Returns:
+            List of parameter expressions for each layer
+            list
+
+        Raises:
+            ValueError: This raises an expression if initial_state hasn't been called because it requires thr parameters to be loaded in the computation graph. However it prevents the parameters to be loaded twice in the computation graph (compared to :code:`dynet.parameter(rnn.get_parameters()[0][0])` for example).
+        """
+        if self.thislstmptr.param_vars.size() == 0 or self.thislstmptr.param_vars[0][0].is_stale():
+            raise ValueError("Attempt to use a stale expression, renew CG and/or call initial_state before accessing LSTMBuilder internal parameters expression")
+
+        exprs = []
+        for l in self.thislstmptr.param_vars:
+            layer_exprs=[]
+            for w in l:
+                layer_exprs.append(Expression.from_cexpr(_cg.version(),w))
+            exprs.append(layer_exprs)
+        return exprs
 
     def whoami(self): return "LSTMBuilder"
 # )
@@ -3282,6 +3408,82 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # (((
         else:
             self.thisvanillaptr = self.thisptr = new CVanillaLSTMBuilder()
         self.cg_version = -1
+
+    cpdef get_parameters(self):
+        """Retrieve the internal parameters of the VanillaLSTM
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_x,W_h,b` where :math:`W_x,W_h` are stacked version of the individual gates matrices:
+
+        .. code::
+
+                  h/x   
+                +------+
+                |      |
+            i   |      |
+                +------+
+                |      |
+            f   |      |
+                +------+
+                |      |
+            o   |      |
+                +------+
+                |      |
+            c   |      |
+                +------+
+
+        Returns:
+            List of parameters for each layer
+            list
+        """
+        params = []
+        for l in self.thisvanillaptr.params:
+            layer_params=[]
+            for w in l:
+                layer_params.append(Parameters.wrap_ptr(w))
+            params.append(layer_params)
+        return params
+
+
+    cpdef get_parameter_expressions(self):
+        """Retrieve the internal parameters expressions of the VanillaLSTM
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_x,W_h,b` where :math:`W_x,W_h` are stacked version of the individual gates matrices:
+
+        .. code::
+
+                  h/x   
+                +------+
+                |      |
+            i   |      |
+                +------+
+                |      |
+            f   |      |
+                +------+
+                |      |
+            o   |      |
+                +------+
+                |      |
+            c   |      |
+                +------+
+        
+        Returns:
+            List of parameter expressions for each layer
+            list
+
+        Raises:
+            ValueError: This raises an expression if initial_state hasn't been called because it requires thr parameters to be loaded in the computation graph. However it prevents the parameters to be loaded twice in the computation graph (compared to :code:`dynet.parameter(rnn.get_parameters()[0][0])` for example).
+        """
+        if self.thisvanillaptr.param_vars.size() == 0 or self.thisvanillaptr.param_vars[0][0].is_stale():
+            raise ValueError("Attempt to use a stale expression, renew CG and/or call initial_state before accessing VanillaLSTMBuilder internal parameters expression")
+
+        exprs = []
+        for l in self.thisvanillaptr.param_vars:
+            layer_exprs=[]
+            for w in l:
+                layer_exprs.append(Expression.from_cexpr(_cg.version(),w))
+            exprs.append(layer_exprs)
+        return exprs
+
 
     cpdef void set_dropouts(self, float d, float d_r):
         """Set the dropout rates
@@ -3331,9 +3533,52 @@ cdef class FastLSTMBuilder(_RNNBuilder): # (((
     
     [description]
     """
+    cdef CFastLSTMBuilder* thisfastptr
     def __cinit__(self, unsigned layers, unsigned input_dim, unsigned hidden_dim, Model model):
-        self.thisptr = new CFastLSTMBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
+        self.thisfastptr = self.thisptr = new CFastLSTMBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
         self.cg_version = -1
+
+    cpdef get_parameters(self):
+        """Retrieve the internal parameters of the FastLSTM
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_{ix},W_{ih},W_{ic},b_i,W_{ox},W_{oh},W_{oc},b_o,W_{cx},W_{ch},b_c`
+        
+        Returns:
+            List of parameters for each layer
+            list
+        """
+        params = []
+        for l in self.thisfastptr.params:
+            layer_params=[]
+            for w in l:
+                layer_params.append(Parameters.wrap_ptr(w))
+            params.append(layer_params)
+        return params
+
+
+    cpdef get_parameter_expressions(self):
+        """Retrieve the internal parameters expressions of the FastLSTM
+        
+        The output is a list with one item per layer. Each item is a list containing :math:`W_{ix},W_{ih},W_{ic},b_i,W_{ox},W_{oh},W_{oc},b_o,W_{cx},W_{ch},b_c`
+        
+        Returns:
+            List of parameter expressions for each layer
+            list
+
+        Raises:
+            ValueError: This raises an expression if initial_state hasn't been called because it requires thr parameters to be loaded in the computation graph. However it prevents the parameters to be loaded twice in the computation graph (compared to :code:`dynet.parameter(rnn.get_parameters()[0][0])` for example).
+        """
+        if self.thisfastptr.param_vars.size() == 0 or self.thisfastptr.param_vars[0][0].is_stale():
+            raise ValueError("Attempt to use a stale expression, renew CG and/or call initial_state before accessing FastLSTMBuilder internal parameters expression")
+
+        exprs = []
+        for l in self.thisfastptr.param_vars:
+            layer_exprs=[]
+            for w in l:
+                layer_exprs.append(Expression.from_cexpr(_cg.version(),w))
+            exprs.append(layer_exprs)
+        return exprs
+
 
     def whoami(self): return "FastLSTMBuilder"
 # )

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -2,7 +2,6 @@ import dynet as dy
 import numpy as np
 import unittest
 
-
 class TestInput(unittest.TestCase):
 
     def setUp(self):
@@ -231,6 +230,103 @@ class TestOperations(unittest.TestCase):
         y_np_value = self.v2 / self.v1.std() * (self.v1 - self.v1.mean()) + self.v3
 
         self.assertTrue(np.allclose(y.npvalue(),y_np_value))
+
+class TestSimpleRNN(unittest.TestCase):
+
+    def setUp(self):
+        # create model
+        self.m = dy.Model()
+        self.rnn = dy.SimpleRNNBuilder(2,10,10,self.m)
+
+    def test_get_parameters(self):
+        dy.renew_cg()
+        self.rnn.initial_state()
+        P_p = self.rnn.get_parameters()
+        P_e = self.rnn.get_parameter_expressions()
+        for l_p,l_e in zip(P_p,P_e):
+            for w_p,w_e in zip(l_p,l_e):
+                self.assertTrue(np.allclose(w_e.npvalue(),w_p.as_array()))
+
+    def test_get_parameters_sanity(self):
+        self.assertRaises(ValueError, lambda x : x.get_parameter_expressions(), self.rnn)
+
+class TestGRU(unittest.TestCase):
+
+    def setUp(self):
+        # create model
+        self.m = dy.Model()
+        self.rnn = dy.GRUBuilder(2,10,10,self.m)
+
+    def test_get_parameters(self):
+        dy.renew_cg()
+        self.rnn.initial_state()
+        P_p = self.rnn.get_parameters()
+        P_e = self.rnn.get_parameter_expressions()
+        for l_p,l_e in zip(P_p,P_e):
+            for w_p,w_e in zip(l_p,l_e):
+                self.assertTrue(np.allclose(w_e.npvalue(),w_p.as_array()))
+
+    def test_get_parameters_sanity(self):
+        self.assertRaises(ValueError, lambda x : x.get_parameter_expressions(), self.rnn)
+
+class TestLSTM(unittest.TestCase):
+
+    def setUp(self):
+        # create model
+        self.m = dy.Model()
+        self.rnn = dy.LSTMBuilder(2,10,10,self.m)
+
+    def test_get_parameters(self):
+        dy.renew_cg()
+        self.rnn.initial_state()
+        P_p = self.rnn.get_parameters()
+        P_e = self.rnn.get_parameter_expressions()
+        for l_p,l_e in zip(P_p,P_e):
+            for w_p,w_e in zip(l_p,l_e):
+                self.assertTrue(np.allclose(w_e.npvalue(),w_p.as_array()))
+
+    def test_get_parameters_sanity(self):
+        self.assertRaises(ValueError, lambda x : x.get_parameter_expressions(), self.rnn)
+
+
+class TestVanillaLSTM(unittest.TestCase):
+
+    def setUp(self):
+        # create model
+        self.m = dy.Model()
+        self.rnn = dy.VanillaLSTMBuilder(2,10,10,self.m)
+
+    def test_get_parameters(self):
+        dy.renew_cg()
+        self.rnn.initial_state()
+        P_p = self.rnn.get_parameters()
+        P_e = self.rnn.get_parameter_expressions()
+        for l_p,l_e in zip(P_p,P_e):
+            for w_p,w_e in zip(l_p,l_e):
+                self.assertTrue(np.allclose(w_e.npvalue(),w_p.as_array()))
+
+    def test_get_parameters_sanity(self):
+        self.assertRaises(ValueError, lambda x : x.get_parameter_expressions(), self.rnn)
+
+
+class TestFastLSTM(unittest.TestCase):
+
+    def setUp(self):
+        # create model
+        self.m = dy.Model()
+        self.rnn = dy.FastLSTMBuilder(2,10,10,self.m)
+
+    def test_get_parameters(self):
+        dy.renew_cg()
+        self.rnn.initial_state()
+        P_p = self.rnn.get_parameters()
+        P_e = self.rnn.get_parameter_expressions()
+        for l_p,l_e in zip(P_p,P_e):
+            for w_p,w_e in zip(l_p,l_e):
+                self.assertTrue(np.allclose(w_e.npvalue(),w_p.as_array()))
+
+    def test_get_parameters_sanity(self):
+        self.assertRaises(ValueError, lambda x : x.get_parameter_expressions(), self.rnn)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Addresses a complaint I've heard here and there.

Now RNNBuilders have two new methods: 

- `get_parameters`, Retrieves the internal parameters of the builder
- `get_parameter_expressions`, Retrieves the internal parameters expressions of the builder. This is more efficient because it retrieves the expressions directly if they've already been loaded in the computation graph

Paging @iamyoungjo , I think we discussed this a while back

Comes with doc and tests