### PR TITLE
Adds layer norm to vanilla LSTM

### DIFF
--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -330,13 +330,15 @@ DYNET_SERIALIZE_IMPL(LSTMBuilder);
 
 //enum { _X2I, _H2I, _C2I, _BI, _X2F, _H2F, _C2F, _BF, _X2O, _H2O, _C2O, _BO, _X2G, _H2G, _C2G, _BG };
 enum { _X2I, _H2I, _BI, _X2F, _H2F, _BF, _X2O, _H2O, _BO, _X2G, _H2G, _BG };
+enum { LN_GH, LN_BH, LN_GX, LN_BX, LN_GC, LN_BC};
 
-VanillaLSTMBuilder::VanillaLSTMBuilder() : has_initial_state(false), layers(0), input_dim(0), hid(0), dropout_rate_h(0) { }
+VanillaLSTMBuilder::VanillaLSTMBuilder() : has_initial_state(false), layers(0), input_dim(0), hid(0), dropout_rate_h(0), ln_lstm(false) { }
 
 VanillaLSTMBuilder::VanillaLSTMBuilder(unsigned layers,
                                        unsigned input_dim,
                                        unsigned hidden_dim,
-                                       Model& model) : layers(layers), input_dim(input_dim), hid(hidden_dim) {
+                                       Model& model,
+                                       bool ln_lstm) : layers(layers), input_dim(input_dim), hid(hidden_dim), ln_lstm(ln_lstm) {
   unsigned layer_input_dim = input_dim;
   for (unsigned i = 0; i < layers; ++i) {
     // [i; f; o; g]
@@ -345,10 +347,23 @@ VanillaLSTMBuilder::VanillaLSTMBuilder(unsigned layers,
     //Parameter p_c2i = model.add_parameters({hidden_dim, hidden_dim});
     Parameter p_bi = model.add_parameters({hidden_dim * 4}, ParameterInitConst(0.f));
 
+
+
     layer_input_dim = hidden_dim;  // output (hidden) from 1st layer is input to next
 
     vector<Parameter> ps = {p_x2i, p_h2i, /*p_c2i,*/ p_bi};
     params.push_back(ps);
+
+    if (ln_lstm){
+      Parameter p_gh = model.add_parameters({hidden_dim * 4}, ParameterInitConst(1.f));
+      Parameter p_bh = model.add_parameters({hidden_dim * 4}, ParameterInitConst(0.f));
+      Parameter p_gx = model.add_parameters({hidden_dim * 4}, ParameterInitConst(1.f));
+      Parameter p_bx = model.add_parameters({hidden_dim * 4}, ParameterInitConst(0.f));
+      Parameter p_gc = model.add_parameters({hidden_dim}, ParameterInitConst(1.f));
+      Parameter p_bc = model.add_parameters({hidden_dim}, ParameterInitConst(0.f));
+      vector<Parameter> ln_ps = {p_gh, p_bh, p_gx, p_bx, p_gc, p_bc};
+      ln_params.push_back(ln_ps);
+    }
   }  // layers
   dropout_rate = 0.f;
   dropout_rate_h = 0.f;
@@ -356,12 +371,18 @@ VanillaLSTMBuilder::VanillaLSTMBuilder(unsigned layers,
 
 void VanillaLSTMBuilder::new_graph_impl(ComputationGraph& cg) {
   param_vars.clear();
-
+  if (ln_lstm)ln_param_vars.clear();
   for (unsigned i = 0; i < layers; ++i) {
     auto& p = params[i];
     vector<Expression> vars;
     for (unsigned j = 0; j < p.size(); ++j) { vars.push_back(parameter(cg, p[j])); }
     param_vars.push_back(vars);
+    if (ln_lstm){
+      auto& ln_p = ln_params[i];
+      vector<Expression> ln_vars;
+      for (unsigned j = 0; j < ln_p.size(); ++j) { ln_vars.push_back(parameter(cg, ln_p[j])); }
+      ln_param_vars.push_back(ln_vars);
+    }
   }
 
   _cg = &cg;
@@ -457,6 +478,7 @@ Expression VanillaLSTMBuilder::add_input_impl(int prev, const Expression& x) {
   Expression in = x;
   for (unsigned i = 0; i < layers; ++i) {
     const vector<Expression>& vars = param_vars[i];
+    const vector<Expression>& ln_vars = ln_param_vars[i];
     Expression i_h_tm1, i_c_tm1;
     bool has_prev_state = (prev >= 0 || has_initial_state);
     if (prev < 0) {
@@ -483,10 +505,17 @@ Expression VanillaLSTMBuilder::add_input_impl(int prev, const Expression& x) {
     Expression i_aft;
     Expression i_aot;
     Expression i_agt;
-    if (has_prev_state)
-      tmp = affine_transform({vars[_BI], vars[_X2I], in, vars[_H2I], i_h_tm1});
-    else
-      tmp = affine_transform({vars[_BI], vars[_X2I], in});
+    if (ln_lstm){
+      if (has_prev_state)
+        tmp = vars[_BI] + layer_norm(vars[_X2I] * in, ln_vars[LN_GX], ln_vars[LN_BX]) + layer_norm(vars[_H2I] * i_h_tm1, ln_vars[LN_GH], ln_vars[LN_BH]);
+      else
+        tmp = vars[_BI] + layer_norm(vars[_X2I] * in, ln_vars[LN_GX], ln_vars[LN_BX]);
+    }else{
+      if (has_prev_state)
+        tmp = affine_transform({vars[_BI], vars[_X2I], in, vars[_H2I], i_h_tm1});
+      else
+        tmp = affine_transform({vars[_BI], vars[_X2I], in});
+    }
     i_ait = pickrange(tmp, 0, hid);
     i_aft = pickrange(tmp, hid, hid * 2);
     i_aot = pickrange(tmp, hid * 2, hid * 3);
@@ -498,19 +527,25 @@ Expression VanillaLSTMBuilder::add_input_impl(int prev, const Expression& x) {
     Expression i_gt = tanh(i_agt);
 
     ct[i] = has_prev_state ? (cmult(i_ft, i_c_tm1) + cmult(i_it, i_gt)) :  cmult(i_it, i_gt);
-    in = ht[i] = cmult(i_ot, tanh(ct[i]));
+    if (ln_lstm)
+      in = ht[i] = cmult(i_ot, tanh(layer_norm(ct[i],ln_vars[LN_GC],ln_vars[LN_BC])));
+    else
+      in = ht[i] = cmult(i_ot, tanh(ct[i]));
   }
   return ht.back();
 }
 
 void VanillaLSTMBuilder::copy(const RNNBuilder & rnn) {
-  const LSTMBuilder & rnn_lstm = (const LSTMBuilder&)rnn;
+  const VanillaLSTMBuilder & rnn_lstm = (const VanillaLSTMBuilder&)rnn;
   DYNET_ARG_CHECK(params.size() == rnn_lstm.params.size(),
-                          "Attempt to copy LSTMBuilder with different number of parameters "
+                          "Attempt to copy VanillaLSTMBuilder with different number of parameters "
                           "(" << params.size() << " != " << rnn_lstm.params.size() << ")");
   for (size_t i = 0; i < params.size(); ++i)
     for (size_t j = 0; j < params[i].size(); ++j)
       params[i][j] = rnn_lstm.params[i][j];
+  for (size_t i = 0; i < ln_params.size(); ++i)
+    for (size_t j = 0; j < ln_params[i].size(); ++j)
+      ln_params[i][j] = rnn_lstm.ln_params[i][j];
 }
 
 void VanillaLSTMBuilder::save_parameters_pretraining(const string& fname) const {
@@ -524,6 +559,9 @@ void VanillaLSTMBuilder::save_parameters_pretraining(const string& fname) const 
   oa << layers;
   for (unsigned i = 0; i < layers; ++i) {
     for (auto p : params[i]) {
+      oa << p.get()->values;
+    }
+    for (auto p : ln_params[i]) {
       oa << p.get()->values;
     }
   }
@@ -548,6 +586,9 @@ void VanillaLSTMBuilder::load_parameters_pretraining(const string& fname) {
     for (auto p : params[i]) {
       ia >> p.get()->values;
     }
+    for (auto p : ln_params[i]) {
+      ia >> p.get()->values;
+    }
   }
 }
 
@@ -570,7 +611,9 @@ void VanillaLSTMBuilder::disable_dropout() {
   dropout_rate_h = 0.f;
 }
 
-DYNET_SERIALIZE_COMMIT(VanillaLSTMBuilder, DYNET_SERIALIZE_DERIVED_DEFINE(RNNBuilder, params, layers, dropout_rate, dropout_rate_h, hid, input_dim))
+DYNET_SERIALIZE_COMMIT(VanillaLSTMBuilder, 
+  DYNET_SERIALIZE_DERIVED_DEFINE(RNNBuilder, params, layers, dropout_rate, dropout_rate_h, hid, input_dim),
+  DYNET_VERSION_SERIALIZE_DEFINE(1, MAX_SERIALIZE_VERSION, ln_params, ln_lstm))
 DYNET_SERIALIZE_IMPL(VanillaLSTMBuilder);
 
 } // namespace dynet

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -195,11 +195,13 @@ struct VanillaLSTMBuilder : public RNNBuilder {
    * \param input_dim Dimention of the input \f$x_t\f$
    * \param hidden_dim Dimention of the hidden states \f$h_t\f$ and \f$c_t\f$
    * \param model Model holding the parameters
+   * \param ln_lstm Whether to use layer normalization
    */
   explicit VanillaLSTMBuilder(unsigned layers,
                               unsigned input_dim,
                               unsigned hidden_dim,
-                              Model& model);
+                              Model& model,
+                              bool ln_lstm = false);
 
   Expression back() const override { return (cur == -1 ? h0.back() : h[cur].back()); }
   std::vector<Expression> final_h() const override { return (h.size() == 0 ? h0 : h.back()); }
@@ -273,9 +275,13 @@ protected:
 public:
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;
+  // first index is layer, then ...
+  std::vector<std::vector<Parameter>> ln_params;
 
   // first index is layer, then ...
   std::vector<std::vector<Expression>> param_vars;
+  // first index is layer, then ...
+  std::vector<std::vector<Expression>> ln_param_vars;
 
   // first index is layer, then ...
   std::vector<std::vector<Expression>> masks;
@@ -291,6 +297,7 @@ public:
   unsigned layers;
   unsigned input_dim, hid;
   float dropout_rate_h;
+  bool ln_lstm;
 
 
 
@@ -305,5 +312,8 @@ private:
 
 // Class version
 DYNET_VERSION_DEFINE(dynet::LSTMBuilder, 1);
+// Class version
+DYNET_VERSION_DEFINE(dynet::VanillaLSTMBuilder, 1);
+
 
 #endif

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -402,8 +402,8 @@ cdef extern from "dynet/rnn.h" namespace "dynet":
     cdef cppclass CRNNBuilder "dynet::RNNBuilder":
         void new_graph(CComputationGraph &cg)
         void start_new_sequence(vector[CExpression] ces)
-        CExpression add_input(CExpression &x)
-        CExpression add_input(CRNNPointer prev, CExpression &x)
+        CExpression add_input(CExpression &x) except +
+        CExpression add_input(CRNNPointer prev, CExpression &x) except +
         CExpression set_h(CRNNPointer prev, vector[CExpression] ces)
         CExpression set_s(CRNNPointer prev, vector[CExpression] ces)
         void rewind_one_step()
@@ -468,7 +468,7 @@ cdef extern from "dynet/lstm.h" namespace "dynet":
 
     cdef cppclass CVanillaLSTMBuilder "dynet::VanillaLSTMBuilder" (CRNNBuilder):
         CVanillaLSTMBuilder()
-        CVanillaLSTMBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model)
+        CVanillaLSTMBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model, bool ln_lstm)
         void set_dropout(float d, float d_r)
         void set_dropout_masks(unsigned batch_size)
 

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3305,12 +3305,13 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # (((
         input_dim (int): Dimension of the input
         hidden_dim (int): Dimension of the recurrent units
         model (dynet.Model): Model to hold the parameters
+        ln_lstm (bool): Whether to use layer normalization
 
     """
     cdef CVanillaLSTMBuilder* thisvanillaptr
-    def __cinit__(self, unsigned layers, unsigned input_dim, unsigned hidden_dim, Model model):
+    def __cinit__(self, unsigned layers, unsigned input_dim, unsigned hidden_dim, Model model, ln_lstm=False):
         if layers > 0:
-            self.thisvanillaptr = self.thisptr = new CVanillaLSTMBuilder(layers, input_dim, hidden_dim, model.thisptr[0])
+            self.thisvanillaptr = self.thisptr = new CVanillaLSTMBuilder(layers, input_dim, hidden_dim, model.thisptr[0], ln_lstm)
         else:
             self.thisvanillaptr = self.thisptr = new CVanillaLSTMBuilder()
         self.cg_version = -1

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Boost COMPONENTS system filesystem unit_test_framework serializatio
 include_directories(${TEST_SOURCE_DIR}/src ${Boost_INCLUDE_DIRS})
 add_definitions(-DBOOST_TEST_DYN_LINK)
 
-foreach(TESTNAME dynet io mem nodes params tensor trainers serialize)
+foreach(TESTNAME dynet io mem nodes params tensor trainers serialize rnn)
 
   add_executable(test-${TESTNAME} test-${TESTNAME}.cc)
   

--- a/tests/test-rnn.cc
+++ b/tests/test-rnn.cc
@@ -1,0 +1,96 @@
+#define BOOST_TEST_MODULE TEST_RNN
+
+#include <dynet/dynet.h>
+#include <dynet/expr.h>
+#include <dynet/rnn.h>
+#include <dynet/lstm.h>
+#include <dynet/fast-lstm.h>
+#include <dynet/gru.h>
+#include <dynet/grad-check.h>
+#include <boost/test/unit_test.hpp>
+#include "test.h"
+#include <stdexcept>
+#include <fstream>
+
+using namespace dynet;
+using namespace dynet::expr;
+using namespace std;
+
+
+struct RNNTest {
+  RNNTest() {
+    // initialize if necessary
+    if (default_device == nullptr) {
+      for (auto x : {"RNNTest", "--dynet-mem", "10"}) {
+        av.push_back(strdup(x));
+      }
+      char **argv = &av[0];
+      int argc = av.size();
+      dynet::initialize(argc, argv);
+    }
+    seq_vals = {1.f, 0.f, 1.f, 1.f, 0.f, 1.f, 0.f, 1.f, 1.f, 1.f, 0.f, 1.f};
+    ones_vals = {1.f, 1.f, 1.f};
+    param_vals = {1.1f, -2.2f, 3.3f};
+    param2_vals = {1.1f, -2.2f, 3.3f};
+  }
+  ~RNNTest() {
+    for (auto x : av) free(x);
+  }
+
+  template <class T>
+  std::string print_vec(const std::vector<T> vec) {
+    ostringstream oss;
+    if (vec.size()) oss << vec[0];
+    for (size_t i = 1; i < vec.size(); i++)
+      oss << ' ' << vec[i];
+    return oss.str();
+  }
+
+  std::vector<float> ones_vals, param_vals, param2_vals, seq_vals;
+  std::vector<char*> av;
+};
+
+// define the test suite
+BOOST_FIXTURE_TEST_SUITE(rnn_test, RNNTest);
+
+#define DYNET_RNN_GRADIENT_TEST_CASE(name, RNN_TYPE)      \
+BOOST_AUTO_TEST_CASE( name ) {                            \
+  dynet::Model mod;                                       \
+  RNN_TYPE rnn(2,3,10,mod);                               \
+  dynet::ComputationGraph cg;                             \
+  rnn.new_graph(cg);                                      \
+  rnn.start_new_sequence();                               \
+  for(unsigned i=0;i<4;i++){                              \
+    Expression x = dynet::input(cg,Dim({3}), ones_vals);  \
+    rnn.add_input(x);                                     \
+  }                                                       \
+  Expression z = squared_norm(rnn.final_h()[1]);          \
+  BOOST_CHECK(check_grad(mod, z, 0));                     \
+}                                                         \
+
+DYNET_RNN_GRADIENT_TEST_CASE(simple_rnn_gradient, dynet::SimpleRNNBuilder)
+
+DYNET_RNN_GRADIENT_TEST_CASE(vanilla_lstm_gradient, dynet::VanillaLSTMBuilder)
+
+DYNET_RNN_GRADIENT_TEST_CASE(lstm_gradient, dynet::LSTMBuilder)
+
+DYNET_RNN_GRADIENT_TEST_CASE(gru_gradient, dynet::GRUBuilder)
+
+DYNET_RNN_GRADIENT_TEST_CASE(fast_lstm, dynet::FastLSTMBuilder)
+
+BOOST_AUTO_TEST_CASE( vanilla_lstm_ln_gradient ) {
+  dynet::Model mod;
+  dynet::VanillaLSTMBuilder vanilla_lstm(2, 3, 10, mod, true);
+  dynet::ComputationGraph cg;
+  vanilla_lstm.new_graph(cg);
+  vanilla_lstm.start_new_sequence();
+  for (unsigned i = 0; i < 4; i++) {
+    Expression x = dynet::input(cg, Dim({3}), ones_vals);
+    vanilla_lstm.add_input(x);
+  }
+  Expression z = squared_norm(vanilla_lstm.final_h()[1]);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This adds a `ln_lstm` optional parameter to the VanillaLSTM which enables layer norm according to [the original paper](https://arxiv.org/abs/1607.06450)

Also adds a bunch of tests for RNNs in c++

Also contains python bindings

Performance:

I've run a super quick test on cpu for character lm. Something I've noticed is that lstm with layer norm is substantially slower (because of layer norm and the fact that the `affine_transform` has to be broken. Didn' record the time but i'd say x 1.5-2 as slow as vanilla. EDIT : I checked and it's **x 6** (on CPU) so much slower. Can't test on GPU right now though

However the results are very good

![ln](https://cloud.githubusercontent.com/assets/10391785/25503582/ecaa3e08-2b68-11e7-9296-7030c0c67e01.png)

The tests were done with the `example/python/rnnlm-batch.py` script