### PR TITLE
Made everything but tests/mp compile w/o boost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_script:
   - cd build
   - conda create -q -n dynet-environment python=$PYVER $CONDA_PACKAGES
   - source activate dynet-environment
-  - cmake .. -DEIGEN3_INCLUDE_DIR=/usr/local/include/eigen3 -DPYTHON=`which python`
+  - cmake .. -DEIGEN3_INCLUDE_DIR=/usr/local/include/eigen3 -DINCLUDE_BOOST -DPYTHON=`which python`
 
 after_failure:
   - cat $TRAVIS_BUILD_DIR/build/CMakeFiles/CMakeError.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_script:
   - cd build
   - conda create -q -n dynet-environment python=$PYVER $CONDA_PACKAGES
   - source activate dynet-environment
-  - cmake .. -DEIGEN3_INCLUDE_DIR=/usr/local/include/eigen3 -DINCLUDE_BOOST -DPYTHON=`which python`
+  - cmake .. -DEIGEN3_INCLUDE_DIR=/usr/local/include/eigen3 -DENABLE_BOOST -DPYTHON=`which python`
 
 after_failure:
   - cat $TRAVIS_BUILD_DIR/build/CMakeFiles/CMakeError.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,8 @@ endfunction()
 # echo "export BOOST_LIBRARYDIR=/usr/local/lib" >> ~/.bashrc
 # echo "export BOOST_ROOT=/cygdrive/d/tools/boost_1_58_0/boost_1_58_0" >> ~/.bashrc
 # then run source ~/.bashrc to have those environment variable effective immediately
-if(INCLUDE_BOOST)
+if(ENABLE_BOOST)
+  message("-- Enabling Boost")
   if(DEFINED ENV{BOOST_ROOT})
     set(Boost_NO_SYSTEM_PATHS ON)
     if(DEFINED ${Boost_INCLUDE_DIR})
@@ -171,13 +172,12 @@ add_subdirectory(dynet)
 add_subdirectory(tutorial)
 add_subdirectory(python)
 
-option(INCLUDE_SWIG "INCLUDE_SWIG" OFF)
-if(INCLUDE_SWIG)
-  message("-- Including SWIG")
+if(ENABLE_SWIG)
+  message("-- Enabling SWIG")
   add_subdirectory(contrib/swig)
-endif(INCLUDE_SWIG)
+endif(ENABLE_SWIG)
 
-if(INCLUDE_BOOST)
+if(ENABLE_BOOST)
   add_subdirectory(tests)
   enable_testing()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,6 @@ else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -funroll-loops -fno-finite-math-only -Wall -Wno-missing-braces -std=c++11 -Ofast -g -march=native")
 endif()
 
-enable_testing()
-
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}
                     ${PROJECT_SOURCE_DIR}/external/easyloggingpp/src)
 
@@ -100,23 +98,6 @@ function(find_cudnn)
 endfunction()
 
 # look for Boost
-if(DEFINED ENV{BOOST_ROOT})
-  set(Boost_NO_SYSTEM_PATHS ON)
-  if(DEFINED ${Boost_INCLUDE_DIR})
-    get_filename_component(Boost_INCLUDE_DIR "${Boost_INCLUDE_DIR}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
-  endif()
-endif()
-set(Boost_REALPATH ON)
-find_package(Boost COMPONENTS program_options regex serialization REQUIRED)
-message("-- Boost dir is " ${Boost_INCLUDE_DIR})
-include_directories(${Boost_INCLUDE_DIR})
-if(MSVC)
-  # Boost does auto-linking when using a compiler like Microsoft Visual C++, we just need to help it find the libraries
-  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LIBPATH:${Boost_LIBRARY_DIRS}")
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LIBPATH:${Boost_LIBRARY_DIRS}")
-else()
-  set(LIBS ${LIBS} ${Boost_LIBRARIES})
-endif()
 # trouble shooting:
 # if boost library cannot be found, in addition to install boost library
 # check if environment variables are set
@@ -126,6 +107,24 @@ endif()
 # echo "export BOOST_LIBRARYDIR=/usr/local/lib" >> ~/.bashrc
 # echo "export BOOST_ROOT=/cygdrive/d/tools/boost_1_58_0/boost_1_58_0" >> ~/.bashrc
 # then run source ~/.bashrc to have those environment variable effective immediately
+if(INCLUDE_BOOST)
+  if(DEFINED ENV{BOOST_ROOT})
+    set(Boost_NO_SYSTEM_PATHS ON)
+    if(DEFINED ${Boost_INCLUDE_DIR})
+      get_filename_component(Boost_INCLUDE_DIR "${Boost_INCLUDE_DIR}" REALPATH BASE_DIR "${CMAKE_BINARY_DIR}")
+    endif()
+  endif()
+  set(Boost_REALPATH ON)
+  find_package(Boost COMPONENTS program_options regex serialization REQUIRED)
+  message("-- Boost dir is " ${Boost_INCLUDE_DIR})
+  include_directories(${Boost_INCLUDE_DIR})
+  if(MSVC)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LIBPATH:${Boost_LIBRARY_DIRS}")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /LIBPATH:${Boost_LIBRARY_DIRS}")
+  else()
+    set(LIBS ${LIBS} ${Boost_LIBRARIES})
+  endif()
+endif()
 
 if(BACKEND)
   message("-- BACKEND: ${BACKEND}")
@@ -168,7 +167,6 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(dynet)
-add_subdirectory(tests)
 #add_subdirectory(examples)
 add_subdirectory(tutorial)
 add_subdirectory(python)
@@ -179,4 +177,7 @@ if(INCLUDE_SWIG)
   add_subdirectory(contrib/swig)
 endif(INCLUDE_SWIG)
 
-enable_testing()
+if(INCLUDE_BOOST)
+  add_subdirectory(tests)
+  enable_testing()
+endif()

--- a/dynet/CMakeLists.txt
+++ b/dynet/CMakeLists.txt
@@ -37,7 +37,7 @@ set(dynet_library_SRCS
     weight-decay.cc
     io.cc
 )
-if(INCLUDE_BOOST)
+if(ENABLE_BOOST)
   list(APPEND dynet_library_SRCS mp.cc)
 endif()
 
@@ -83,7 +83,7 @@ set(dynet_library_HDRS
     weight-decay.h
     io.h
 )
-if(INCLUDE_BOOST)
+if(ENABLE_BOOST)
   list(APPEND dynet_library_HDRS mp.h)
 endif()
 

--- a/dynet/CMakeLists.txt
+++ b/dynet/CMakeLists.txt
@@ -20,7 +20,6 @@ set(dynet_library_SRCS
     lstm.cc
     mem.cc
     model.cc
-    mp.cc
     nodes.cc
     nodes-common.cc
     nodes-contract.cc
@@ -38,6 +37,9 @@ set(dynet_library_SRCS
     weight-decay.cc
     io.cc
 )
+if(INCLUDE_BOOST)
+  list(APPEND dynet_library_SRCS mp.cc)
+endif()
 
 # Headers:
 set(dynet_library_HDRS
@@ -63,7 +65,6 @@ set(dynet_library_HDRS
     lstm.h
     mem.h
     model.h
-    mp.h
     nodes.h
     nodes-contract.h
     nodes-conv.h
@@ -82,6 +83,9 @@ set(dynet_library_HDRS
     weight-decay.h
     io.h
 )
+if(INCLUDE_BOOST)
+  list(APPEND dynet_library_HDRS mp.h)
+endif()
 
 file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tests/*.cc)
 if (NOT MSVC)

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -1,6 +1,5 @@
 #include "dynet/devices.h"
 
-#include <boost/algorithm/string.hpp>
 #include <iostream>
 #include <unsupported/Eigen/CXX11/Tensor>
 
@@ -8,6 +7,7 @@
 #include "dynet/dynet.h"
 #include "dynet/expr.h"
 #include "dynet/except.h"
+#include "dynet/str-util.h"
 
 using namespace std;
 
@@ -26,8 +26,7 @@ DeviceMempoolSizes::DeviceMempoolSizes(size_t fx_s, size_t dEdfs_s, size_t ps_s)
 }
 
 DeviceMempoolSizes::DeviceMempoolSizes(const std::string & descriptor) {
-  vector<string> strs;
-  boost::algorithm::split(strs, descriptor, boost::is_any_of(","));
+  vector<string> strs = str_split(descriptor, ',');
   if (strs.size() == 1) {
     size_t total_size = stoi(strs[0]);
     used[0] = total_size / 3;

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -12,8 +12,6 @@
 #include <initializer_list>
 #include <utility>
 
-#include <boost/serialization/strong_typedef.hpp>
-
 #include "dynet/init.h"
 #include "dynet/aligned-mem-pool.h"
 #include "dynet/tensor.h"
@@ -55,7 +53,7 @@ struct ParameterNodeBase;
 struct Node;
 namespace expr { struct Expression; }
 
-BOOST_STRONG_TYPEDEF(unsigned, VariableIndex)
+typedef unsigned VariableIndex;
 
 struct CGCheckpoint {
   int node_idx;

--- a/dynet/functors.h
+++ b/dynet/functors.h
@@ -8,7 +8,6 @@
 #  define DYNET_DEVICE_FUNC __device__
 #  define DYNET_DEVICE_MIN -1.175494351e-38f
 #else
-#  include <boost/math/special_functions/digamma.hpp>
 #  define DYNET_DEVICE_FUNC
 #  define DYNET_DEVICE_MIN std::numeric_limits<float>::min()
 #endif
@@ -180,12 +179,6 @@ struct FSoftmaxBackward {
   }
   float off_diag_sum;
 };
-
-// struct FLogGammaBackward {
-//   DYNET_DEVICE_FUNC inline float operator()(float x, float d) const {
-//     return boost::math::digamma(x) * d;
-//   }
-// };
 
 struct FNegLogSoftmaxBackward {
   FNegLogSoftmaxBackward(float lz, float err) : logz(lz), d(err) {}

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -14,7 +14,7 @@
 #include "dynet/model.h"
 #include "dynet/tensor.h"
 #include "dynet/except.h"
-#include "dynet/str_util.h"
+#include "dynet/str-util.h"
 
 namespace dynet {
 

--- a/dynet/rnn.h
+++ b/dynet/rnn.h
@@ -19,7 +19,7 @@ namespace dynet {
 
 class ParameterCollection;
 
-BOOST_STRONG_TYPEDEF(int, RNNPointer)
+typedef int RNNPointer;
 inline void swap(RNNPointer& i1, RNNPointer& i2) {
   RNNPointer t = i1; i1 = i2; i2 = t;
 }

--- a/dynet/str-util.h
+++ b/dynet/str-util.h
@@ -6,16 +6,16 @@
 
 namespace dynet {
 
-bool startswith(const std::string & str, const std::string & key) {
+inline bool startswith(const std::string & str, const std::string & key) {
   return str.find(key) == 0;
 }
 
-bool endswith(const std::string & str, const std::string & key) {
+inline bool endswith(const std::string & str, const std::string & key) {
   if (str.size() < key.size()) return false;
   return str.rfind(key) == (str.size() - key.size());
 }
 
-std::vector<std::string> str_split(const std::string & str, const char sep) {
+inline std::vector<std::string> str_split(const std::string & str, const char sep) {
   std::vector<std::string> lst;
   size_t st = 0, en = 0;
   while (1) {


### PR DESCRIPTION
Adds a new `INCLUDE_BOOST` definition for cmake, which is disabled by default. Tests and MP are only compiled if it is enabled.