### PR TITLE
Refactor code without using boost serialization in example/cpp folder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,7 +168,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(dynet)
-#add_subdirectory(examples)
+add_subdirectory(examples)
 add_subdirectory(tutorial)
 add_subdirectory(python)
 

--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -3,7 +3,7 @@
 
 namespace dynet {
 
-void Pack::save(const ParameterCollection & model,
+void Packer::save(const ParameterCollection & model,
                 const std::string & key, bool is_append) {
   std::string key_str(key);
   if (key.size() == 0) {
@@ -28,13 +28,13 @@ void Pack::save(const ParameterCollection & model,
   os.close();
 }
 
-void Pack::save(const ParameterCollection & model,
+void Packer::save(const ParameterCollection & model,
                 const std::vector<std::string> & filter_lst,
                 const std::string & key, bool is_append) {
-  DYNET_RUNTIME_ERR("This interface is not implemented yet for Pack object.");
+  DYNET_RUNTIME_ERR("This interface is not implemented yet for Packer object.");
 }
 
-void Pack::save(const Parameter & param, const std::string & key, bool is_append) {
+void Packer::save(const Parameter & param, const std::string & key, bool is_append) {
   std::string key_str(key);
   if (key.size() == 0) {
     key_str = param.get_fullname();
@@ -53,7 +53,7 @@ void Pack::save(const Parameter & param, const std::string & key, bool is_append
   os.close();
 }
 
-void Pack::save(const LookupParameter & lookup_param, const std::string & key, bool is_append) {
+void Packer::save(const LookupParameter & lookup_param, const std::string & key, bool is_append) {
   std::string key_str(key);
   if (key.size() == 0) {
     key_str = lookup_param.get_fullname();
@@ -73,61 +73,61 @@ void Pack::save(const LookupParameter & lookup_param, const std::string & key, b
   os.close();
 }
 
-void Pack::populate(ParameterCollection & model, const std::string & key) {
+void Packer::populate(ParameterCollection & model, const std::string & key) {
   this->deserialize(model, key);
 }
 
-void Pack::populate(ParameterCollection & model,
+void Packer::populate(ParameterCollection & model,
                     const std::vector<std::string> & filter_lst,
                     const std::string & key) {
-  DYNET_RUNTIME_ERR("This interface is not implemented yet for Pack object.");
+  DYNET_RUNTIME_ERR("This interface is not implemented yet for Packer object.");
 }
 
-void Pack::populate(Parameter & param,
+void Packer::populate(Parameter & param,
                     const std::string & key) {
   this->deserialize(param, key);
 }
 
-void Pack::populate(Parameter & param,
+void Packer::populate(Parameter & param,
                     const std::string & model_name,
                     const std::string & key) {
   this->deserialize(param, model_name, key);
 }
 
-void Pack::populate(LookupParameter & lookup_param,
+void Packer::populate(LookupParameter & lookup_param,
                     const std::string & key) {
   this->deserialize(lookup_param, key);
 }
 
-void Pack::populate(LookupParameter & lookup_param,
+void Packer::populate(LookupParameter & lookup_param,
                     const std::string & model_name,
                     const std::string & key) {
   this->deserialize(lookup_param, model_name, key);
 }
 
-Parameter Pack::load_param(ParameterCollection & model,
+Parameter Packer::load_param(ParameterCollection & model,
                            const std::string & key) {
   return this->deserialize_param(model, key);
 }
 
-Parameter Pack::load_param(ParameterCollection & model,
+Parameter Packer::load_param(ParameterCollection & model,
                            const std::string & model_name,
                            const std::string & key) {
   return this->deserialize_param(model, model_name, key);
 }
 
-LookupParameter Pack::load_lookup_param(ParameterCollection & model,
+LookupParameter Packer::load_lookup_param(ParameterCollection & model,
                                         const std::string & key) {
   return this->deserialize_lookup_param(model, key);
 }
 
-LookupParameter Pack::load_lookup_param(ParameterCollection & model,
+LookupParameter Packer::load_lookup_param(ParameterCollection & model,
                                         const std::string & model_name,
                                         const std::string & key) {
   return this->deserialize_lookup_param(model, model_name, key);
 }
 
-bool Pack::duplicate_key_check(const std::string & key) {
+bool Packer::duplicate_key_check(const std::string & key) {
   std::ifstream f(fn_meta);
   std::string line;
   while (std::getline(f, line)) {
@@ -138,7 +138,7 @@ bool Pack::duplicate_key_check(const std::string & key) {
   return true;
 }
 
-void Pack::serialize(const ParameterCollection & model,
+void Packer::serialize(const ParameterCollection & model,
                      const std::string & key,
                      bool is_append,
                      std::unordered_map<std::string, long long> & offset_dict) {
@@ -171,7 +171,7 @@ void Pack::serialize(const ParameterCollection & model,
   os.close();
 }
 
-void Pack::serialize(const Parameter & param,
+void Packer::serialize(const Parameter & param,
                      const std::string & key,
                      bool is_append) {
   std::ofstream os;
@@ -188,7 +188,7 @@ void Pack::serialize(const Parameter & param,
   os.close();
 }
 
-void Pack::serialize(const LookupParameter & lookup_param,
+void Packer::serialize(const LookupParameter & lookup_param,
                      const std::string & key,
                      bool is_append) {
   std::ofstream os;
@@ -205,7 +205,7 @@ void Pack::serialize(const LookupParameter & lookup_param,
   os.close();
 }
 
-void Pack::deserialize(ParameterCollection & model, const std::string & key) {
+void Packer::deserialize(ParameterCollection & model, const std::string & key) {
   std::ifstream meta_f(fn_meta);
   std::ifstream f(fn);
   // find the offset of the key
@@ -310,7 +310,7 @@ void Pack::deserialize(ParameterCollection & model, const std::string & key) {
   meta_f.close();
 }
   
-void Pack::deserialize(Parameter & param, const std::string & key) {
+void Packer::deserialize(Parameter & param, const std::string & key) {
   std::ifstream f(fn);
   std::string line;
   f.seekg(this->seek_offset(key));
@@ -340,7 +340,7 @@ void Pack::deserialize(Parameter & param, const std::string & key) {
   f.close();
 }
 
-void Pack::deserialize(Parameter & param,
+void Packer::deserialize(Parameter & param,
                        const std::string & model_name,
                        const std::string & key) {
   std::ifstream f(fn);
@@ -368,7 +368,7 @@ void Pack::deserialize(Parameter & param,
   f.close();
 }
 
-void Pack::deserialize(LookupParameter & lookup_param,
+void Packer::deserialize(LookupParameter & lookup_param,
                        const std::string & key) {
   std::ifstream f(fn);
   std::string line;
@@ -403,7 +403,7 @@ void Pack::deserialize(LookupParameter & lookup_param,
   f.close();
 }
 
-void Pack::deserialize(LookupParameter & lookup_param,
+void Packer::deserialize(LookupParameter & lookup_param,
                        const std::string & model_name,
                        const std::string & key) {
   std::ifstream f(fn);
@@ -433,7 +433,7 @@ void Pack::deserialize(LookupParameter & lookup_param,
   f.close();
 }
 
-Parameter Pack::deserialize_param(ParameterCollection & model,
+Parameter Packer::deserialize_param(ParameterCollection & model,
                                   const std::string & key) {
   std::ifstream f(fn);
   std::string line;
@@ -463,7 +463,7 @@ Parameter Pack::deserialize_param(ParameterCollection & model,
   return param;
 }
 
-Parameter Pack::deserialize_param(ParameterCollection & model,
+Parameter Packer::deserialize_param(ParameterCollection & model,
                             const std::string & model_name,
                             const std::string & key) {
   std::ifstream f(fn);
@@ -491,7 +491,7 @@ Parameter Pack::deserialize_param(ParameterCollection & model,
   return param;
 }
 
-LookupParameter Pack::deserialize_lookup_param(ParameterCollection & model,
+LookupParameter Packer::deserialize_lookup_param(ParameterCollection & model,
                                          const std::string & model_name,
                                          const std::string & key) {
 
@@ -525,7 +525,7 @@ LookupParameter Pack::deserialize_lookup_param(ParameterCollection & model,
   return lookup_param;
 }
 
-LookupParameter Pack::deserialize_lookup_param(ParameterCollection & model,
+LookupParameter Packer::deserialize_lookup_param(ParameterCollection & model,
                                                const std::string & key) {
   std::ifstream f(fn);
   std::string line;
@@ -566,20 +566,20 @@ LookupParameter Pack::deserialize_lookup_param(ParameterCollection & model,
   return lookup_param;
 }
 
-void Pack::serialize_parameter(std::ofstream & os, const ParameterStorage *p) {
+void Packer::serialize_parameter(std::ofstream & os, const ParameterStorage *p) {
   os << p->name << '\n' << p->dim << '\n';
   os << dynet::as_vector(p->values);
   os << dynet::as_vector(p->g);
 }
 
-void Pack::serialize_lookup_parameter(std::ofstream & os,
+void Packer::serialize_lookup_parameter(std::ofstream & os,
                                       const LookupParameterStorage *p) {
   os << p->name << '\n' << p->all_dim << '\n' << p->dim << '\n';
   os << dynet::as_vector(p->all_values);
   os << dynet::as_vector(p->all_grads);
 }
 
-long long Pack::seek_offset(const std::string & key) {
+long long Packer::seek_offset(const std::string & key) {
   std::ifstream meta_f(fn_meta);
   std::string line;
   long long local_offset = -1;
@@ -601,7 +601,7 @@ long long Pack::seek_offset(const std::string & key) {
   return local_offset;
 }
 
-long long Pack::seek_offset(const std::string & model_name,
+long long Packer::seek_offset(const std::string & model_name,
                             const std::string & key) {
   std::ifstream meta_f(fn_meta);
   std::string line;

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -31,9 +31,9 @@ std::istream& operator>>(std::istream& is, std::vector<T> & v) {
   return is;
 }
 
-class Pack {
+class Packer {
  public:
-  Pack(std::string filename) : fn(filename), fn_meta(filename + ".meta") {}
+  Packer(std::string filename) : fn(filename), fn_meta(filename + ".meta") {}
   
   void reinit(std::string filename) {
     offset = 0;
@@ -239,7 +239,7 @@ class Pack {
  private:
   std::string fn, fn_meta;
   long long offset = 0;
-}; // class Pack
+}; // class Packer
 
 } // namespace dynet
 

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -3,6 +3,7 @@
 #include "dynet/aligned-mem-pool.h"
 #include "dynet/dynet.h"
 #include "dynet/param-init.h"
+#include "dynet/io.h"
 
 #include <unordered_set>
 #include <iostream>
@@ -425,19 +426,15 @@ const ParameterCollectionStorage& ParameterCollection::get_storage() const {
   return *storage;
 }
 
-/*
 void save_dynet_model(std::string filename, ParameterCollection* model) {
-  std::ofstream out(filename);
-  boost::archive::text_oarchive oa(out);
-  oa << (*model);
+  Pack packer(filename);
+  packer.save(*model, "model");
 };
 
 void load_dynet_model(std::string filename, ParameterCollection* model) {
-  std::ifstream in(filename);
-  boost::archive::text_iarchive ia(in);
-  ia >> (*model);
+  Pack packer(filename);
+  packer.populate(*model, "model");
 };
-*/
 
 #endif
 

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -427,12 +427,12 @@ const ParameterCollectionStorage& ParameterCollection::get_storage() const {
 }
 
 void save_dynet_model(std::string filename, ParameterCollection* model) {
-  Pack packer(filename);
+  Packer packer(filename);
   packer.save(*model, "model");
 };
 
 void load_dynet_model(std::string filename, ParameterCollection* model) {
-  Pack packer(filename);
+  Packer packer(filename);
   packer.populate(*model, "model");
 };
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,11 +1,15 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 if (NOT MSVC)
-  set(MP_EXAMPLES rnnlm-mp xor-mp xor-simple-mp)
+  set(MP_EXAMPLES xor-mp xor-simple-mp)
 endif()
 
 if(ENABLE_BOOST)
-  set(RNNLM rnnlm)
+  if (NOT MSVC)
+    set(RNNLM rnnlm rnnlm-mp)
+  else()
+    set(RNNLM rnnlm)
+  endif()
 endif()
 
 # TODO: segrnn-sup

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,10 +1,15 @@
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 if (NOT MSVC)
-   set(MP_EXAMPLES rnnlm-mp xor-mp xor-simple-mp)
+  set(MP_EXAMPLES rnnlm-mp xor-mp xor-simple-mp)
 endif()
 
-foreach(FOLDER encdec mlc mnist tok-embed poisson-regression tag-bilstm embed-cl xor xor-xent xor-batch xor-batch-lookup rnnlm rnnlm-aevb rnnlm-cfsm rnnlm-batch nlm textcat read-write segrnn-sup attention imdb ${MP_EXAMPLES})
+if(ENABLE_BOOST)
+  set(RNNLM rnnlm)
+endif()
+
+# TODO: segrnn-sup
+foreach(FOLDER encdec mlc mnist tok-embed poisson-regression tag-bilstm embed-cl xor xor-xent xor-batch xor-batch-lookup rnnlm-aevb rnnlm-cfsm rnnlm-batch nlm textcat read-write attention imdb ${RNNLM} ${MP_EXAMPLES})
   set(TARGET train_${FOLDER})
   ADD_EXECUTABLE(${TARGET} cpp/${FOLDER}/${TARGET}.cc)
   if (WITH_CUDA_BACKEND)
@@ -17,4 +22,3 @@ foreach(FOLDER encdec mlc mnist tok-embed poisson-regression tag-bilstm embed-cl
     target_link_libraries(${TARGET} rt)
   endif()
 endforeach()
-

--- a/examples/cpp/embed-cl/train_embed-cl.cc
+++ b/examples/cpp/embed-cl/train_embed-cl.cc
@@ -67,7 +67,7 @@ struct Encoder {
 
   void save() {
     std::remove("embed-cl.model.meta"); std::remove("embed-cl.model");
-    Pack packer("embed-cl.model");
+    Packer packer("embed-cl.model");
     packer.save(p_s, "p_s");
     packer.save(p_t, "p_t");
   }
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
   Encoder emb;
   if (argc == 4) {
     string fname = argv[3];
-    Pack packer(fname);
+    Packer packer(fname);
     packer.populate(model, "model");
   }
   else {

--- a/examples/cpp/embed-cl/train_embed-cl.cc
+++ b/examples/cpp/embed-cl/train_embed-cl.cc
@@ -4,13 +4,11 @@
 #include "dynet/timing.h"
 #include "dynet/dict.h"
 #include "dynet/expr.h"
+#include "dynet/io.h"
 
 #include <iostream>
 #include <fstream>
 #include <sstream>
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/serialization/access.hpp>
 
 using namespace std;
 using namespace dynet;
@@ -67,11 +65,11 @@ struct Encoder {
 #endif
   }
 
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int) {
-    ar & p_s;
-    ar & p_t;
+  void save() {
+    std::remove("embed-cl.model.meta"); std::remove("embed-cl.model");
+    Pack packer("embed-cl.model");
+    packer.save(p_s, "p_s");
+    packer.save(p_t, "p_t");
   }
 };
 
@@ -137,9 +135,8 @@ int main(int argc, char** argv) {
   Encoder emb;
   if (argc == 4) {
     string fname = argv[3];
-    ifstream in(fname);
-    boost::archive::text_iarchive ia(in);
-    ia >> model >> emb;
+    Pack packer(fname);
+    packer.populate(model, "model");
   }
   else {
     emb = Encoder(model);

--- a/examples/cpp/encdec/encdec.h
+++ b/examples/cpp/encdec/encdec.h
@@ -22,9 +22,6 @@
 #include <fstream>
 #include <sstream>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-
 using namespace std;
 using namespace dynet;
 using namespace dynet::expr;
@@ -362,19 +359,6 @@ public:
     }
 
 private:
-    friend class boost::serialization::access;
-    template<class Archive>
-    void serialize(Archive & ar, const unsigned int) {
-        ar & bidirectional;
-        ar & LAYERS & INPUT_DIM & HIDDEN_DIM;
-        ar & p_c & p_ec & p_R & p_bias;
-        if (bidirectional)
-            ar & p_ie2oe & p_boe;
-        if (bidirectional)
-            ar & dec_builder & rev_enc_builder & fwd_enc_builder;
-        else
-            ar & dec_builder & fwd_enc_builder;
-    }
     inline int sample(const vector<float>& v) {
         float p = (float)rand() / (float) RAND_MAX;
         float cumul = 0.f;

--- a/examples/cpp/encdec/train_encdec.cc
+++ b/examples/cpp/encdec/train_encdec.cc
@@ -140,7 +140,7 @@ int main(int argc, char** argv) {
 
   // Load preexisting weights (if provided)
   if (params.model_file != "") {
-    Pack packer(params.model_file);
+    Packer packer(params.model_file);
     packer.populate(model, "model");
   }
 
@@ -227,7 +227,7 @@ int main(int argc, char** argv) {
         best = dloss;
         std::string fname_meta = fname + ".meta";
         std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-        Pack packer(fname);
+        Packer packer(fname);
         packer.save(model, "model", false);
       }
       // Print informations

--- a/examples/cpp/encdec/train_encdec.cc
+++ b/examples/cpp/encdec/train_encdec.cc
@@ -5,6 +5,7 @@
  * This provide an example of usage of the encdec.h model
  */
 #include "encdec.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
 #include "../utils/cl-args.h"
 
@@ -139,9 +140,8 @@ int main(int argc, char** argv) {
 
   // Load preexisting weights (if provided)
   if (params.model_file != "") {
-    ifstream in(params.model_file);
-    boost::archive::text_iarchive ia(in);
-    ia >> model >> lm;
+    Pack packer(params.model_file);
+    packer.populate(model, "model");
   }
 
   // Initialize variables for training -------------------------------------------------------------
@@ -225,9 +225,10 @@ int main(int argc, char** argv) {
       // If the validation loss is the lowest, save the parameters
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model << lm;
+        std::string fname_meta = fname + ".meta";
+        std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+        Pack packer(fname);
+        packer.save(model, "model", false);
       }
       // Print informations
       cerr << "\n***DEV [epoch=" << (epoch)
@@ -271,6 +272,4 @@ int main(int argc, char** argv) {
   }
   // Free memory
   delete adam;
-
 }
-

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -302,7 +302,7 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-        packer.save(model, "model");
+        packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / (double)dtags) << ' ';
     }

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -14,6 +14,7 @@
  * On a small proportion of the IMDB data (2500 for training, 500 for dev.), this
  * model achieves 80% accuracy on two-way classification.
  */
+#include <unistd.h>
 #include "dynet/nodes.h"
 #include "dynet/dynet.h"
 #include "dynet/training.h"
@@ -24,13 +25,12 @@
 #include "dynet/dict.h"
 #include "dynet/expr.h"
 #include "dynet/globals.h"
+#include "dynet/io.h"
+
 #include "../utils/getpid.h"
 
 #include <iostream>
 #include <fstream>
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 
 using namespace std;
 using namespace dynet;
@@ -253,6 +253,8 @@ int main(int argc, char** argv) {
   bool first = true;
   int report = 0;
   unsigned lines = 0;
+  std::remove("imdb.model.meta"); std::remove("imdb.model");
+  Pack packer("imdb.model");
   while (1) {
     Timer iteration("completed in");
     double loss = 0;
@@ -300,9 +302,7 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model;
+        packer.save(model, "model");
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / (double)dtags) << ' ';
     }

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -254,7 +254,7 @@ int main(int argc, char** argv) {
   int report = 0;
   unsigned lines = 0;
   std::remove("imdb.model.meta"); std::remove("imdb.model");
-  Pack packer("imdb.model");
+  Packer packer("imdb.model");
   while (1) {
     Timer iteration("completed in");
     double loss = 0;

--- a/examples/cpp/mnist/mlp.h
+++ b/examples/cpp/mnist/mlp.h
@@ -19,10 +19,6 @@
 
 #include <boost/serialization/utility.hpp>
 #include <boost/serialization/vector.hpp>
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 
 #include <iostream>
 #include <fstream>
@@ -71,14 +67,7 @@ public:
     activation(activation),
     dropout_rate(dropout_rate) {};
   Layer() {};
-private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive & ar, const unsigned int) {
-    ar & input_dim & output_dim & activation & dropout_rate;
-  }
 };
-DYNET_SERIALIZE_IMPL(Layer);
 
 /**
  * \ingroup ffbuilders
@@ -284,16 +273,6 @@ private:
       break;
     }
   }
-
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive & ar, const unsigned int) {
-    ar & LAYERS;
-    ar & layers & params;
-    ar & dropout_active;
-  }
-
-
 };
 
 #endif

--- a/examples/cpp/mnist/mlp.h
+++ b/examples/cpp/mnist/mlp.h
@@ -17,9 +17,6 @@
 #include "dynet/expr.h"
 #include "dynet/io-macros.h"
 
-#include <boost/serialization/utility.hpp>
-#include <boost/serialization/vector.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/cpp/mnist/train_mnist.cc
+++ b/examples/cpp/mnist/train_mnist.cc
@@ -4,6 +4,7 @@
  * This provide an example of usage of the mlp.h model
  */
 #include "mlp.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
 #include "../utils/cl-args.h"
 #include "../utils/data-io.h"
@@ -63,9 +64,8 @@ int main(int argc, char** argv) {
 
   // Load preexisting weights (if provided)
   if (params.model_file != "") {
-    ifstream in(params.model_file);
-    boost::archive::text_iarchive ia(in);
-    ia >> model >> nn;
+    Pack packer(params.model_file);
+    packer.populate(model, "model");
   }
 
   // Initialize variables for training -------------------------------------------------------------
@@ -161,9 +161,10 @@ int main(int argc, char** argv) {
       // If the dev loss is lower than the previous ones, save the ,odel
       if (dpos > worst) {
         worst = dpos;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model << nn;
+        std::string fname_meta = fname + ".meta";
+        std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+        Pack packer(fname);
+        packer.save(model, "model", false);
       }
       // Print informations
       cerr << "\n***DEV [epoch=" << (epoch)
@@ -177,7 +178,4 @@ int main(int argc, char** argv) {
     ++epoch;
 
   }
-
-
 }
-

--- a/examples/cpp/mnist/train_mnist.cc
+++ b/examples/cpp/mnist/train_mnist.cc
@@ -64,7 +64,7 @@ int main(int argc, char** argv) {
 
   // Load preexisting weights (if provided)
   if (params.model_file != "") {
-    Pack packer(params.model_file);
+    Packer packer(params.model_file);
     packer.populate(model, "model");
   }
 
@@ -163,7 +163,7 @@ int main(int argc, char** argv) {
         worst = dpos;
         std::string fname_meta = fname + ".meta";
         std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-        Pack packer(fname);
+        Packer packer(fname);
         packer.save(model, "model", false);
       }
       // Print informations

--- a/examples/cpp/poisson-regression/train_poisson-regression.cc
+++ b/examples/cpp/poisson-regression/train_poisson-regression.cc
@@ -194,7 +194,7 @@ int main(int argc, char** argv) {
         std::string fname_meta = fname + ".meta";
         std::remove(fname_meta.c_str()); std::remove(fname.c_str());
         Pack packer(fname);
-        packer.save(model, "model");
+        packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
     }

--- a/examples/cpp/poisson-regression/train_poisson-regression.cc
+++ b/examples/cpp/poisson-regression/train_poisson-regression.cc
@@ -140,7 +140,7 @@ int main(int argc, char** argv) {
 
   RNNLengthPredictor<LSTMBuilder> lm(model);
   if (argc == 4) {
-    Pack packer(argv[3]);
+    Packer packer(argv[3]);
     packer.populate(model, "model");
   }
 
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
         best = dloss;
         std::string fname_meta = fname + ".meta";
         std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-        Pack packer(fname);
+        Packer packer(fname);
         packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';

--- a/examples/cpp/poisson-regression/train_poisson-regression.cc
+++ b/examples/cpp/poisson-regression/train_poisson-regression.cc
@@ -10,14 +10,12 @@
 #include "dynet/dict.h"
 #include "dynet/expr.h"
 #include "dynet/globals.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
 
 #include <iostream>
 #include <fstream>
 #include <sstream>
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 
 using namespace std;
 using namespace dynet;
@@ -142,10 +140,8 @@ int main(int argc, char** argv) {
 
   RNNLengthPredictor<LSTMBuilder> lm(model);
   if (argc == 4) {
-    string fname = argv[3];
-    ifstream in(fname);
-    boost::archive::text_iarchive ia(in);
-    ia >> model;
+    Pack packer(argv[3]);
+    packer.populate(model, "model");
   }
 
   unsigned report_every_i = 50;
@@ -195,9 +191,10 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model;
+        std::string fname_meta = fname + ".meta";
+        std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+        Pack packer(fname);
+        packer.save(model, "model");
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
     }

--- a/examples/cpp/read-write/train_read-write.cc
+++ b/examples/cpp/read-write/train_read-write.cc
@@ -74,7 +74,7 @@ public:
 };
 
 void WriteToFile(string& filename, XORModel& model, ParameterCollection& dynet_model) {
-  Pack packer(filename);
+  Packer packer(filename);
   packer.save(dynet_model, "model");
   packer.save(model.pW, "model.pW");
   packer.save(model.pb, "model.pb");
@@ -83,7 +83,7 @@ void WriteToFile(string& filename, XORModel& model, ParameterCollection& dynet_m
 }
 
 void ReadFromFile(string& filename, XORModel& model, ParameterCollection& dynet_model) {
-  Pack packer(filename);
+  Packer packer(filename);
   packer.populate(dynet_model, "model");
   packer.populate(model.pW, "model.pW");
   packer.populate(model.pb, "model.pb");

--- a/examples/cpp/read-write/train_read-write.cc
+++ b/examples/cpp/read-write/train_read-write.cc
@@ -3,8 +3,7 @@
 #include "dynet/training.h"
 #include "dynet/gpu-ops.h"
 #include "dynet/expr.h"
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
+#include "dynet/io.h"
 
 #include <iostream>
 #include <fstream>
@@ -72,58 +71,25 @@ public:
     Expression y_pred = V*h + a;
     return as_scalar(cg.forward(y_pred));
   }
-
-  // This function should save all those variables in the archive, which
-  // determine the size of other members of the class, here: hidden_size
-  friend class boost::serialization::access;
-  template<class Archive> void serialize(Archive& ar, const unsigned int) {
-
-    // This can either save or read the value of hidden_size from ar,
-    // depending on whether its the output or input archive.
-    ar & hidden_size;
-
-    // We may save class data, such as the hidden size
-    // but we must be sure to save all Parameter objects
-    // that are members of this class.
-    ar & pW;
-    ar & pV;
-    ar & pa;
-    ar & pb;
-  }
 };
 
 void WriteToFile(string& filename, XORModel& model, ParameterCollection& dynet_model) {
-  ofstream outfile(filename);
-  if (!outfile.is_open()) {
-    cerr << "File opening failed" << endl;
-    exit(1);
-  }
-
-  // Write out the DYNET model and the XOR model.
-  // It's important to write the DYNET model first.
-  // Since the XOR model uses the DYNET model,
-  // saving in the opposite order will generate a
-  // boost archive "Pointer Conflict" exception.
-  boost::archive::text_oarchive oa(outfile);
-  oa & dynet_model;  // Write down the dynet::Model object.
-  oa & model;  // Write down your class object.
-  outfile.close();
+  Pack packer(filename);
+  packer.save(dynet_model, "model");
+  packer.save(model.pW, "model.pW");
+  packer.save(model.pb, "model.pb");
+  packer.save(model.pV, "model.pV");
+  packer.save(model.pa, "model.pa");
 }
 
 void ReadFromFile(string& filename, XORModel& model, ParameterCollection& dynet_model) {
-  ifstream infile(filename);
-  if (!infile.is_open()) {
-    cerr << "File opening failed" << endl;
-    exit(1);
-  }
-
-  boost::archive::text_iarchive ia(infile);
-  ia & dynet_model;  // Read the dynet::Model
-  ia & model;  // Read your class object
-
-  infile.close();
+  Pack packer(filename);
+  packer.populate(dynet_model, "model");
+  packer.populate(model.pW, "model.pW");
+  packer.populate(model.pb, "model.pb");
+  packer.populate(model.pV, "model.pV");
+  packer.populate(model.pa, "model.pa");
 }
-
 
 int main(int argc, char** argv) {
   dynet::initialize(argc, argv);
@@ -165,4 +131,3 @@ int main(int argc, char** argv) {
   cerr << "Output for the input: " << x_values[0] << " " << x_values[1] << endl;
   cerr << read_model.Decode(x_values);  // Checking output for sanity
 }
-

--- a/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
+++ b/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
@@ -8,14 +8,12 @@
 #include "dynet/dict.h"
 #include "dynet/expr.h"
 #include "dynet/globals.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
 
 #include <iostream>
 #include <fstream>
 #include <sstream>
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 
 using namespace std;
 using namespace dynet;
@@ -189,9 +187,8 @@ int main(int argc, char** argv) {
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
   if (argc == 4) {
     string fname = argv[3];
-    ifstream in(fname);
-    boost::archive::text_iarchive ia(in);
-    ia >> model;
+    Pack packer(fname);
+    packer.populate(model, "model");
   }
 
   unsigned report_every_i = 50;
@@ -242,9 +239,10 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model;
+        std::string fname_meta = fname + ".meta";
+        std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+        Pack packer(fname);
+        packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
     }

--- a/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
+++ b/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
@@ -187,7 +187,7 @@ int main(int argc, char** argv) {
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
   if (argc == 4) {
     string fname = argv[3];
-    Pack packer(fname);
+    Packer packer(fname);
     packer.populate(model, "model");
   }
 
@@ -241,7 +241,7 @@ int main(int argc, char** argv) {
         best = dloss;
         std::string fname_meta = fname + ".meta";
         std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-        Pack packer(fname);
+        Packer packer(fname);
         packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';

--- a/examples/cpp/rnnlm-batch/rnnlm-batch.h
+++ b/examples/cpp/rnnlm-batch/rnnlm-batch.h
@@ -221,15 +221,6 @@ public:
     }
     cerr << endl;
   }
-
-private:
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive & ar, const unsigned int) {
-    ar & LAYERS & INPUT_DIM & HIDDEN_DIM;
-    ar & p_c & p_R & p_bias;
-    ar & rnn;
-  }
 };
 
 #endif

--- a/examples/cpp/rnnlm-batch/rnnlm-batch.h
+++ b/examples/cpp/rnnlm-batch/rnnlm-batch.h
@@ -20,10 +20,6 @@
 #include "dynet/dict.h"
 #include "dynet/expr.h"
 
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
+++ b/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
@@ -4,9 +4,9 @@
  * This provide an example of usage of the rnnlm-batch.h model
  */
 #include "rnnlm-batch.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
 #include "../utils/cl-args.h"
-
 
 using namespace std;
 using namespace dynet;
@@ -134,9 +134,8 @@ int main(int argc, char** argv) {
 
   // Load preexisting weights (if provided)
   if (params.model_file != "") {
-    ifstream in(params.model_file);
-    boost::archive::text_iarchive ia(in);
-    ia >> model >> lm;
+    Pack packer(params.model_file);
+    packer.populate(model, "model");
   }
 
   // Initialize variables for training -------------------------------------------------------------
@@ -215,12 +214,12 @@ int main(int argc, char** argv) {
         // Add loss
         dloss += as_scalar(cg.forward(loss_expr));
       }
-      // If the dev loss is lower than the previous ones, save the ,odel
+      // If the dev loss is lower than the previous ones, save the model
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model << lm;
+        std::remove("rnnlm-batch.model.meta"); std::remove("rnnlm-batch.model");
+        Pack packer("rnnlm-batch.model");
+        packer.save(model, "model", false);
       }
       // Print informations
       cerr << "\n***DEV [epoch=" << (epoch)
@@ -238,11 +237,6 @@ int main(int argc, char** argv) {
 
     // Increment epoch
     ++epoch;
-
   }
-
   delete adam;
-
-
 }
-

--- a/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
+++ b/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
 
   // Load preexisting weights (if provided)
   if (params.model_file != "") {
-    Pack packer(params.model_file);
+    Packer packer(params.model_file);
     packer.populate(model, "model");
   }
 
@@ -218,7 +218,7 @@ int main(int argc, char** argv) {
       if (dloss < best) {
         best = dloss;
         std::remove("rnnlm-batch.model.meta"); std::remove("rnnlm-batch.model");
-        Pack packer("rnnlm-batch.model");
+        Packer packer("rnnlm-batch.model");
         packer.save(model, "model", false);
       }
       // Print informations

--- a/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
+++ b/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
@@ -9,14 +9,12 @@
 #include "dynet/expr.h"
 #include "dynet/cfsm-builder.h"
 #include "dynet/globals.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
 
 #include <iostream>
 #include <fstream>
 #include <sstream>
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 
 using namespace std;
 using namespace dynet;
@@ -151,10 +149,8 @@ int main(int argc, char** argv) {
   RNNLanguageModel<LSTMBuilder> lm(model, cfsm);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model, cfsm);
   if (argc == 5) {
-    string fname = argv[4];
-    ifstream in(fname);
-    boost::archive::text_iarchive ia(in);
-    ia >> model;
+    Pack packer(argv[4]);
+    packer.populate(model, "model");
   }
 
   unsigned report_every_i = 50;
@@ -209,9 +205,10 @@ int main(int argc, char** argv) {
 #if 1
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model;
+        std::string fname_meta = fname + ".meta";
+        std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+        Pack packer(fname);
+        packer.save(model, "model", false);
       }
     }
 #endif

--- a/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
+++ b/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
@@ -149,7 +149,7 @@ int main(int argc, char** argv) {
   RNNLanguageModel<LSTMBuilder> lm(model, cfsm);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model, cfsm);
   if (argc == 5) {
-    Pack packer(argv[4]);
+    Packer packer(argv[4]);
     packer.populate(model, "model");
   }
 
@@ -207,7 +207,7 @@ int main(int argc, char** argv) {
         best = dloss;
         std::string fname_meta = fname + ".meta";
         std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-        Pack packer(fname);
+        Packer packer(fname);
         packer.save(model, "model", false);
       }
     }

--- a/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
+++ b/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
@@ -15,9 +15,6 @@
 #include <sstream>
 #include <algorithm>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-
 using namespace std;
 using namespace dynet;
 
@@ -203,10 +200,8 @@ int main(int argc, char** argv) {
 
   RNNLanguageModel<LSTMBuilder> lm(model);
   if (argc == 4) {
-    string fname = argv[3];
-    ifstream in(fname);
-    boost::archive::text_iarchive ia(in);
-    ia >> model;
+    Pack packer(argv[3]);
+    packer.populate(model, "model");
   }
 
   unsigned report_every_i = 50;
@@ -253,13 +248,13 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model;
+        std::string fname_meta = fname + ".meta";
+        std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+        Pack packer(fname);
+        packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
     }
   }
   delete sgd;
 }
-

--- a/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
+++ b/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
@@ -200,7 +200,7 @@ int main(int argc, char** argv) {
 
   RNNLanguageModel<LSTMBuilder> lm(model);
   if (argc == 4) {
-    Pack packer(argv[3]);
+    Packer packer(argv[3]);
     packer.populate(model, "model");
   }
 
@@ -250,7 +250,7 @@ int main(int argc, char** argv) {
         best = dloss;
         std::string fname_meta = fname + ".meta";
         std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-        Pack packer(fname);
+        Packer packer(fname);
         packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';

--- a/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
+++ b/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
@@ -15,9 +15,6 @@
 #include <fstream>
 #include <sstream>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-
 using namespace std;
 using namespace dynet;
 
@@ -172,10 +169,8 @@ int main(int argc, char** argv) {
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
   if (argc == 4) {
-    string fname = argv[3];
-    ifstream in(fname);
-    boost::archive::text_iarchive ia(in);
-    ia >> model;
+    Pack packer(argv[3]);
+    packer.populate(model, "model");
   }
 
   unsigned report_every_i = 50;

--- a/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
+++ b/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
   if (argc == 4) {
-    Pack packer(argv[3]);
+    Packer packer(argv[3]);
     packer.populate(model, "model");
   }
 

--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -228,7 +228,7 @@ int main(int argc, char** argv) {
   if (has_model_to_load) {
     string fname = conf["model"].as<string>();
     cerr << "Reading parameters from " << fname << "...\n";
-    Pack packer(fname);
+    Packer packer(fname);
     packer.save(model, "model");
   }
 
@@ -320,7 +320,7 @@ int main(int argc, char** argv) {
           best = dloss;
           std::string fname_meta = fname + ".meta";
           std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-          Pack packer(fname);
+          Packer packer(fname);
           packer.save(model, "model", false);
         }
         cerr << "\n***DEV [epoch=" << (lines / training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';

--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -10,6 +10,7 @@
 #include "dynet/cfsm-builder.h"
 #include "dynet/hsm-builder.h"
 #include "dynet/globals.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
 
 #include <iostream>
@@ -18,8 +19,6 @@
 
 #include <boost/algorithm/string/join.hpp>
 #include <boost/program_options.hpp>
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
 #include <boost/regex.hpp>
 
 using namespace std;
@@ -229,10 +228,8 @@ int main(int argc, char** argv) {
   if (has_model_to_load) {
     string fname = conf["model"].as<string>();
     cerr << "Reading parameters from " << fname << "...\n";
-    ifstream in(fname);
-    assert(in);
-    boost::archive::binary_iarchive ia(in);
-    ia >> model;
+    Pack packer(fname);
+    packer.save(model, "model");
   }
 
   bool LEARN = conf.count("learn");
@@ -321,9 +318,10 @@ int main(int argc, char** argv) {
         }
         if (dloss < best) {
           best = dloss;
-          ofstream out(fname);
-          boost::archive::binary_oarchive oa(out);
-          oa << model;
+          std::string fname_meta = fname + ".meta";
+          std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+          Pack packer(fname);
+          packer.save(model, "model", false);
         }
         cerr << "\n***DEV [epoch=" << (lines / training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
       }

--- a/examples/cpp/skiprnnlm/train_skiprnnlm.cc
+++ b/examples/cpp/skiprnnlm/train_skiprnnlm.cc
@@ -16,9 +16,6 @@
 #include <sstream>
 #include <tuple>
 
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
-
 using namespace std;
 using namespace dynet;
 
@@ -137,10 +134,8 @@ int main(int argc, char** argv) {
 
     RNNSkipLM lm(model);
     if (argc == 4) {
-        string fname = argv[3];
-        ifstream in(fname);
-        boost::archive::text_iarchive ia(in);
-        ia >> model;
+        Pack packer(argv[3]);
+        packer.populate(model, "model");'
     }
 
     unsigned report_every_i = 50;
@@ -196,9 +191,10 @@ int main(int argc, char** argv) {
             }
             if (dloss < best) {
                 best = dloss;
-                ofstream out(fname);
-                boost::archive::text_oarchive oa(out);
-                oa << model;
+                std::string fname_meta = fname + ".meta";
+                std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+                Pack packer(fname);
+                packer.save(model, "model");
             }
             LOG(INFO) << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
         }

--- a/examples/cpp/skiprnnlm/train_skiprnnlm.cc
+++ b/examples/cpp/skiprnnlm/train_skiprnnlm.cc
@@ -134,7 +134,7 @@ int main(int argc, char** argv) {
 
     RNNSkipLM lm(model);
     if (argc == 4) {
-        Pack packer(argv[3]);
+        Packer packer(argv[3]);
         packer.populate(model, "model");'
     }
 
@@ -193,7 +193,7 @@ int main(int argc, char** argv) {
                 best = dloss;
                 std::string fname_meta = fname + ".meta";
                 std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-                Pack packer(fname);
+                Packer packer(fname);
                 packer.save(model, "model");
             }
             LOG(INFO) << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -1,3 +1,8 @@
+#include <unistd.h>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
 #include "dynet/nodes.h"
 #include "dynet/dynet.h"
 #include "dynet/training.h"
@@ -8,14 +13,8 @@
 #include "dynet/dict.h"
 #include "dynet/expr.h"
 #include "dynet/globals.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
-
-#include <iostream>
-#include <fstream>
-#include <sstream>
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 
 using namespace std;
 using namespace dynet;
@@ -193,10 +192,8 @@ int main(int argc, char** argv) {
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
   if (argc == 4) {
-    string fname = argv[3];
-    ifstream in(fname);
-    boost::archive::text_iarchive ia(in);
-    ia >> model;
+    Pack packer(argv[3]);
+    packer.populate(model, "model");
   }
 
   unsigned report_every_i = 50;
@@ -250,13 +247,13 @@ int main(int argc, char** argv) {
       eval = false;
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model;
+        std::string fname_meta = fname + ".meta";
+        std::remove(fname_meta.c_str()); std::remove(fname.c_str());
+        Pack packer(fname);
+        packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / dtags) << ' ';
     }
   }
   delete sgd;
 }
-

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -192,7 +192,7 @@ int main(int argc, char** argv) {
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
   if (argc == 4) {
-    Pack packer(argv[3]);
+    Packer packer(argv[3]);
     packer.populate(model, "model");
   }
 
@@ -249,7 +249,7 @@ int main(int argc, char** argv) {
         best = dloss;
         std::string fname_meta = fname + ".meta";
         std::remove(fname_meta.c_str()); std::remove(fname.c_str());
-        Pack packer(fname);
+        Packer packer(fname);
         packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / dtags) << ' ';

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -8,13 +8,11 @@
 #include "dynet/dict.h"
 #include "dynet/expr.h"
 #include "dynet/globals.h"
+#include "dynet/io.h"
 #include "../utils/getpid.h"
 
 #include <iostream>
 #include <fstream>
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
 
 using namespace std;
 using namespace dynet;
@@ -251,6 +249,8 @@ int main(int argc, char** argv) {
   bool first = true;
   int report = 0;
   unsigned lines = 0;
+  std::remove("textcat.model.meta"); std::remove("textcat.model");
+  Pack packer("textcat.model");
   while(1) {
     Timer iteration("completed in");
     double loss = 0;
@@ -306,9 +306,7 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-        ofstream out(fname);
-        boost::archive::text_oarchive oa(out);
-        oa << model;
+        packer.save(model, "model");
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / (double)dtags) << ' ';
     }

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -250,7 +250,7 @@ int main(int argc, char** argv) {
   int report = 0;
   unsigned lines = 0;
   std::remove("textcat.model.meta"); std::remove("textcat.model");
-  Pack packer("textcat.model");
+  Packer packer("textcat.model");
   while(1) {
     Timer iteration("completed in");
     double loss = 0;

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -306,7 +306,7 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-        packer.save(model, "model");
+        packer.save(model, "model", false);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / (double)dtags) << ' ';
     }

--- a/examples/cpp/utils/getpid.h
+++ b/examples/cpp/utils/getpid.h
@@ -3,5 +3,4 @@
 #if _WINDOWS
     #include <process.h>
 #endif
-
-
+#include <unistd.h>

--- a/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
+++ b/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
@@ -26,7 +26,7 @@ int main(int argc, char** argv) {
   if (argc == 2) {
     // Load the model and parameters from
     // file if given.
-    Pack packer(argv[1]);
+    Packer packer(argv[1]);
     packer.populate(m, "model");
     p_W = packer.load_param(m, "p_W");
     p_b = packer.load_param(m, "p_b");
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
   // Output the model and parameter objects
   // to a cout.
   std::remove("xor-batch-lookup.model.meta"); std::remove("xor-batch-lookup.model");
-  Pack packer("xor-batch-lookup.model");
+  Packer packer("xor-batch-lookup.model");
   packer.save(m, "model");
   packer.save(p_W, "p_W");
   packer.save(p_b, "p_b");

--- a/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
+++ b/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
@@ -3,8 +3,7 @@
 #include "dynet/training.h"
 #include "dynet/gpu-ops.h"
 #include "dynet/expr.h"
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
+#include "dynet/io.h"
 
 #include <iostream>
 #include <fstream>
@@ -27,9 +26,12 @@ int main(int argc, char** argv) {
   if (argc == 2) {
     // Load the model and parameters from
     // file if given.
-    ifstream in(argv[1]);
-    boost::archive::text_iarchive ia(in);
-    ia >> m >> p_W >> p_b >> p_V >> p_a;
+    Pack packer(argv[1]);
+    packer.populate(m, "model");
+    p_W = packer.load_param(m, "p_W");
+    p_b = packer.load_param(m, "p_b");
+    p_V = packer.load_param(m, "p_V");
+    p_a = packer.load_param(m, "p_a");
   }
   else {
     // Otherwise, just create a new model.
@@ -81,7 +83,12 @@ int main(int argc, char** argv) {
   }
   // Output the model and parameter objects
   // to a cout.
-  boost::archive::text_oarchive oa(cout);
-  oa << m << p_W << p_b << p_V << p_a << x_values << y_values;
+  std::remove("xor-batch-lookup.model.meta"); std::remove("xor-batch-lookup.model");
+  Pack packer("xor-batch-lookup.model");
+  packer.save(m, "model");
+  packer.save(p_W, "p_W");
+  packer.save(p_b, "p_b");
+  packer.save(p_V, "p_V");
+  packer.save(p_a, "p_a");
 }
 

--- a/examples/cpp/xor-batch/train_xor-batch.cc
+++ b/examples/cpp/xor-batch/train_xor-batch.cc
@@ -26,7 +26,7 @@ int main(int argc, char** argv) {
   if (argc == 2) {
     // Load the model and parameters from
     // file if given.
-    Pack packer(argv[1]);
+    Packer packer(argv[1]);
     packer.populate(m, "model");
     p_W = packer.load_param(m, "p_W");
     p_b = packer.load_param(m, "p_b");
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
   // Output the model and parameter objects
   // to a cout.
   std::remove("xor-batch.model.meta"); std::remove("xor-batch.model");
-  Pack packer("xor-batch.model");
+  Packer packer("xor-batch.model");
   packer.save(m, "model");
   packer.save(p_W, "p_W");
   packer.save(p_b, "p_b");

--- a/examples/cpp/xor-batch/train_xor-batch.cc
+++ b/examples/cpp/xor-batch/train_xor-batch.cc
@@ -3,8 +3,7 @@
 #include "dynet/training.h"
 #include "dynet/gpu-ops.h"
 #include "dynet/expr.h"
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
+#include "dynet/io.h"
 
 #include <iostream>
 #include <fstream>
@@ -27,9 +26,12 @@ int main(int argc, char** argv) {
   if (argc == 2) {
     // Load the model and parameters from
     // file if given.
-    ifstream in(argv[1]);
-    boost::archive::text_iarchive ia(in);
-    ia >> m >> p_W >> p_b >> p_V >> p_a;
+    Pack packer(argv[1]);
+    packer.populate(m, "model");
+    p_W = packer.load_param(m, "p_W");
+    p_b = packer.load_param(m, "p_b");
+    p_V = packer.load_param(m, "p_V");
+    p_a = packer.load_param(m, "p_a");
   }
   else {
     // Otherwise, just create a new model.
@@ -71,7 +73,11 @@ int main(int argc, char** argv) {
 
   // Output the model and parameter objects
   // to a cout.
-  boost::archive::text_oarchive oa(cout);
-  oa << m << p_W << p_b << p_V << p_a;
+  std::remove("xor-batch.model.meta"); std::remove("xor-batch.model");
+  Pack packer("xor-batch.model");
+  packer.save(m, "model");
+  packer.save(p_W, "p_W");
+  packer.save(p_b, "p_b");
+  packer.save(p_V, "p_V");
+  packer.save(p_a, "p_a");
 }
-

--- a/examples/cpp/xor-mp/train_xor-mp.cc
+++ b/examples/cpp/xor-mp/train_xor-mp.cc
@@ -4,8 +4,7 @@
 #include "dynet/gpu-ops.h"
 #include "dynet/expr.h"
 #include "dynet/mp.h"
-#include <boost/archive/text_oarchive.hpp>
-#include <boost/archive/text_iarchive.hpp>
+#include "dynet/io.h"
 
 #include <iostream>
 #include <fstream>
@@ -55,37 +54,7 @@ private:
   Parameter p_W, p_b, p_V, p_a;
   Expression W, b, V, a;
   ComputationGraph* pcg;
-
-  friend class boost::serialization::access;
-  template<class Archive>
-  void serialize(Archive& ar, const unsigned int) {
-    ar & p_W & p_b & p_V & p_a;
-  }
 };
-
-void serialize(const XorModel* const xor_model, const ParameterCollection& dynet_model, const Trainer* const trainer) {
-  // Remove existing stdout output
-  int r = ftruncate(fileno(stdout), 0);
-  if (r != 0) {}
-
-  // Move the cursor to the beginning of the stdout stream
-  fseek(stdout, 0, SEEK_SET);
-
-  // Dump the model to stdout
-  boost::archive::text_oarchive oa(cout);
-  oa & dynet_model;
-  oa & xor_model;
-  oa & trainer;
-}
-
-void deserialize(const string& filename, XorModel* xor_model, ParameterCollection& dynet_model, Trainer* trainer) {
-  ifstream in(filename.c_str());
-  boost::archive::text_iarchive ia(in);
-  ia & dynet_model;
-  ia & xor_model;
-  ia & trainer;
-  in.close();
-}
 
 class SufficientStats {
 public:
@@ -132,11 +101,7 @@ public:
     return SufficientStats(loss, 1);
   }
 
-  void SaveModel() {
-    if (!quiet) {
-      serialize(xor_model, dynet_model, trainer);
-    }
-  }
+  void SaveModel() {}
 
 private:
   XorModel* xor_model;
@@ -155,16 +120,10 @@ int main(int argc, char** argv) {
   XorModel* xor_model = nullptr;
   Trainer* trainer = nullptr;
 
-  if (argc == 2) {
-    // Load the model and parameters from file if given.
-    deserialize(argv[1], xor_model, dynet_model, trainer);
-  }
-  else {
-    // Otherwise, just create a new model.
-    const unsigned HIDDEN_SIZE = 8;
-    xor_model = new XorModel(HIDDEN_SIZE, dynet_model);
-    trainer = new SimpleSGDTrainer(dynet_model);
-  }
+  // Otherwise, just create a new model.
+  const unsigned HIDDEN_SIZE = 8;
+  xor_model = new XorModel(HIDDEN_SIZE, dynet_model);
+  trainer = new SimpleSGDTrainer(dynet_model);
 
   vector<Datum> data(4);
   data[0] = Datum({0, 0}, 0);

--- a/examples/cpp/xor-xent/train_xor-xent.cc
+++ b/examples/cpp/xor-xent/train_xor-xent.cc
@@ -2,9 +2,7 @@
 #include "dynet/dynet.h"
 #include "dynet/training.h"
 #include "dynet/expr.h"
-
-#include <boost/archive/text_iarchive.hpp>
-#include <boost/archive/text_oarchive.hpp>
+#include "dynet/io.h"
 
 #include <iostream>
 #include <fstream>
@@ -25,9 +23,12 @@ int main(int argc, char** argv) {
 
   Parameter p_W, p_b, p_V, p_a;
   if (argc == 2) {
-    ifstream in(argv[1]);
-    boost::archive::text_iarchive ia(in);
-    ia >>  m >> p_W >> p_b >> p_V >> p_a;
+    Pack packer(argv[1]);
+    packer.populate(m, "model");
+    p_W = packer.load_param(m, "p_W");
+    p_b = packer.load_param(m, "p_b");
+    p_V = packer.load_param(m, "p_V");
+    p_a = packer.load_param(m, "p_a");
   }
   else {
     p_W = m.add_parameters({HIDDEN_SIZE, 2});
@@ -72,7 +73,12 @@ int main(int argc, char** argv) {
 
   // Output the model and parameter objects
   // to a cout.
-  boost::archive::text_oarchive oa(cout);
-  oa << m << p_W << p_b << p_V << p_a;
+  std::remove("xor-xent.model.meta"); std::remove("xor-xent.model");
+  Pack packer("xor-xent.model");
+  packer.save(m, "model");
+  packer.save(p_W, "p_W");
+  packer.save(p_b, "p_b");
+  packer.save(p_V, "p_V");
+  packer.save(p_a, "p_a");
 }
 

--- a/examples/cpp/xor-xent/train_xor-xent.cc
+++ b/examples/cpp/xor-xent/train_xor-xent.cc
@@ -23,7 +23,7 @@ int main(int argc, char** argv) {
 
   Parameter p_W, p_b, p_V, p_a;
   if (argc == 2) {
-    Pack packer(argv[1]);
+    Packer packer(argv[1]);
     packer.populate(m, "model");
     p_W = packer.load_param(m, "p_W");
     p_b = packer.load_param(m, "p_b");
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
   // Output the model and parameter objects
   // to a cout.
   std::remove("xor-xent.model.meta"); std::remove("xor-xent.model");
-  Pack packer("xor-xent.model");
+  Packer packer("xor-xent.model");
   packer.save(m, "model");
   packer.save(p_W, "p_W");
   packer.save(p_b, "p_b");

--- a/examples/cpp/xor/train_xor.cc
+++ b/examples/cpp/xor/train_xor.cc
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
   Parameter p_W, p_b, p_V, p_a;
   if (argc == 2) {
     // Load the model and parameters from file if given.
-    Pack packer(argv[1]);
+    Packer packer(argv[1]);
     packer.populate(m, "model");
     p_W = packer.load_param(m, "p_W");
     p_b = packer.load_param(m, "p_b");
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
 
   // Output the model and parameter objects to a cout.
   std::remove("xor.model.meta"); std::remove("xor.model");
-  Pack packer("xor.model");
+  Packer packer("xor.model");
   packer.save(m, "model");
   packer.save(p_W, "p_W");
   packer.save(p_b, "p_b");

--- a/python/pybridge.h
+++ b/python/pybridge.h
@@ -143,4 +143,3 @@ struct ParameterCollectionLoader {
 
 };
 }
-

--- a/tests/test-io.cc
+++ b/tests/test-io.cc
@@ -71,7 +71,7 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter_collection ) {
     Parameter b = m.add_parameters({3,7});
     LookupParameter c = m.add_lookup_parameters(10, {2});
     std::remove("test.model"); std::remove("test.model.meta");
-    dynet::Pack s("test.model");
+    dynet::Packer s("test.model");
     s.save(m, "model1");
     s.save(m, m.get_namespace(), true);
 
@@ -85,14 +85,14 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter_collection ) {
     ParameterCollection collec;
     testModel spec(collec);
     std::remove("a.model"); std::remove("a.model.meta");
-    Pack s1("a.model");
+    Packer s1("a.model");
     s1.save(collec, "all");
     ParameterCollection collec2;
     s1.populate(collec2);
     DYNET_CHECK_EQUAL(collec2.size(), collec.size());
   
     std::remove("b.model"); std::remove("b.model.meta");
-    Pack s2("b.model");
+    Packer s2("b.model");
     s2.save(collec, "all");
     s2.save(spec.get_lstm_model(), "lstm", true);
     s2.save(spec.get_affine_model(), "affine", true);
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter_collection ) {
     auto cc2 = cc.add_subcollection("xx");
     cc2.add_parameters({2, 3, 4, 5});
     std::remove("d.model"); std::remove("d.model.meta");
-    Pack s3("d.model");
+    Packer s3("d.model");
     s3.save(cc, "key");
 
     ParameterCollection ccc;
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter_collection ) {
 BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
   {
     std::remove("f.model.meta"); std::remove("f.model");
-    Pack packer("f.model");
+    Packer packer("f.model");
     ParameterCollection model_out;
     Parameter m_out = model_out.add_parameters({100});
     LookupParameter lookup_m_out = model_out.add_lookup_parameters(10, {128});
@@ -154,7 +154,7 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
   }
   {
     std::remove("g.model.meta"); std::remove("g.model");
-    Pack packer("g.model");
+    Packer packer("g.model");
     ParameterCollection model;
     Parameter m = model.add_parameters({10});
     LookupParameter lookup_m = model.add_lookup_parameters(10, {128});


### PR DESCRIPTION
Since current packer only supports mix Parameter, LookupParameter, and ParameterCollection save and load, I removed builder and user-defined class serialization/deserialization functionality in `example/cpp` folder.