### PR TITLE
Fixed bug in select_rows and select_cols

### DIFF
--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1857,7 +1857,7 @@ void SelectCols::backward_dev_impl(const MyDevice & dev,
   DYNET_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectCols::backward");
   auto& rm = *pcols;
   for (unsigned i = 0; i < rm.size(); ++i)
-    dEdxi.t<2>().chip<1>(rm[i]).device(*dev.edevice) = dEdf.t<2>().chip<1>(i);
+    dEdxi.t<2>().chip<1>(rm[i]).device(*dev.edevice) += dEdf.t<2>().chip<1>(i);
 }
 DYNET_NODE_INST_DEV_IMPL(SelectCols)
 
@@ -1882,7 +1882,7 @@ void SelectRows::backward_dev_impl(const MyDevice & dev,
   DYNET_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectRows::backward");
   auto& rm = *prows;
   for (unsigned i = 0; i < rm.size(); ++i)
-    dEdxi.t<2>().chip<0>(rm[i]).device(*dev.edevice) = dEdf.t<2>().chip<0>(i);
+    dEdxi.t<2>().chip<0>(rm[i]).device(*dev.edevice) += dEdf.t<2>().chip<0>(i);
 }
 DYNET_NODE_INST_DEV_IMPL(SelectRows)
 

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1199,6 +1199,16 @@ BOOST_AUTO_TEST_CASE( select_rows_gradient ) {
 }
 
 // Expression select_rows(const Expression& x, vector<unsigned>& rows);
+BOOST_AUTO_TEST_CASE( select_rows_multiple_gradient ) {
+  dynet::ComputationGraph cg;
+  vector<unsigned> rows = {0,2};
+  Expression x1 = parameter(cg, param_square1);
+  Expression y = select_rows(x1, rows) * x1;
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression select_rows(const Expression& x, vector<unsigned>& rows);
 BOOST_AUTO_TEST_CASE( select_rows_oob ) {
   dynet::ComputationGraph cg;
   vector<unsigned> rows = {3};
@@ -1213,6 +1223,16 @@ BOOST_AUTO_TEST_CASE( select_cols_gradient ) {
   vector<unsigned> cols = {1};
   Expression x1 = parameter(cg, param_square1);
   Expression y = select_cols(x1, cols);
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression select_cols(const Expression& x, vector<unsigned>& cols);
+BOOST_AUTO_TEST_CASE( select_cols_multiple_gradient ) {
+  dynet::ComputationGraph cg;
+  vector<unsigned> cols = {0,2};
+  Expression x1 = parameter(cg, param_square1);
+  Expression y = x1 * select_cols(x1, cols);
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
 }


### PR DESCRIPTION
There was a bug in `select_rows` and `select_cols` that wasn't caught by unit tests (gradients were being reset, not aggregated, which is necessary). This pull request fixes this bug.