### PR TITLE
Moment expressions

### DIFF
--- a/doc/source/python_ref.rst
+++ b/doc/source/python_ref.rst
@@ -194,7 +194,17 @@ Arithmetic operations
 
 .. autofunction:: dynet.sum_elems
 
-.. autofunction:: dynet.sum_batches
+.. autofunction:: dynet.mean_elems
+
+.. autofunction:: dynet.moment_elems
+
+.. autofunction:: dynet.std_elems
+
+.. autofunction:: dynet.mean_dim
+
+.. autofunction:: dynet.moment_dim
+
+.. autofunction:: dynet.std_dim
 
 .. autofunction:: dynet.fold_rows
 
@@ -243,6 +253,14 @@ Flow/Shaping operations
 .. autofunction:: dynet.pick_batch_elem
 
 .. autofunction:: dynet.pick_batch_elems
+
+.. autofunction:: dynet.sum_batches
+
+.. autofunction:: dynet.mean_batches
+
+.. autofunction:: dynet.moment_batches
+
+.. autofunction:: dynet.std_batches
 
 .. autofunction:: dynet.reshape
 

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -157,8 +157,18 @@ Expression sum_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.
 Expression sum_rows(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 0)); }
 Expression sum_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, 1)); }
 Expression sum_elems(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumElements>({x.i})); }
+Expression mean_elems(const Expression& x) { return Expression(x.pg, x.pg->add_function<MomentElements>({x.i}, 1)); }
+Expression moment_elems(const Expression& x, unsigned r) { return Expression(x.pg, x.pg->add_function<MomentElements>({x.i}, r)); }
+Expression std_elems(const Expression& x) { return Expression(x.pg, x.pg->add_function<StdElements>({x.i})); }
 
 Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumBatches>({x.i})); }
+Expression moment_batches(const Expression& x, unsigned r) { return Expression(x.pg, x.pg->add_function<MomentBatches>({x.i}, r)); }
+Expression mean_batches(const Expression& x) { return Expression(x.pg, x.pg->add_function<MomentBatches>({x.i}, 1)); }
+Expression std_batches(const Expression& x) { return Expression(x.pg, x.pg->add_function<StdBatches>({x.i})); }
+
+Expression mean_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MomentDimension>({x.i}, d, 1)); }
+Expression moment_dim(const Expression& x, unsigned d, unsigned r) { return Expression(x.pg, x.pg->add_function<MomentDimension>({x.i}, d, r)); }
+Expression std_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<StdDimension>({x.i}, d)); }
 
 Expression kmh_ngram(const Expression& x, unsigned n) { return Expression(x.pg, x.pg->add_function<KMHNGram>({x.i}, n)); }
 
@@ -166,11 +176,10 @@ Expression max_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.
 Expression min_dim(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<MinDimension>({x.i}, d)); }
 
 Expression layer_norm(const Expression& x, const Expression& g, const Expression& b){
-    float n = (float) (x.dim().batch_size());
-    Expression mu = sum_elems(x) / n;
+    Expression mu = mean_elems(x);
     Expression x_centered= x - mu;
-    Expression sigma = expr::sqrt(sum_elems(square(x_centered)) / n);
-    return cmult(cdiv(g,sigma), x_centered) + b;
+    Expression sigma = std_elems(x);
+    return cmult(g, cdiv(x_centered,sigma + 1e-8)) + b;
 }
 }
 }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -616,6 +616,40 @@ Expression sum_elems(const Expression& x);
 
 /**
  * \ingroup arithmeticoperations
+ * \brief Compute moment over all elements
+ * \details Compute the moment of order \f$r\f$, \f$\frac 1 n\sum_{i=1}^nx_i^r\f$ over all the elements in each batch of the expression
+ *
+ * \param x The input mini-batched expression
+ * \param r Order of the moment
+ *
+ * \return A scalar expression (with a potential batch dimension)
+ */
+Expression moment_elems(const Expression& x, unsigned r);
+
+/**
+ * \ingroup arithmeticoperations
+ * \brief Compute mean over all elements
+ * \details Computes \f$\frac 1 n\sum_{i=1}^nx_i\f$ over all the elements in each batch of the expression
+ *
+ * \param x The input mini-batched expression
+ *
+ * \return A scalar expression (with a potential batch dimension)
+ */
+Expression mean_elems(const Expression& x);
+
+/**
+ * \ingroup arithmeticoperations
+ * \brief Compute Standard deviation over all elements
+ * \details Computes \f$\frac 1 n\sum_{i=1}^n(x_i -\mu)^2\f$ where \f$\mu=\frac 1 n\sum_{i=1}^nx_i\f$ over all the elements in each batch of the expression
+ *
+ * \param x The input mini-batched expression
+ *
+ * \return A scalar expression (with a potential batch dimension)
+ */
+Expression std_elems(const Expression& x);
+
+/**
+ * \ingroup arithmeticoperations
  * \brief Average
  * \details This performs an elementwise average over all the expressions in xs
  *
@@ -1337,6 +1371,78 @@ Expression sum_batches(const Expression& x);
 
 /**
  * \ingroup flowoperations
+ * \brief Compute moment over minibatches
+ * \details Compute the moment of order \f$r\f$, \f$\frac 1 n\sum_{i=1}^nx_i^r\f$ along the batch dimension 
+ *
+ * \param x The input mini-batched expression
+ * \param r Order of the moment
+ *
+ * \return An expression with a single batch
+ */
+Expression moment_batches(const Expression& x, unsigned r);
+
+
+/**
+ * \ingroup flowoperations
+ * \brief Compute mean over minibatches
+ * \details Computes \f$\frac 1 n\sum_{i=1}^nx_i\f$ along the batch dimension 
+ *
+ * \param x The input mini-batched expression
+ *
+ * \return An expression with a single batch
+ */
+Expression mean_batches(const Expression& x);
+
+/**
+ * \ingroup flowoperations
+ * \brief Compute standard deviation over minibatches
+ * \details Computes \f$\frac 1 n\sum_{i=1}^n(x_i -\mu)^2\f$ where \f$\mu=\frac 1 n\sum_{i=1}^nx_i\f$ along the batch dimension 
+ *
+ * \param x The input mini-batched expression
+ *
+ * \return A scalar expression (with a potential batch dimension)
+ */
+Expression std_batches(const Expression& x);
+
+/**
+ * \ingroup flowoperations
+ * \brief Compute standard deviation along an arbitrary dimension
+ * \details Computes \f$\frac 1 n\sum_{i=1}^n(x_i -\mu)^2\f$ where \f$\mu=\frac 1 n\sum_{i=1}^nx_i\f$ along an arbitrary dimension
+ *
+ * \param x The input mini-batched expression
+ * \param d Dimension along which to reduce
+ *
+ * \return A scalar expression (with a potential batch dimension)
+ */
+Expression std_dim(const Expression& x, unsigned d);
+
+/**
+ * \ingroup flowoperations
+ * \brief Compute moment along a specific dimension
+ * \details Compute the moment of order \f$r\f$, \f$\frac 1 n\sum_{i=1}^nx_i^r\f$ along a specific dimension
+ *
+ * \param x The input mini-batched expression
+ * \param d Dimension along which to reduce
+ * \param r Order of the moment
+ *
+ * \return An expression with one less dimension
+ */
+Expression moment_dim(const Expression& x, unsigned d, unsigned r);
+/**
+ * \ingroup flowoperations
+ * \brief Compute mean along  a specific dimension
+ * \details Computes \f$\frac 1 n\sum_{i=1}^nx_i\f$ along a specific dimension
+ *
+ * \param x The input mini-batched expression
+ * \param d Dimension along which to reduce
+ *
+ * \return An expression with one less dimension
+ */
+Expression mean_dim(const Expression& x, unsigned d);
+
+
+/**
+ * \ingroup flowoperations
  * \brief Pick element
  * \details Pick a single element/row/column/sub-tensor from an expression.
  *          This will result in the dimension of the tensor being reduced
@@ -1583,6 +1689,7 @@ Expression max_dim(const Expression& x, unsigned d = 0);
  * \return An expression of sub-tensor with min value along dimension d
  */
 Expression min_dim(const Expression& x, unsigned d = 0);
+
 
 ////////////////////////////////////////////////
 // Noise operations                           //

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -319,6 +319,84 @@ Dim SumBatches::dim_forward(const vector<Dim>& xs) const {
   return xs[0].single_batch();
 }
 
+string MomentElements::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "moment_elems( expression=" << arg_names[0] << ", order=" << order << " )";
+  return s.str();
+}
+
+Dim MomentElements::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in MomentElements")
+  DYNET_ARG_CHECK(order>= 1, "Order of moment should be >=1 in MomentElements (recieved "<<order<<")")
+  return Dim({1}, xs[0].bd);
+}
+
+string MomentBatches::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "moment_batches( expression=" << arg_names[0] << ", order=" << order << " )";
+  return s.str();
+}
+
+Dim MomentBatches::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in MomentBatches")
+  DYNET_ARG_CHECK(order>= 1, "Order of moment should be >=1 in MomentBatches (recieved "<<order<<")")
+  return xs[0].single_batch();
+}
+
+string StdElements::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "std_elems( expression=" << arg_names[0] << " )";
+  return s.str();
+}
+
+Dim StdElements::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in StdElements")
+  return Dim({1}, xs[0].bd);
+}
+
+string StdBatches::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "std_batches( expression=" << arg_names[0] << " )";
+  return s.str();
+}
+
+Dim StdBatches::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in StdBatches")
+ 
+  return xs[0].single_batch();
+}
+
+string StdDimension::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "moment_dim(expression=" << arg_names[0] << ',' << dimension <<'}';
+  return s.str();
+}
+
+Dim StdDimension::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in StdDimension");
+  DYNET_ARG_CHECK(xs[0].nd <= 3, "StdDimension implemented up to tensors of order 3 (with minibatch) for now")
+  DYNET_ARG_CHECK(dimension < xs[0].nd, "dimension " << dimension << " is out of bounds of tensor of order " << xs[0].nd << " in StdDimension" )
+  Dim ret(xs[0]);
+  ret.delete_dim(dimension);
+  return ret;
+}
+
+string MomentDimension::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "moment_dim(expression=" << arg_names[0] << ',' << dimension << ", order="<<order<<'}';
+  return s.str();
+}
+
+Dim MomentDimension::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ASSERT(xs.size() == 1, "Failed input count check in MomentDimension");
+  DYNET_ARG_CHECK(xs[0].nd <= 3, "MomentDimension implemented up to tensors of order 3 (with minibatch) for now")
+  DYNET_ARG_CHECK(dimension < xs[0].nd, "dimension " << dimension << " is out of bounds of tensor of order " << xs[0].nd << " in MomentDimension" )
+  DYNET_ARG_CHECK(order>= 1, "Order of moment should be >=1 in MomentDimension (recieved "<<order<<")")
+  Dim ret(xs[0]);
+  ret.delete_dim(dimension);
+  return ret;
+}
+
 string Average::as_string(const vector<string>& arg_names) const {
   ostringstream s;
   s << "average(" << arg_names[0];
@@ -900,6 +978,18 @@ Dim SquaredNorm::dim_forward(const vector<Dim>& xs) const {
   DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in SquaredNorm")
   return Dim({1}, xs[0].bd);
 }
+
+string L2Norm::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "|| " << arg_names[0] << " ||";
+  return s.str();
+}
+
+Dim L2Norm::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in L2Norm")
+  return Dim({1}, xs[0].bd);
+}
+
 
 string SquaredEuclideanDistance::as_string(const vector<string>& arg_names) const {
   ostringstream s;

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -428,6 +428,57 @@ struct SumBatches : public Node {
   virtual bool supports_multibatch() const override { return true; }
 };
 
+// y = \sum_i,j,... x[i,j,...]
+struct StdElements : public Node {
+  template <typename T> explicit StdElements(const T& a) : Node(a) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+};
+
+// y = \sum_i x_i
+struct StdBatches : public Node {
+  template <typename T> explicit StdBatches(const T& a) : Node(a) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+};
+
+//y = \sum_i x_i
+struct StdDimension : public Node {
+  template <typename T> explicit StdDimension(const T& a, unsigned d) : Node(a), dimension(d) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+private:
+  unsigned dimension;
+};
+
+// y = \sum_i,j,... x[i,j,...]
+struct MomentElements : public Node {
+  template <typename T> explicit MomentElements(const T& a, unsigned o) : Node(a), order(o) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+private:
+  unsigned order;
+};
+
+// y = \sum_i x_i
+struct MomentBatches : public Node {
+  template <typename T> explicit MomentBatches(const T& a, unsigned o) : Node(a), order(o) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+private:
+  unsigned order;
+};
+
+//y = \sum_i x_i
+struct MomentDimension : public Node {
+  template <typename T> explicit MomentDimension(const T& a, unsigned d, unsigned o) : Node(a), dimension(d), order(o) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+private:
+  unsigned dimension;
+  unsigned order;
+};
+
 // y = ( \sum_i x_i ) / |x|
 struct Average : public Node {
   template <typename T> explicit Average(const T& a) : Node(a) {}
@@ -454,6 +505,13 @@ struct PoissonRegressionLoss : public Node {
 // y = || x_1 ||^2
 struct SquaredNorm : public Node {
   explicit SquaredNorm(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  virtual bool supports_multibatch() const override { return true; }
+  DYNET_NODE_DEFINE_DEV_IMPL()
+};
+
+// y = || x_1 ||
+struct L2Norm : public Node {
+  explicit L2Norm(const std::initializer_list<VariableIndex>& a) : Node(a) {}
   virtual bool supports_multibatch() const override { return true; }
   DYNET_NODE_DEFINE_DEV_IMPL()
 };

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -358,6 +358,15 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
 
     CExpression c_sum_batches "dynet::expr::sum_batches" (CExpression& x) except +
     CExpression c_sum_elems "dynet::expr::sum_elems" (CExpression& x) except +
+    CExpression c_moment_batches "dynet::expr::moment_batches" (CExpression& x, unsigned r) except +
+    CExpression c_moment_elems "dynet::expr::moment_elems" (CExpression& x, unsigned r) except +
+    CExpression c_moment_dim "dynet::expr::moment_dim" (CExpression& x, unsigned d, unsigned r) except +
+    CExpression c_mean_elems "dynet::expr::mean_elems" (CExpression& x) except +
+    CExpression c_mean_batches "dynet::expr::mean_batches" (CExpression& x) except +
+    CExpression c_mean_dim "dynet::expr::mean_dim" (CExpression& x, unsigned d) except +
+    CExpression c_std_dim "dynet::expr::std_dim" (CExpression& x, unsigned d) except +
+    CExpression c_std_elems "dynet::expr::std_elems" (CExpression& x) except +
+    CExpression c_std_batches "dynet::expr::std_batches" (CExpression& x) except +
 
     #CExpression c_pick "dynet::expr::pick" (CExpression& x, unsigned v) except +   #
     CExpression c_select_rows "dynet::expr::select_rows" (CExpression& x, vector[unsigned] rs) except +

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -2466,6 +2466,136 @@ cpdef Expression sum_batches(Expression x):
     """
     return Expression.from_cexpr(x.cg_version, c_sum_batches(x.c()))
 
+cpdef Expression mean_elems(Expression x):
+    """Mean of elements of the tensor
+    
+    Computes the mean :math:`\\frac 1 n \sum_ix_i` of all the elements of each minibatch.
+
+    Args:
+        x (dynet.Expression): Input expression
+    
+    Returns:
+        dynet.Expression: A scalar expression (minibatched)
+    """
+    return Expression.from_cexpr(x.cg_version, c_mean_elems(x.c()))
+
+cpdef Expression mean_batches(Expression x):
+    """Mean along the batch dimension
+    
+    Computes the mean :math:`\\frac 1 n \sum_ix_i`  along the batch dimension.
+
+
+    Args:
+        x (dynet.Expression): Input expression
+    
+    Returns:
+        dynet.Expression: An expression with a single batch
+    """
+    return Expression.from_cexpr(x.cg_version, c_mean_batches(x.c()))
+
+cpdef Expression std_elems(Expression x):
+    """Standard deviation of elements of the tensor
+    
+    Computes the standard deviation :math:`\sigma=\sqrt{\\frac 1 n \sum_i(x_i-\mu)^2}`of all the elements of each minibatch.
+
+    Args:
+        x (dynet.Expression): Input expression
+    
+    Returns:
+        dynet.Expression: A scalar expression (minibatched)
+    """
+    return Expression.from_cexpr(x.cg_version, c_std_elems(x.c()))
+
+cpdef Expression std_batches(Expression x):
+    """Standard deviation along the batch dimension
+    
+    Computes the standard deviation :math:`\sigma=\sqrt{\\frac 1 n \sum_i(x_i-\mu)^2}`  along the batch dimension.
+
+
+    Args:
+        x (dynet.Expression): Input expression
+    
+    Returns:
+        dynet.Expression: An expression with a single batch
+    """
+    return Expression.from_cexpr(x.cg_version, c_std_batches(x.c()))
+
+cpdef Expression std_dim(Expression x, unsigned d):
+    """Standard deviation along an arbitrary dimension
+    
+    Computes the standard deviation :math:`\sigma=\sqrt{\\frac 1 n \sum_i(x_i-\mu)^2}` along an arbitrary dimension.
+
+
+    Args:
+        x (dynet.Expression): Input expression
+        d (int): Dimension along which to reduce
+    
+    Returns:
+        dynet.Expression: An expression with one less dimension
+    """
+    return Expression.from_cexpr(x.cg_version, c_std_dim(x.c(), d))
+
+
+cpdef Expression mean_dim(Expression x, unsigned d):
+    """Mean along an arbitrary dimension
+    
+    Computes the mean :math:`\\frac 1 n \sum_ix_i`  along an arbitrary dimension.
+
+
+    Args:
+        x (dynet.Expression): Input expression
+        d (int): Dimension along which to reduce
+    
+    Returns:
+        dynet.Expression: An expression with one less dimension
+    """
+    return Expression.from_cexpr(x.cg_version, c_mean_dim(x.c(), d))
+
+cpdef Expression moment_elems(Expression x, unsigned r):
+    """Statistical moment of elements of the tensor
+    
+    Computes the statistical moment of order :math:`r`, :math:`\\frac 1 n \sum_ix_i^r` of all the elements of each minibatch.
+
+    Args:
+        x (dynet.Expression): Input expression
+        r (int): Moment order
+    
+    Returns:
+        dynet.Expression: A scalar expression (minibatched)
+    """
+    return Expression.from_cexpr(x.cg_version, c_moment_elems(x.c(), r))
+
+cpdef Expression moment_batches(Expression x, unsigned r):
+    """Statistical moment along the batch dimension
+    
+    Computes the statistical moment of order :math:`r`, :math:`\\frac 1 n \sum_ix_i^r`  along the batch dimension.
+
+
+    Args:
+        x (dynet.Expression): Input expression
+        r (int): Moment order
+    
+    Returns:
+        dynet.Expression: An expression with a single batch
+    """
+    return Expression.from_cexpr(x.cg_version, c_moment_batches(x.c(), r))
+
+cpdef Expression moment_dim(Expression x, unsigned d, unsigned r):
+    """Statistical moment along an arbitrary dimension
+    
+    Computes the statistical moment of order :math:`r`, :math:`\\frac 1 n \sum_ix_i^r`  along an arbitrary dimension.
+
+
+    Args:
+        x (dynet.Expression): Input expression
+        d (int): Dimension along which to reduce
+        r (int): Moment order
+    
+    Returns:
+        dynet.Expression: An expression with one less dimension
+    """
+    return Expression.from_cexpr(x.cg_version, c_moment_dim(x.c(), d, r))
+
 #expr-opt
 cpdef Expression fold_rows(Expression x, unsigned nrows=2):
     """[summary]

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1329,6 +1329,112 @@ BOOST_AUTO_TEST_CASE( pickneglogsoftmax_batch_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+
+// Expression sum_elems(x);
+BOOST_AUTO_TEST_CASE( sum_elems_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x = parameter(cg, param4);
+  Expression z = sum_elems(x);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression mean_elems(x);
+BOOST_AUTO_TEST_CASE( mean_elems_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x = parameter(cg, param4);
+  Expression z = mean_elems(x);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression moment_elems(x, r);
+BOOST_AUTO_TEST_CASE( moment_elems_gradient ) {
+  for (unsigned r=2;r<5;r++){
+    dynet::ComputationGraph cg;
+    Expression x = parameter(cg, param4);
+    Expression z = moment_elems(x, r);
+    BOOST_CHECK(check_grad(mod, z, 0));
+  }
+}
+
+// Expression std_elems(x);
+BOOST_AUTO_TEST_CASE( std_elems_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x = parameter(cg, param4);
+  Expression z = std_elems(x);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression sum_batches(x);
+BOOST_AUTO_TEST_CASE( sum_batches_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x = parameter(cg, param4);
+  Expression y = reshape(x, Dim({1}, 6));
+  Expression z = sum_batches(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression mean_batches(x);
+BOOST_AUTO_TEST_CASE( mean_batches_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x = parameter(cg, param4);
+  Expression y = reshape(x, Dim({1}, 6));
+  Expression z = mean_batches(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression moment_batches(x, r);
+BOOST_AUTO_TEST_CASE( moment_batches_gradient ) {
+  for (unsigned r=2;r<5;r++){
+    dynet::ComputationGraph cg;
+    Expression x = parameter(cg, param4);
+    Expression y = reshape(x, Dim({1}, 6));
+    Expression z = moment_batches(y, r);
+    BOOST_CHECK(check_grad(mod, z, 0));
+  }
+}
+
+// Expression std_batches(x);
+BOOST_AUTO_TEST_CASE( std_batches_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x = parameter(cg, param4);
+  Expression y = reshape(x, Dim({1}, 6));
+  Expression z = std_batches(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression mean_dim(x);
+BOOST_AUTO_TEST_CASE( mean_dim_gradient ) {
+  dynet::ComputationGraph cg;
+    Expression x = parameter(cg, param_cube1);
+    Expression z = x;
+    for (unsigned d=3;d>0;d--)
+      z = mean_dim(z, d - 1);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression moment_dim(x, r);
+BOOST_AUTO_TEST_CASE( moment_dim_gradient ) {
+  for (unsigned r=2;r<5;r++){
+    dynet::ComputationGraph cg;
+    Expression x = parameter(cg, param_cube1);
+    Expression z = x;
+    for (unsigned d=3;d>0;d--)
+      z = moment_dim(z, d - 1, r);
+    BOOST_CHECK(check_grad(mod, z, 0));
+  }
+}
+
+// Expression mean_dim(x);
+BOOST_AUTO_TEST_CASE( std_dim_gradient ) {
+  dynet::ComputationGraph cg;
+    Expression x = parameter(cg, param_cube1);
+    Expression z = x;
+    for (unsigned d=3;d>0;d--)
+      z = std_dim(z, d - 1);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+
 // Expression layer_norm(x,g,b);
 BOOST_AUTO_TEST_CASE( layer_norm_backward_gradient ) {
   dynet::ComputationGraph cg;
@@ -1341,7 +1447,7 @@ BOOST_AUTO_TEST_CASE( layer_norm_backward_gradient ) {
 }
 
 // Expression layer_norm(x,g,b);
-BOOST_AUTO_TEST_CASE( layer_norm_forward_gradient ) {
+BOOST_AUTO_TEST_CASE( layer_norm_forward ) {
   dynet::ComputationGraph cg;
   Expression x = parameter(cg, param1);
   Expression g = input(cg, Dim({3}), ones3_vals);


### PR DESCRIPTION
Adds a whole bunch of expressions to compute statistical moments : 

- `moment_dim` / `moment_elems` / `moment_batches` (moments of arbitrary orders)
- `mean_dim` / `mean_elems` / `mean_batches` (mean)
- `std_dim` / `std_elems` / `std_batches` (standard deviation)

Also refactors the code of `layer_norm` to have less expressions.

Tests, docs and python bindings included