### PR TITLE
Add dropout along one dimension

### DIFF
--- a/doc/source/python_ref.rst
+++ b/doc/source/python_ref.rst
@@ -289,6 +289,8 @@ Noise operations
 
 .. autofunction:: dynet.dropout
 
+.. autofunction:: dynet.dropout_dim
+
 .. autofunction:: dynet.block_dropout
 
 Linear algebra operations

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -101,6 +101,7 @@ Expression min(const Expression& x, const Expression& y) { return Expression(x.p
 Expression max(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Max>({x.i, y.i})); }
 Expression noise(const Expression& x, real stddev) { return Expression(x.pg, x.pg->add_function<GaussianNoise>({x.i}, stddev)); }
 Expression dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<Dropout>({x.i}, p)); }
+Expression dropout_dim(const Expression& x, unsigned d, real p) { return Expression(x.pg, x.pg->add_function<DropoutDim>({x.i}, d, p)); }
 Expression block_dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<BlockDropout>({x.i}, p)); }
 
 Expression reshape(const Expression& x, const Dim& d) { return Expression(x.pg, x.pg->add_function<Reshape>({x.i}, d)); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1733,6 +1733,21 @@ Expression dropout(const Expression& x, real p);
 
 /**
  * \ingroup noiseoperations
+ * \brief Dropout along a specific dimension
+ * \details Identical to the dropout operation except the dropout mask is the same across one dimension. Use this if you want to drop columns or lines in a matrix for example 
+ * 
+ * For now this only supports tensors of order <= 3 (with or without batch dimension)
+ *
+ * \param x The input expression
+ * \param d The dimension along which to drop
+ * \param p The dropout probability
+ *
+ * \return The dropped out expression
+ */
+Expression dropout_dim(const Expression& x, unsigned d, real p);
+
+/**
+ * \ingroup noiseoperations
  * \brief Block dropout
  * \details Identical to the dropout operation, but either drops out *all*
  *          or *no* values in the expression, as opposed to making a decision

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -224,6 +224,19 @@ Dim Dropout::dim_forward(const vector<Dim>& xs) const {
   return xs[0];
 }
 
+string DropoutDim::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "dropout_dim(" << arg_names[0] << ",p=" << p << ')';
+  return s.str();
+}
+
+Dim DropoutDim::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in DropoutDim")
+  DYNET_ARG_CHECK(xs[0].nd < 4, "DropoutDim only supports tensor up to order 3 + batch dimension, got tensor of order"<<xs[0].nd)
+  DYNET_ARG_CHECK(xs[0].nd > dimension, "In DropoutDim : tried to drop along dimension "<<dimension<<" on tensor of order"<<xs[0].nd)
+  return xs[0];
+}
+
 string BlockDropout::as_string(const vector<string>& arg_names) const {
   ostringstream s;
   s << "block_dropout(" << arg_names[0] << ",dropout_probability=" << dropout_probability << ')';

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -152,6 +152,16 @@ struct Dropout : public Node {
   real p;
 };
 
+// y = dropout(x,p) where p specifies the dropout probability
+struct DropoutDim : public Node {
+  explicit DropoutDim(const std::initializer_list<VariableIndex>& a, unsigned d,real p) : Node(a), dimension(d), p(p) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  size_t aux_storage_size() const override;
+  virtual bool supports_multibatch() const override { return true; }
+  unsigned dimension;
+  real p;
+};
+
 // y = block_dropout(x,p) where p specifies the probability for dropping-out the entire block
 struct BlockDropout : public Node {
   explicit BlockDropout(const std::initializer_list<VariableIndex>& a, real p) : Node(a), dropout_probability(p) {}

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -328,6 +328,7 @@ cdef extern from "dynet/expr.h" namespace "dynet::expr":
     CExpression c_bmax "dynet::expr::max" (CExpression& x, CExpression& y) except + #
     CExpression c_noise "dynet::expr::noise" (CExpression& x, float stddev) except + #
     CExpression c_dropout "dynet::expr::dropout" (CExpression& x, float p) except + #
+    CExpression c_dropout_dim "dynet::expr::dropout_dim" (CExpression& x, unsigned d, float p) except + #
     CExpression c_block_dropout "dynet::expr::block_dropout" (CExpression& x, float p) except + #
 
     CExpression c_reshape "dynet::expr::reshape" (CExpression& x, CDim& d) except + #?

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -2869,12 +2869,31 @@ cpdef Expression dropout(Expression x, float p):
     
     Args:
         x (dynet.Expression): Input expression
-        p (dynet.Expression): The dropout probability
+        p (number): The dropout probability
     
     Returns:
         dynet.Expression: The dropped out expression :math:`y=\\frac{1}{1-\\texttt{p}}x\circ z, z\sim\\text{Bernoulli}(1-\\texttt{p})`
     """
     return Expression.from_cexpr(x.cg_version, c_dropout(x.c(), p))
+
+
+cpdef Expression dropout_dim(Expression x, unsigned d, float p):
+    """Dropout along one dimension
+    
+    Identical to the dropout operation except the dropout mask is the same across one dimension. Use this if you want to drop columns or lines in a matrix for example 
+
+    For now this only supports tensors of order <= 3 (with or without batch dimension)
+
+    Args:
+        x (dynet.Expression): Input expression
+        d (int): Dimension along which to drop
+        p (number): The dropout probability
+    
+    Returns:
+        dynet.Expression: The dropped expression
+    """
+    return Expression.from_cexpr(x.cg_version, c_dropout_dim(x.c(), d, p))
+
 cpdef Expression block_dropout(Expression x, float p):
     """Block dropout
     
@@ -2882,7 +2901,7 @@ cpdef Expression block_dropout(Expression x, float p):
     
     Args:
         x (dynet.Expression): Input expression
-        p (dynet.Expression): The dropout probability
+        p (number): The dropout probability
     
     Returns:
         dynet.Expression: The block dropout expression

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -807,24 +807,34 @@ BOOST_AUTO_TEST_CASE( max_gradient ) {
 }
 
 // TODO: Noise is random, so it cannot be tested simply?
-// // Expression noise(const Expression& x, real stddev);
-// BOOST_AUTO_TEST_CASE( noise_gradient ) {
-//   dynet::ComputationGraph cg;
-//   Expression x1 = parameter(cg, param1);
-//   Expression y = noise(x1, 0.5);
-//   Expressionz z = sum_elems(y);
-//   BOOST_CHECK(check_grad(mod, z, 0));
-// }
+// Expression noise(const Expression& x, real stddev);
+BOOST_AUTO_TEST_CASE( noise_forward ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression y = noise(x1, 0.5);
+  Expression z = sum_elems(y);
+  cg.forward(z);
+}
 
-// TODO: Dropout scales the gradients at training time, so they don't match.
-// // Expression dropout(const Expression& x, real p);
-// BOOST_AUTO_TEST_CASE( dropout_gradient ) {
-//   dynet::ComputationGraph cg;
-//   Expression x1 = parameter(cg, param1);
-//   Expression y = dropout(x1, 0.5);
-//   Expression z = sum_elems(y);
-//   BOOST_CHECK(check_grad(mod, z, 0));
-// }
+//TODO: Dropout scales the gradients at training time, so they don't match.
+// Expression dropout(const Expression& x, real p);
+BOOST_AUTO_TEST_CASE( dropout_forward ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression y = dropout(x1, 0.5);
+  Expression z = sum_elems(y);
+  cg.forward(z);
+}
+
+BOOST_AUTO_TEST_CASE( dropout_dim_forward ) {
+    for (unsigned d=0;d<3;d++){
+      dynet::ComputationGraph cg;
+      Expression x = parameter(cg, param_cube1);
+      Expression y = dropout_dim(x, d, 0.5);
+      Expression z = sum_elems(y);
+      cg.forward(z);
+    }
+}
 
 // TODO: Dropout scales the gradients at training time, so they don't match.
 // Expression block_dropout(const Expression& x, real p);


### PR DESCRIPTION
This allows to drop along one dimension, ie to use the same dropout mask along this dimension.

This is useful if one wants to drop rows/columns in a matrix for instance.

I also reactivated tests for the noise operations, right now the tests just run a forward pass to detect bugs.

Tests+doc+python bindings