### PR TITLE
minor fixes to example python code

### DIFF
--- a/examples/python/cpu_vs_gpu.py
+++ b/examples/python/cpu_vs_gpu.py
@@ -1,6 +1,8 @@
 import _gdynet as G
-print()
 import _dynet as C
+
+G.init()
+C.init()
 
 cm = C.Model()
 gm = G.Model()

--- a/examples/python/xor.py
+++ b/examples/python/xor.py
@@ -38,13 +38,13 @@ for iter in range(ITERATIONS):
     mloss = 0.0
     for mi in range(4):
         x1 = mi % 2
-        x2 = (mi / 2) % 2
+        x2 = (mi // 2) % 2
         x.set([T if x1 else F, T if x2 else F])
         y.set(T if x1 != x2 else F)
         mloss += loss.scalar_value()
         loss.backward()
         sgd.update(1.0)
-    sgd.update_epoch();
+    sgd.update_epoch()
     mloss /= 4.
     print("loss: %0.9f" % mloss)
 


### PR DESCRIPTION
xor.py - division in python3 turns int to float leading to incorrect xor training example 
cpu_vs_gpu.py - segmentation fault occurs when importing _dynet directly and not calling init()
