### PR TITLE
Add Eigen note for sudo-less installation

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -28,21 +28,12 @@ get Boost, CMake, and Mercurial with either homebrew or macports:
 To compile DyNet you also need the `development version of the Eigen
 library <https://bitbucket.org/eigen/eigen>`__. **If you use any of the
 released versions, you may get assertion failures or compile errors.**
-If you have sudo access and don't have Eigen installed already, you can 
-get it easily using the following command:
+If you don't have Eigen already, you can get it easily using the
+following command:
 
 ::
 
     hg clone https://bitbucket.org/eigen/eigen/ -r 346ecdb
-    cd eigen
-    mkdir build && cd build
-    cmake ..
-    make install # sudo permissions might be necessary on Linux.
-    cd ../..
-    
-If you don't have sudo access, clone the Eigen repository but don't attempt
-to build or install; this is `sufficient <https://eigen.tuxfamily.org/dox/
-GettingStarted.html>`__ for DyNet. 
     
 The `-r NUM` specified a revision number that is known to work.  Adventurous
 users can remove it and use the very latest version, at the risk of the code

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -28,8 +28,8 @@ get Boost, CMake, and Mercurial with either homebrew or macports:
 To compile DyNet you also need the `development version of the Eigen
 library <https://bitbucket.org/eigen/eigen>`__. **If you use any of the
 released versions, you may get assertion failures or compile errors.**
-If you have sudo access and don't have Eigen installed already, you can get it easily using
-the following command:
+If you have sudo access and don't have Eigen installed already, you can 
+get it easily using the following command:
 
 ::
 
@@ -41,7 +41,8 @@ the following command:
     cd ../..
     
 If you don't have sudo access, clone the Eigen repository but don't attempt
-to build or install; this is `sufficient <https://eigen.tuxfamily.org/dox/GettingStarted.html>`__ for DyNet. 
+to build or install; this is `sufficient <https://eigen.tuxfamily.org/dox/
+GettingStarted.html>`__ for DyNet. 
     
 The `-r NUM` specified a revision number that is known to work.  Adventurous
 users can remove it and use the very latest version, at the risk of the code

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -28,7 +28,7 @@ get Boost, CMake, and Mercurial with either homebrew or macports:
 To compile DyNet you also need the `development version of the Eigen
 library <https://bitbucket.org/eigen/eigen>`__. **If you use any of the
 released versions, you may get assertion failures or compile errors.**
-If you don't have Eigen installed already, you can get it easily using
+If you have sudo access and don't have Eigen installed already, you can get it easily using
 the following command:
 
 ::
@@ -39,6 +39,9 @@ the following command:
     cmake ..
     make install # sudo permissions might be necessary on Linux.
     cd ../..
+    
+If you don't have sudo access, clone the Eigen repository but don't attempt
+to build or install; this is `sufficient <https://eigen.tuxfamily.org/dox/GettingStarted.html>`__ for DyNet. 
     
 The `-r NUM` specified a revision number that is known to work.  Adventurous
 users can remove it and use the very latest version, at the risk of the code


### PR DESCRIPTION
Using/Installing DyNet without sudo is possible if one does not have to install Eigen. 
This was of use to me, and may be of use to others using academic grids with possibly slow sysadmin response.
Eigen does not need to be installed; the repository need only be cloned.
As for testing, I at least, have not run into any problems with this.

https://eigen.tuxfamily.org/dox/GettingStarted.html/