### PR TITLE
autobatch debug info, batch scalar_mult

### DIFF
--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -575,6 +575,17 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
       }
     }
 
+    // 2.5 print some debug info
+    if (autobatch_debug_flag) {
+      cout << "Forward Call" << endl;
+      for(VariableIndex bid = num_batches_evaluated; bid < batch_id; ++bid) {
+        auto & batch_ids = batches[bid].ids;
+        VariableIndex curr_node = batch_ids[0];
+        const Node* node = cg.nodes[curr_node];
+        cout << "BatchSize:" << batch_ids.size() << " " << node->as_dummy_string() << endl;
+      }
+    }
+
     // 3. Based on the batches, allocate the memory, etc
     for(VariableIndex bid = num_batches_evaluated; bid < batch_id; ++bid) {
 

--- a/dynet/globals.cc
+++ b/dynet/globals.cc
@@ -7,6 +7,7 @@ std::mt19937* rndeng = nullptr;
 std::vector<Device*> devices;
 Device* default_device = nullptr;
 float weight_decay_lambda;
-int autobatch_flag;
+int autobatch_flag; 
+int autobatch_debug_flag = 0;
 
 }

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -17,7 +17,7 @@ using namespace std;
 
 namespace dynet {
 
-DynetParams::DynetParams() : random_seed(0), mem_descriptor("512"), weight_decay(0), autobatch(0),
+DynetParams::DynetParams() : random_seed(0), mem_descriptor("512"), weight_decay(0), autobatch(0), autobatch_debug(0),
   shared_parameters(false)
 #if HAVE_CUDA
   , ngpus_requested(false), ids_requested(false), requested_gpus(-1)
@@ -94,6 +94,10 @@ DynetParams extract_dynet_params(int& argc, char**& argv, bool shared_parameters
         istringstream c(a2); c >> params.autobatch;
         remove_args(argc, argv, argi, 2);
       }
+    }
+    else if (arg == "--dynet-autobatch-debug" || arg == "--dynet_autobatch_debug") {
+      params.autobatch_debug = 1;
+        remove_args(argc, argv, argi, 1);
     }
 
 #if HAVE_CUDA
@@ -189,6 +193,7 @@ void initialize(DynetParams& params) {
 
   // Set autobatch
   autobatch_flag = params.autobatch;
+  autobatch_debug_flag = params.autobatch_debug;
 
   // Allocate memory
   cerr << "[dynet] allocating memory: " << params.mem_descriptor << "MB\n";

--- a/dynet/init.h
+++ b/dynet/init.h
@@ -8,6 +8,7 @@ namespace dynet {
 
 extern float weight_decay_lambda;
 extern int autobatch_flag;
+extern int autobatch_debug_flag;
 
 /**
  * \brief Represents general parameters for dynet
@@ -20,6 +21,7 @@ struct DynetParams {
   std::string mem_descriptor = "512"; /**< Total memory to be allocated for Dynet */
   float weight_decay = 0; /**< Weight decay rate for L2 regularization */
   int autobatch = 1; /**< Whether to autobatch or not */
+  int autobatch_debug = 0; /**< Whether to show autobatch debug info or not */
   bool shared_parameters = false; /**< TO DOCUMENT */
   bool ngpus_requested = false; /**< GPUs requested by number */
   bool ids_requested = false; /**< GPUs requested by ids */

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -670,6 +670,15 @@ Dim Softmax::dim_forward(const vector<Dim>& xs) const {
   return xs[0];
 }
 
+int Softmax::autobatch_sig(const ComputationGraph & cg, SigMap &sm) const {
+  Sig s(nt::softmax);
+  s.add_dim(dim);
+  return sm.get_idx(s);
+}
+std::vector<int> Softmax::autobatch_concat(const ComputationGraph & cg) const {
+  return vector<int>(1, 1);
+}
+
 string SoftSign::as_string(const vector<string>& arg_names) const {
   ostringstream s;
   s << "softsign(" << arg_names[0] << ')';

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -652,6 +652,15 @@ struct Softmax : public Node {
   DYNET_NODE_DEFINE_DEV_IMPL()
   size_t aux_storage_size() const override;
   virtual bool supports_multibatch() const override { return true; }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override;
+  virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override;
+  virtual void autobatch_reshape(const ComputationGraph & cg,
+                                 const std::vector<VariableIndex> & batch_ids,
+                                 const std::vector<int> & concat,
+                                 std::vector<const Tensor*>& xs,
+                                 Tensor& fx) const override {
+    autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
+  }
 };
 
 // z = \sum_j \exp (x_i)_j

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -97,6 +97,8 @@ struct TraceOfProduct : public Node {
 struct ConstScalarMultiply : public Node {
   explicit ConstScalarMultiply(const std::initializer_list<VariableIndex>& a, float alpha) : Node(a), alpha(alpha) {}
   virtual bool supports_multibatch() const override { return true; }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::scalar_mult); s.add_node(alpha); return sm.get_idx(s); }
+  virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }
   DYNET_NODE_DEFINE_DEV_IMPL()
   float alpha;
 };

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -97,7 +97,7 @@ struct TraceOfProduct : public Node {
 struct ConstScalarMultiply : public Node {
   explicit ConstScalarMultiply(const std::initializer_list<VariableIndex>& a, float alpha) : Node(a), alpha(alpha) {}
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::scalar_mult); s.add_node(alpha); return sm.get_idx(s); }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::scalar_mult); s.add_node(*((int*)&alpha)); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }
   DYNET_NODE_DEFINE_DEV_IMPL()
   float alpha;
@@ -186,7 +186,7 @@ struct BlockDropout : public Node {
 struct ConstantPlusX : public Node {
   explicit ConstantPlusX(const std::initializer_list<VariableIndex>& a, real o) : Node(a), c(o) {}
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::plus_const); s.add_node(c); return sm.get_idx(s); }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::plus_const); s.add_node(*((int*)&c)); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }  
   DYNET_NODE_DEFINE_DEV_IMPL()
   real c;

--- a/dynet/sig.h
+++ b/dynet/sig.h
@@ -11,8 +11,8 @@ namespace dynet {
   namespace nt {
     enum NodeType { 
       tanh=1, sqrt, abs, erf, square, cube, exp, loggamma, log, nobackprop, flipgradient, identity, negate, rectify, logistic, softsign,
-      plus_const, concat, cmult, sum, squared_distance, pnls, pickrange,
-      input, scalar_input, lookup,
+      plus_const, concat, cmult, sum, squared_distance, pnls, pickrange, scalar_mult,
+      input, scalar_input, lookup, 
       COMPLEX,
       affine, matmul,
     };

--- a/dynet/sig.h
+++ b/dynet/sig.h
@@ -11,7 +11,7 @@ namespace dynet {
   namespace nt {
     enum NodeType { 
       tanh=1, sqrt, abs, erf, square, cube, exp, loggamma, log, nobackprop, flipgradient, identity, negate, rectify, logistic, softsign,
-      plus_const, concat, cmult, sum, squared_distance, pnls, pickrange, scalar_mult,
+      plus_const, concat, cmult, sum, squared_distance, softmax, pnls, pickrange, scalar_mult,
       input, scalar_input, lookup, 
       COMPLEX,
       affine, matmul,


### PR DESCRIPTION
Prints out batching behavior (which operations are being batched, and batch sizes) when requested by the `--dynet-autobatch-debug` flag.

(also, added batching support for ScalarMultiply)