### PR TITLE
Notify when autobatching is used by Dynet

### DIFF
--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -192,7 +192,12 @@ void initialize(DynetParams& params) {
   weight_decay_lambda = params.weight_decay;
 
   // Set autobatch
+  if(params.autobatch)
+    cerr << "[dynet] using autobatching" << endl;
   autobatch_flag = params.autobatch;
+  
+  if(params.autobatch_debug)
+    cerr << "[dynet] using autobatching debugging" << endl;
   autobatch_debug_flag = params.autobatch_debug;
 
   // Allocate memory


### PR DESCRIPTION
Small quality of life change : the initialization message now prints `[dynet] using autobatching` when autobatching is set to 1.

Same for autobatch_debug