### PR TITLE
Autobatch test failing on GPU

### DIFF
--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -269,7 +269,7 @@ void BatchedExecutionEngine::accumulate_tensors(const Tensor& tin, std::vector<V
   float* src = tin.v;
   // copy
   for (auto id : batch_ids) {
-    const size_t sz = node2size[id];
+    const size_t sz = node2size[cg.nodes[id]->args[ai]];
 
     locs[i] = src; // src
     locs[i+TRG] = ndEdfs[cg.nodes[id]->args[ai]].v;

--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -271,9 +271,8 @@ void BatchedExecutionEngine::accumulate_tensors(const Tensor& tin, std::vector<V
   for (auto id : batch_ids) {
     const size_t sz = node2size[id];
 
-    float* my_trg = batches[node2batch[id]].nfx.v + node2offset[id];
     locs[i] = src; // src
-    locs[i+TRG] = my_trg;
+    locs[i+TRG] = ndEdfs[cg.nodes[id]->args[ai]].v;
     locs[i+LEN] = (float*)sz;
     if (max_length < sz) max_length = sz;
     i++;

--- a/dynet/gpu-ops.cu
+++ b/dynet/gpu-ops.cu
@@ -110,7 +110,7 @@ __global__ void ker_parallel_accumulate(int num_seqs, float **src, float **trg, 
   int seq_id = id % num_seqs;
   int i = id / num_seqs;
   if (i < (unsigned long)len[seq_id])
-    trg[seq_id][i] += src[seq_id][i];
+    atomicAdd(&trg[seq_id][i], src[seq_id][i]);
 
   __syncthreads();
 }

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -5,8 +5,7 @@ if (NOT MSVC)
 endif()
 
 
-# foreach(FOLDER encdec mlc mnist tok-embed poisson-regression tag-bilstm embed-cl xor xor-autobatch xor-xent xor-batch xor-batch-lookup rnnlm rnnlm-aevb rnnlm-cfsm rnnlm-batch nlm read-write segrnn-sup attention imdb rnnlm-batch-nce ${MP_EXAMPLES})
-foreach(FOLDER xor-autobatch rnn-autobatch)
+foreach(FOLDER encdec mlc mnist tok-embed poisson-regression tag-bilstm embed-cl xor xor-autobatch xor-xent xor-batch xor-batch-lookup rnn-autobatch rnnlm rnnlm-aevb rnnlm-cfsm rnnlm-batch nlm read-write segrnn-sup attention imdb rnnlm-batch-nce ${MP_EXAMPLES})
   set(TARGET train_${FOLDER})
   ADD_EXECUTABLE(${TARGET} cpp/${FOLDER}/${TARGET}.cc)
   if (WITH_CUDA_BACKEND)

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -16,7 +16,7 @@ struct NodeTest {
   NodeTest() {
     // initialize if necessary
     if (default_device == nullptr) {
-      for (auto x : {"NodeTest", "--dynet-mem", "100", "--dynet-autobatch", "1"}) {
+      for (auto x : {"NodeTest", "--dynet-mem", "100"}) {
         av.push_back(strdup(x));
       }
       char **argv = &av[0];

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -68,7 +68,7 @@ struct NodeTest {
     TensorTools::set_elements(lookup1.get()->all_values, param_square1_vals);
   }
   ~NodeTest() {
-    for (auto x : av) free(x);
+    // for (auto x : av) free(x);
   }
 
   template <class T>

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -16,7 +16,7 @@ struct NodeTest {
   NodeTest() {
     // initialize if necessary
     if (default_device == nullptr) {
-      for (auto x : {"NodeTest", "--dynet-mem", "100"}) {
+      for (auto x : {"NodeTest", "--dynet-mem", "100", "--dynet-autobatch", "1"}) {
         av.push_back(strdup(x));
       }
       char **argv = &av[0];

--- a/tests/test-rnn.cc
+++ b/tests/test-rnn.cc
@@ -21,7 +21,7 @@ struct RNNTest {
   RNNTest() {
     // initialize if necessary
     if (default_device == nullptr) {
-      for (auto x : {"RNNTest", "--dynet-seed", "10", "--dynet-autobatch", "1", "--dynet-mem", "10"}) {
+      for (auto x : {"RNNTest", "--dynet-seed", "10", "--dynet-mem", "10"}) {
         av.push_back(strdup(x));
       }
       char **argv = &av[0];


### PR DESCRIPTION
For some reason auto-batching has regressed and is failing tests on GPU. This fixes one bug, but there are still a few tests that are failing like the `vanilla_lstm` tests. These should be fixed ASAP. Autobatching is working fine on CPU, so it's likely something in memory copy or something.