### PR TITLE
print fw timing info on debug output

### DIFF
--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -87,7 +87,7 @@ const Tensor& SimpleExecutionEngine::incremental_forward(VariableIndex i) {
       dev->pools[(int)DeviceMempool::FXS]->free();
 
   if (i >= num_nodes_evaluated) {
-    NamedTimer timer; string current_node_name;
+    string current_node_name;
     nfxs.resize(i + 1);
 
     //vector<string> dummy(5, "x");
@@ -126,7 +126,6 @@ const Tensor& SimpleExecutionEngine::incremental_forward(VariableIndex i) {
 
       if (autobatch_debug_flag) { timer.stop(current_node_name); }
     }
-    if (autobatch_debug_flag) { cout << "Timing Info:" << endl; timer.show(); }
   }
 
   return nfxs[i];
@@ -367,7 +366,7 @@ void BatchedExecutionEngine::garbage_collect() {
 
 const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableIndex upto, int autobatch_strategy) {
   if (upto >= num_nodes_evaluated) {
-    NamedTimer timer; string current_batch_name;
+    string current_batch_name;
 
     size_t uptop1 = upto + 1;
 
@@ -746,7 +745,6 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
     }
 
     free(node2profid);
-    if (autobatch_debug_flag) { cout << "Timing Info:" << endl; timer.show(); }
   }
 
 

--- a/dynet/globals.cc
+++ b/dynet/globals.cc
@@ -1,5 +1,6 @@
 #include "dynet/globals.h"
 #include "dynet/devices.h"
+#include "dynet/timing.h"
 
 namespace dynet {
 
@@ -9,5 +10,6 @@ Device* default_device = nullptr;
 float weight_decay_lambda;
 int autobatch_flag; 
 int autobatch_debug_flag = 0;
+NamedTimer timer;
 
 }

--- a/dynet/globals.h
+++ b/dynet/globals.h
@@ -7,10 +7,12 @@
 namespace dynet {
 
 class Device;
+class NamedTimer;
 
 extern std::mt19937* rndeng;
 extern std::vector<Device*> devices;
 extern Device* default_device;
+extern NamedTimer timer; // debug timing in executors.
 
 } // namespace dynet
 

--- a/dynet/timing.h
+++ b/dynet/timing.h
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <string>
 #include <chrono>
+#include <iomanip>
 
 namespace dynet {
 
@@ -26,6 +27,15 @@ struct Timing {
   }
   void start() { _start = std::chrono::high_resolution_clock::now(); }
   std::chrono::high_resolution_clock::time_point _start;
+};
+
+class NamedTimer {
+public:
+  void start(std::string name) { Timing t; timers[name] = t; }
+  void stop(std::string name) { cumtimes[name] += (timers[name]).stop(); }
+  void show() { for (auto &item : cumtimes) { std::cout << std::setprecision(4) << std::setw(11) << item.second << '\t' << item.first << std::endl; } }
+  std::map<std::string, double> cumtimes;
+  std::map<std::string, Timing> timers;
 };
 
 } // namespace dynet

--- a/dynet/timing.h
+++ b/dynet/timing.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <chrono>
 #include <iomanip>
+#include <map>
 
 namespace dynet {
 

--- a/dynet/timing.h
+++ b/dynet/timing.h
@@ -32,6 +32,11 @@ struct Timing {
 
 class NamedTimer {
 public:
+  ~NamedTimer() { 
+    if (timers.size()>0) {
+      std::cout << "Timing Info:" << std::endl; show();
+    }
+  }
   void start(std::string name) { Timing t; timers[name] = t; }
   void stop(std::string name) { cumtimes[name] += (timers[name]).stop(); }
   void show() { for (auto &item : cumtimes) { std::cout << std::setprecision(4) << std::setw(11) << item.second << '\t' << item.first << std::endl; } }


### PR DESCRIPTION
This adds the ability to measure and print out the cumulative time spent on different node types when using forward, on either the autobatch or non-autobatched executors. It is helpful to (a) see which ops benefit most from autobatching on different platforms (b) helps finding bottlenecks and slow ops in general.
