### PR TITLE
introduce a version of matmul which does not depend on first arg

### DIFF
--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -636,8 +636,10 @@ struct Node {
 
   Device* device; /**< pointer to the node, or null to inherit device from first input, or default when there is no input */
 
+  unsigned matmul_count; // how many matmul nodes am I an arg of?
+
 protected:
-  Node() : args(), device(default_device) {}
+  Node() : args(), device(default_device), matmul_count(0) {}
   explicit Node(const std::initializer_list<VariableIndex>& a) : args(a), device(default_device) {}
   template <typename T>
   explicit Node(const T&c) : args(c.begin(), c.end()), device(default_device) {}

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -52,7 +52,7 @@ Expression operator+(const Expression& x, real y) { return y + x; }
 Expression operator-(const Expression& x, const Expression& y) { return x + (-y); }
 Expression operator-(real x, const Expression& y) { return Expression(y.pg, y.pg->add_function<ConstantMinusX>({y.i}, x)); }
 Expression operator-(const Expression& x, real y) { return -(y - x); }
-Expression operator*(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<MatrixMultiply>({x.i, y.i})); }
+Expression operator*(const Expression& x, const Expression& y) { x.pg->nodes[x.i]->matmul_count++; return Expression(x.pg, x.pg->add_function<MatrixMultiply>({x.i, y.i})); }
 Expression operator*(const Expression& x, float y) { return Expression(x.pg, x.pg->add_function<ConstScalarMultiply>({x.i}, y)); }
 Expression cmult(const Expression& x, const Expression& y) { 
     if (x.dim().batch_size() == 1) 


### PR DESCRIPTION
This introduces two batchable versions of matmul: one in which the first argument is part of the signature, and a second in which it is not. The first version is triggered for cases where the first argument is shared with >2 matmul nodes.