### PR TITLE
Fixed bad autobatch signature for LookupParameters

### DIFF
--- a/dynet/param-nodes.cc
+++ b/dynet/param-nodes.cc
@@ -128,7 +128,7 @@ Node* ScalarInputNode::autobatch_pseudo_node(const ComputationGraph & cg,
 
 int LookupNode::autobatch_sig(const ComputationGraph & cg, SigMap &sm) const {
   Sig s(nt::lookup);
-  s.add_dim(dim);
+  s.add_node(params.index);
   return sm.get_idx(s);
 }
 std::vector<int> LookupNode::autobatch_concat(const ComputationGraph & cg) const {

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -66,6 +66,7 @@ struct NodeTest {
     TensorTools::set_elements(param_cube1.get()->values, param_cube1_vals);
     lookup1 = mod.add_lookup_parameters(3, {3});
     TensorTools::set_elements(lookup1.get()->all_values, param_square1_vals);
+    lookup2 = mod.add_lookup_parameters(10, {3});
   }
   ~NodeTest() {
     // for (auto x : av) free(x);
@@ -84,7 +85,7 @@ struct NodeTest {
   std::vector<char*> av;
   dynet::Model mod;
   dynet::Parameter param1, param2, param3, param4, param_scalar1, param_scalar2, param_kernel1, param_filter1, param_square1, param_cube1;
-  dynet::LookupParameter lookup1;
+  dynet::LookupParameter lookup1, lookup2;
 };
 
 // define the test suite
@@ -1542,6 +1543,16 @@ BOOST_AUTO_TEST_CASE( lookup_test ) {
   dynet::ComputationGraph cg;
   Expression x1 = lookup(cg, lookup1, (unsigned)0);
   Expression x2 = lookup(cg, lookup1, (unsigned)2);
+  Expression y = x1 + x2;
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression lookup();
+BOOST_AUTO_TEST_CASE( lookup_autobatch_dim_test ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = lookup(cg, lookup1, (unsigned)0);
+  Expression x2 = lookup(cg, lookup2, (unsigned)5);
   Expression y = x1 + x2;
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));


### PR DESCRIPTION
There was a bug in the signature for lookup parameters that would cause problems when using multiple lookup parameters with the same dimension in a single computation graph. This commit should fix the problem.