### PR TITLE
Updated the install doc for windows

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -25,6 +25,8 @@ get Boost, CMake, and Mercurial with either homebrew or macports:
     brew install boost cmake hg  # Using homebrew.
     sudo port install boost cmake mercurial # Using macports.
 
+On **Windows**, see :ref:`windows-cpp-install`.
+
 To compile DyNet you also need the `development version of the Eigen
 library <https://bitbucket.org/eigen/eigen>`__. **If you use any of the
 released versions, you may get assertion failures or compile errors.**
@@ -110,8 +112,8 @@ looks fishy. If you would like help, send this ``make.log`` file via the
 "Issues" tab on GitHub, or to the dynet-users mailing list.
 
 
-GPU/MKL support and build options
----------------------------------
+GPU/cuDNN/MKL support
+---------------------
 
 GPU (CUDA) support
 ~~~~~~~~~~~~~~~~~~
@@ -200,7 +202,7 @@ still using only one core. Increasing the number of cores to 2 or 3 is quite ben
 there are diminishing returns or even slowdown.
 
 Non-standard Boost location
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---------------------------
 
 DyNet requires Boost, and will find it if it is in the standard
 location. If Boost is in a non-standard location, say ``$HOME/boost``,
@@ -217,8 +219,10 @@ the ``boost/lib`` directory.
 Note also that Boost must be compiled with the same compiler version as
 you are using to compile DyNet.
 
-Building for Windows
-~~~~~~~~~~~~~~~~~~~~
+.. _windows-cpp-install:
+
+Windows Support
+---------------
 
 DyNet has been tested to build in Windows using Microsoft Visual Studio
 2015. You may be able to build with MSVC 2013 by slightly modifying the

--- a/doc/source/python.rst
+++ b/doc/source/python.rst
@@ -231,7 +231,7 @@ You can also use Python on Windows. For simplicity, we recommend
 using a Python distribution that already has Cython installed. The following has been tested to work:
 
 1) Install WinPython 2.7.10 (comes with Cython already installed).
-2) Compile DyNet according to the directions in the Windows C++ documentation (:ref:`windows-python-install`), and additionally add the following flag when executing ``cmake``: ``-DPYTHON=/path/to/your/python.exe``.
+2) Compile DyNet according to the directions in the Windows C++ documentation (:ref:`windows-cpp-install`), and additionally add the following flag when executing ``cmake``: ``-DPYTHON=/path/to/your/python.exe``.
 3) Open a command prompt and set ``VS90COMNTOOLS`` to the path to your Visual Studio "Common7/Tools" directory. One easy way to do this is a command such as:
 
 ::

--- a/doc/source/python.rst
+++ b/doc/source/python.rst
@@ -1,12 +1,8 @@
 Installing DyNet for Python
 ===========================
 
-(for instructions on installing on a computer with GPU, see below)
-
 Python bindings to DyNet are supported for both Python 2.x and 3.x.
-Before installing, we first need to ensure several packages are installed.
-You can generally do this with your standard package manager (details on
-doing this through Anaconda are listed below).
+Before installing DyNet, you will need to make sure that several packages are installed.
 For example on **Ubuntu Linux**:
 
 ::
@@ -22,6 +18,9 @@ get Boost, CMake, and Mercurial with either homebrew or macports:
     xcode-select --install
     brew install boost cmake hg python # Using homebrew.
     sudo port install boost cmake mercurial py-pip # Using macports.
+
+On **Windows**, see :ref:`windows-python-install`.
+
 
 Once these packages are installed, the following will download, build and install
 DyNet. Note that compiling DyNet may take a long time, up to 10 minutes or more, but as
@@ -45,7 +44,7 @@ we will help you debug. You can also try to install DyNet manually as listed bel
 Manual Installation
 -------------------
 
-(see below for the details)
+The following is a list of all the commands needed to perform a manual install:
 
 .. code:: bash
 
@@ -74,10 +73,8 @@ Manual Installation
     # /path/to/dynet/build/dynet is the location in which libdynet.dylib resides.
     export DYLD_LIBRARY_PATH=/path/to/dynet/build/dynet/:$DYLD_LIBRARY_PATH
 
-Detailed Instructions
----------------------
 
-First, get DyNet:
+To explain these one-by-one, first we get DyNet:
 
 .. code:: bash
 
@@ -212,26 +209,29 @@ Anaconda Support
 ----------------
 
 `Anaconda 
-<https://www.continuum.io/downloads>`_ is a popular package management system for Python. DyNet can be used from within an Anaconda environment, but be sure to activate the environment
+<https://www.continuum.io/downloads>`_ is a popular package management system for Python, and DyNet can be installed into this environment.
+First, make sure that you install all the necessary packages according to the instructions at the top of this page.
+Then create an Anaconda environment and activate it as below:
+
+::
 
      source activate my_environment_name
 
-then install some necessary packages as follows:
+After this, you should be able to install using pip or manual installation as normal.
 
-     conda install gcc cmake boost cython
+Note that on some conda environments, people have had trouble if ``C++`` related packages such as ``boost`` are installed within the Anaconda environment.
+We suggest that you install these packages through the system-wide package manager instead of through Anaconda. But if you would like to install them through Anaconda and encounter build errors, try the solution in `this comment <https://github.com/clab/dynet/issues/268#issuecomment-278806398>`_.
 
-After this, the build process should be the same as normal.
-
-Note that on some conda environments, people have reported build errors related to the interaction between the ``icu`` and ``boost`` packages. If you encounter this, try the solution in `this comment <https://github.com/clab/dynet/issues/268#issuecomment-278806398>`_.
+.. _windows-python-install:
 
 Windows Support
 ---------------
 
-You can also use Python on Windows by following similar steps to the above. For simplicity, we recommend 
+You can also use Python on Windows. For simplicity, we recommend 
 using a Python distribution that already has Cython installed. The following has been tested to work:
 
 1) Install WinPython 2.7.10 (comes with Cython already installed).
-2) Run CMake as above with ``-DPYTHON=/path/to/your/python.exe``.
+2) Compile DyNet according to the directions in the Windows C++ documentation (:ref:`windows-python-install`), and additionally add the following flag when executing ``cmake``: ``-DPYTHON=/path/to/your/python.exe``.
 3) Open a command prompt and set ``VS90COMNTOOLS`` to the path to your Visual Studio "Common7/Tools" directory. One easy way to do this is a command such as:
 
 ::
@@ -309,8 +309,6 @@ to initialize the global parameters, as follows:
     # Same as import dynet as dy
     import _dynet as dy
     dy.init()
-
-
 
 
 Running with MKL


### PR DESCRIPTION
Previously there were two problems with the Windows doc:
* In the C++ section the doc was hidden so low in the Hierarchy that it didn't appear on the sidebar by default.
* In the Python section, there was a mention of "install using cmake as above", but the cmake directions above were the ones for Mac.
This commit should make things easier to understand.

(note to @mattr1)