### PR TITLE
Fixed compile error, warning, added tests

### DIFF
--- a/dynet/cudnn-ops.cu
+++ b/dynet/cudnn-ops.cu
@@ -275,9 +275,15 @@ void CudnnMaxPooling2DOp::forward_impl(const Device_GPU & dev, const std::vector
   CUDNN_CHECK(cudnnSetTensor4dDescriptor(y_desc_, 
               CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
               YN, YC, YW, YH));
-  CUDNN_CHECK(cudnnSetPooling2dDescriptor(pooling_desc_,
-              CUDNN_POOLING_MAX, CUDNN_NOT_PROPAGATE_NAN,
-              ksize_[1], ksize_[0], pad_w, pad_h, stride_[1], stride_[0]));
+  #if CUDNN_VERSION_MIN(5, 0, 0)
+    CUDNN_CHECK(cudnnSetPooling2dDescriptor(pooling_desc_,
+                CUDNN_POOLING_MAX, CUDNN_NOT_PROPAGATE_NAN,
+                ksize_[1], ksize_[0], pad_w, pad_h, stride_[1], stride_[0]));
+  #else
+    CUDNN_CHECK(cudnnSetPooling2dDescriptor_v4(pooling_desc_,
+                CUDNN_POOLING_MAX, CUDNN_NOT_PROPAGATE_NAN,
+                ksize_[1], ksize_[0], pad_w, pad_h, stride_[1], stride_[0]));
+  #endif
   float alpha = 1.f, beta = 0.f;
   CUDNN_CHECK(cudnnPoolingForward(dev.cudnnHandle, pooling_desc_, 
               &alpha, x_desc_, x->v,

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -97,7 +97,7 @@ struct TraceOfProduct : public Node {
 struct ConstScalarMultiply : public Node {
   explicit ConstScalarMultiply(const std::initializer_list<VariableIndex>& a, float alpha) : Node(a), alpha(alpha) {}
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::scalar_mult); s.add_node(*((int*)&alpha)); return sm.get_idx(s); }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::scalar_mult); s.add_float(alpha); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }
   DYNET_NODE_DEFINE_DEV_IMPL()
   float alpha;
@@ -186,7 +186,7 @@ struct BlockDropout : public Node {
 struct ConstantPlusX : public Node {
   explicit ConstantPlusX(const std::initializer_list<VariableIndex>& a, real o) : Node(a), c(o) {}
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::plus_const); s.add_node(*((int*)&c)); return sm.get_idx(s); }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::plus_const); s.add_float(c); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }  
   DYNET_NODE_DEFINE_DEV_IMPL()
   real c;

--- a/dynet/sig.h
+++ b/dynet/sig.h
@@ -83,6 +83,12 @@ struct SigHash {
   inline void add_int(int i) {
     hash = i + (hash << 6) + (hash << 16) - hash;
   }
+  inline void add_float(float i) {
+    assert(sizeof(int) >= sizeof(float));
+    int temp_val = 0;
+    memcpy(&temp_val, &i, sizeof(float));
+    hash = temp_val + (hash << 6) + (hash << 16) - hash;
+  }
   void add_node(unsigned i) { add_int((int)i); }
   void add_dim(const Dim &d) {
     add_int(-(int)d.nd);


### PR DESCRIPTION
This commit:
* Fixes a compile error on particular versions of cuDNN
* Fixes a dangerous usage of casting in signatures for floats
* Adds some additional tests of autobatched nodes