### PR TITLE
Fixed missing initialization in exec.cc

### DIFF
--- a/dynet/exec.h
+++ b/dynet/exec.h
@@ -20,7 +20,7 @@ class ExecutionEngine {
   virtual void backward(bool full = false) = 0;
   virtual void backward(VariableIndex i, bool full = false) = 0;
  protected:
-  explicit ExecutionEngine(const ComputationGraph& cg) : cg(cg) {}
+  explicit ExecutionEngine(const ComputationGraph& cg) : cg(cg), backward_computed(0) {}
   const ComputationGraph& cg;
   VariableIndex backward_computed;
 };


### PR DESCRIPTION
This will cause errors in an edge case where we request gradients before calling backward at all.