### PR TITLE
Fixed bug in auxiliary memory calculation for autobatching

### DIFF
--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -128,6 +128,7 @@ const Tensor& SimpleExecutionEngine::incremental_forward(VariableIndex i) {
     }
   }
 
+  // for(VariableIndex vi = (VariableIndex)0; vi <= i; ++vi) cerr << "nfxs[" << vi << "] == " << print_vec(as_vector(nfxs[vi])) << endl;
   return nfxs[i];
 }
 
@@ -211,6 +212,7 @@ void SimpleExecutionEngine::backward(VariableIndex from_where, bool full) {
     if(i <= from_where)
       static_cast<ParameterNodeBase*>(cg.nodes[i])->accumulate_grad(ndEdfs[i]);
   backward_computed = from_where;
+  // for(VariableIndex vi = (VariableIndex)0; vi <= backward_computed; ++vi) cerr << "ndEdfs[" << vi << "] == " << print_vec(as_vector(ndEdfs[vi])) << endl;
 
 }
 
@@ -633,7 +635,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
           my_aux = node->aux_storage_size();
           node2offset[curr_node] = tot_main;
           tot_main += my_main;
-          node->aux_mem = (void*)my_aux;
+          node->aux_mem = (void*)tot_aux;
           tot_aux += my_aux;
         }
 
@@ -641,14 +643,13 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
         // Allocate main/auxiliary memory for the batch
         float *head_main = static_cast<float*>(node->device->pools[(int)DeviceMempool::FXS]->allocate(tot_main * sizeof(float)));
         if(head_main == nullptr) DYNET_RUNTIME_ERR("Ran out of memory when executing batch " << bid);
-        // for(auto curr_node : batch_ids)
-        //   nfxs[curr_node].v = head_main + node2diff[curr_node];
-        void *head_aux = nullptr;
+        // for(auto curr_node : batch_ids) nfxs[curr_node].v = head_main + node2diff[curr_node];
+        char *head_aux = nullptr;
         if(tot_aux > 0) {
-          head_aux = static_cast<void*>(node->device->pools[(int)DeviceMempool::FXS]->allocate(tot_aux));
+          head_aux = static_cast<char*>(node->device->pools[(int)DeviceMempool::FXS]->allocate(tot_aux));
           if(head_aux == nullptr) DYNET_RUNTIME_ERR("Ran out of memory when executing node " << bid);
           for(auto curr_node : batch_ids)
-            cg.nodes[curr_node]->aux_mem = (void*)((ptrdiff_t)head_aux + (ptrdiff_t)cg.nodes[curr_node]->aux_mem);
+            cg.nodes[curr_node]->aux_mem = (void*)(head_aux + (ptrdiff_t)cg.nodes[curr_node]->aux_mem);
         }
 
         // Get the concatenation and pseudo-node info
@@ -750,7 +751,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
     free(node2profid);
   }
 
-
+  // for(VariableIndex vi = (VariableIndex)0; vi <= upto; ++vi) cerr << "nfxs[" << vi << "] == " << print_vec(as_vector(get_nfx(vi))) << endl;
   return get_nfx(upto);
 }
 
@@ -960,6 +961,7 @@ void BatchedExecutionEngine::backward(VariableIndex from_where, bool full) {
     if(i < (VariableIndex)ndEdfs.size() && ndEdfs[i].v != nullptr)
       static_cast<ParameterNodeBase*>(cg.nodes[i])->accumulate_grad(ndEdfs[i]);
   backward_computed = from_where;
+  // for(VariableIndex vi = (VariableIndex)0; vi <= backward_computed; ++vi) cerr << "ndEdfs[" << vi << "] == " << print_vec(as_vector(ndEdfs[vi])) << endl;
 
 }
 

--- a/dynet/param-nodes.cc
+++ b/dynet/param-nodes.cc
@@ -137,7 +137,7 @@ std::vector<int> LookupNode::autobatch_concat(const ComputationGraph & cg) const
 Node* LookupNode::autobatch_pseudo_node(const ComputationGraph & cg,
                                         const std::vector<VariableIndex> & batch_ids) const {
   vector<unsigned> ids;
-  LookupNode* ln;
+  LookupNode* ln = nullptr;
   for(auto batch_id : batch_ids) {
     ln = static_cast<LookupNode*>(cg.nodes[batch_id]);
     if(ln->pindex != nullptr)

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1687,6 +1687,20 @@ BOOST_AUTO_TEST_CASE( lookup_autobatch_diffmodel_test ) {
   dynet::autobatch_flag = autobatch_cache;
 }
 
+// Expression lookup();
+BOOST_AUTO_TEST_CASE( lookup_autobatch_and_manbatch_test ) {
+  auto autobatch_cache = dynet::autobatch_flag;
+  for(dynet::autobatch_flag = 0; dynet::autobatch_flag < 2; ++dynet::autobatch_flag) {
+    dynet::ComputationGraph cg;
+    Expression x1 = lookup(cg, lookup1, {0,1});
+    Expression x2 = lookup(cg, lookup1, {2,0});
+    Expression y = x1 + x2;
+    Expression z = sum_batches(sum_elems(y));
+    BOOST_CHECK(check_grad(mod, z, 0));
+  }
+  dynet::autobatch_flag = autobatch_cache;
+}
+
 // Expression parameter() with lookup parameter input;
 BOOST_AUTO_TEST_CASE( lookup_matrix_test ) {
   dynet::ComputationGraph cg;


### PR DESCRIPTION
Some nodes use "auxiliary memory", and there was a bug in calculating this in autobatched code. This affects training in cases where:
* a node that uses auxiliary memory is used
* this node also supports autobatching
* autobatching is turned on
In other words, this is a corner case, but one that may affect some people that use autobatching.

This commit fixes this problem, and also hopefully fixes https://github.com/clab/dynet/issues/584