### PR TITLE
Python QoL improvements

### DIFF
--- a/doc/source/python_ref.rst
+++ b/doc/source/python_ref.rst
@@ -317,6 +317,8 @@ Convolution/Pooling operations
 
 .. autofunction:: dynet.conv2d_bias
 
+.. autofunction:: dynet.maxpooling2d
+
 .. autofunction:: dynet.filter1d_narrow
 
 .. autofunction:: dynet.kmax_pooling

--- a/dynet/nodes-maxpooling2d.cc
+++ b/dynet/nodes-maxpooling2d.cc
@@ -119,17 +119,17 @@ void MaxPooling2D::backward_dev_impl(const MyDevice & dev,
                  ksize[1] - xs[0]->d[1]);
   int pad_top = is_valid ? 0 : pad_along_height / 2;
   int pad_left = is_valid ? 0 : pad_along_width / 2;
-  for (int b = 0; b < fx.d.bd; ++b) {
-    for (int i = 0; i < fx.d[0]; ++i) {
-      for (int j = 0; j < fx.d[1]; ++j) {
-        for (int ch = 0; ch < fx.d[2]; ++ch) {    
+  for (unsigned b = 0; b < fx.d.bd; ++b) {
+    for (unsigned i = 0; i < fx.d[0]; ++i) {
+      for (unsigned j = 0; j < fx.d[1]; ++j) {
+        for (unsigned ch = 0; ch < fx.d[2]; ++ch) {    
           int max_r = 0, max_c = 0;
           float max_val;
           bool is_feasible = false;
-          for (int r = 0; r < ksize[0]; ++r) {
-            for (int c = 0; c < ksize[1]; ++c) {
-              int row = stride[0] * i + r - pad_top;
-              int col = stride[1] * j + c - pad_left;
+          for (unsigned r = 0; r < ksize[0]; ++r) {
+            for (unsigned c = 0; c < ksize[1]; ++c) {
+              unsigned row = stride[0] * i + r - pad_top;
+              unsigned col = stride[1] * j + c - pad_left;
               if (((col < xs[0]->d[1]) && (row < xs[0]->d[0])) && ((0 <= col) && (0 <= row))) {
                 if (!is_feasible) {
                   max_val = xs[0]->tb<3>()(row, col, ch, b);

--- a/dynet/sig.h
+++ b/dynet/sig.h
@@ -112,7 +112,7 @@ template <class Sig>
 struct SigLinearMap {
   SigLinearMap() { sigs.reserve(50); whiches.reserve(50); Sig s; sigs.push_back(s); whiches.push_back(s.which); }
   int get_idx(Sig &s) {
-    for (int i=0; i<sigs.size(); ++i) {
+    for (unsigned i=0; i<sigs.size(); ++i) {
       if (sigs[i]==s)
           return i;
     }
@@ -138,7 +138,7 @@ struct SigLinearSortedMap {
       }
       // not found, continue to add.
     } else { // linear scan
-      for (int i=0; i<sigs.size(); ++i) {
+      for (unsigned i=0; i<sigs.size(); ++i) {
         if (sigs[i].first==s) {
           const int res=sigs[i].second;
           found++;

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -9,6 +9,8 @@ cdef extern from "dynet/init.h" namespace "dynet":
         unsigned random_seed
         string mem_descriptor
         float weight_decay
+        int autobatch
+        int autobatch_debug
         bool shared_parameters
         bool ngpus_requested
         bool ids_requested

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -310,7 +310,7 @@ cdef class Parameters:
         cdef float* vals
         t = self.thisptr.get().values
         shape = arr.shape
-        if self.shape() == shape:
+        if self.shape() != shape:
             raise ValueError("Shape of values and parameter don't match in Parameters.set_value")
         vals = t.v
         arr = arr.flatten(order='F')

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -106,7 +106,7 @@ cdef class DynetParams:
         Args:
             autobatch(bool): Set to :code:`True` to activate autobatching
         """
-        if autobatch
+        if autobatch:
             self.cparams.autobatch = 1
         else:
             self.cparams.autobatch = 0
@@ -117,7 +117,7 @@ cdef class DynetParams:
         Args:
             autobatch(bool): Set to :code:`True` to activate autobatching debug
         """
-        if autobatch_debug
+        if autobatch_debug:
             self.cparams.autobatch_debug = 1
         else:
             self.cparams.autobatch_debug = 0
@@ -311,7 +311,7 @@ cdef class Parameters:
         t = self.thisptr.get().values
         shape = arr.shape
         if self.shape() == shape:
-            raise ValueError("Shape of values and parameter don't match in Parameters.set_value"
+            raise ValueError("Shape of values and parameter don't match in Parameters.set_value")
         vals = t.v
         arr = arr.flatten(order='F')
         for i in xrange(arr.size):

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -100,6 +100,28 @@ cdef class DynetParams:
         """
         self.cparams.random_seed = random_seed
 
+    cpdef set_autobatch(self, bool autobatch):
+        """Activate autobatching
+        
+        Args:
+            autobatch(bool): Set to :code:`True` to activate autobatching
+        """
+        if autobatch
+            self.cparams.autobatch = 1
+        else:
+            self.cparams.autobatch = 0
+
+    cpdef set_autobatch_debug(self, bool autobatch_debug):
+        """Activate autobatching debug
+        
+        Args:
+            autobatch(bool): Set to :code:`True` to activate autobatching debug
+        """
+        if autobatch_debug
+            self.cparams.autobatch_debug = 1
+        else:
+            self.cparams.autobatch_debug = 0
+
     cpdef set_weight_decay(self, float weight_decay):
         """Set weight decay parameter
         
@@ -246,12 +268,10 @@ cdef class Parameters:
         return self
 
     cpdef shape(self):
-        """[summary]
-        
-        [description]
+        """Returns shape of the parameter
         
         Returns:
-            [type]: [description]
+            tuple: Shape of the parameter
         """
         return c_dim_as_shape(self.thisptr.get().dim)
 
@@ -276,27 +296,24 @@ cdef class Parameters:
     cpdef clip_inplace(self, float left, float right):
         """Clip the values in the parameter to a fixed range [left, right] (in place)
         
-        Returns:
-            None
+        Args:
+            arr(np.ndarray): Scale
         """
         self.thisptr.clip_inplace(left, right)
         
     # TODO: make more efficient
-    cpdef load_array(self, arr):
-        """Deprecated
+    cpdef set_value(self, arr):
+        """Set value of the parameter
+
         """
-        assert(False),"This method is depracated. Use instead model.parameters_from_numpy(arr)."
         cdef CTensor t
         cdef float* vals
         t = self.thisptr.get().values
         shape = arr.shape
-        if len(shape) == 1:
-            assert(t.d.ndims() == 1)
-            assert(t.d.size() == arr.size)
-        if len(shape) == 2:
-            assert(t.d.rows() == shape[0] and t.d.cols() == shape[1])
+        if self.shape() == shape:
+            raise ValueError("Shape of values and parameter don't match in Parameters.set_value"
         vals = t.v
-        arr = arr.flatten()
+        arr = arr.flatten(order='F')
         for i in xrange(arr.size):
             vals[i] = arr[i]
 
@@ -1543,7 +1560,7 @@ def matInput(int d1, int d2):
     Returns:
         dynet.Expression: [description]
     """
-    return _cg.inputMatrix(d1, d2)
+    raise DeprecationWarning('matInput is now deprecated. Use dynet.inputTensor instead')
 
 def inputMatrix(vector[float] v, tuple d):
     """DEPRECATED : use inputTensor
@@ -1564,7 +1581,7 @@ def inputMatrix(vector[float] v, tuple d):
         array([[ 1.,  3.,  5.],
                [ 2.,  4.,  6.]])
     """
-    return _cg.inputMatrixLiteral(v, d)
+    raise DeprecationWarning('matInput is now deprecated. Use dynet.inputTensor instead')
 
 def inputTensor(arr,batched=False):
     """Creates a tensor expression based on a numpy array or a list.


### PR DESCRIPTION
This:

- Addresses #346 (retires `matInput` and `inputMatrix` in profit of `inputTensor`)
- Addresses #588 (Adds autobatching/debug to python DynetParams)
- Adds a function `set_value` which allows to manually set the values of an existing parameter with a numpy array (previously you had to create another parameter with `Model.parameters_from_numpy`) which was very memory inefficient since you can't delete parameters
- Adds `maxpooling2d` to the python doc
- Fixes some annoying unsigned/int comparison compiler warnings in `sig.h`/`nodes-maxpooling2d.cc`