### PR TITLE
Fix compilation bug with boost 1.59

### DIFF
--- a/dynet/io-macros.h
+++ b/dynet/io-macros.h
@@ -1,6 +1,7 @@
 #ifndef DYNET_IO_MACROS__
 #define DYNET_IO_MACROS__
 
+#include <boost/version.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>
 #include <boost/archive/binary_iarchive.hpp>


### PR DESCRIPTION
BOOST_VERSION is not defined if boost/version.hpp is not directectly imported with my version of boost.