### PR TITLE
Enhance the conv2d and maxpooling2d code a bit, also fix two bugs.

### DIFF
--- a/dynet/cudnn-ops.cu
+++ b/dynet/cudnn-ops.cu
@@ -9,12 +9,11 @@
 namespace dynet {
 
 CudnnConvOp::CudnnConvOp(const std::vector<unsigned>& s, const bool padding_type) {
-  stride.resize(s.size());
-  for (unsigned i = 0; i < stride.size(); ++i) {
-    stride[i] = static_cast<int>(s[i]);
+  stride_.resize(s.size());
+  for (unsigned i = 0; i < stride_.size(); ++i) {
+    stride_[i] = static_cast<int>(s[i]);
   }
-  is_valid = padding_type;
-
+  is_valid_ = padding_type;
   fwd_workspace = NULL;
   bwd_filter_workspace = NULL;
   bwd_data_workspace = NULL;
@@ -22,7 +21,6 @@ CudnnConvOp::CudnnConvOp(const std::vector<unsigned>& s, const bool padding_type
   workspace_bwd_data_size_ = 0;
   workspace_bwd_filter_size_ = 0;
   mempool_ = NULL;
-
   CUDNN_CHECK(cudnnCreateTensorDescriptor(&x_desc_));
   CUDNN_CHECK(cudnnCreateTensorDescriptor(&y_desc_));
   CUDNN_CHECK(cudnnCreateTensorDescriptor(&bias_desc_));
@@ -38,11 +36,13 @@ CudnnConvOp::~CudnnConvOp() {
   CUDNN_CHECK(cudnnDestroyConvolutionDescriptor(conv_desc_));
 }
 
-void CudnnConvOp::forward_impl(const Device_GPU & dev, const std::vector<const Tensor*>& xs, Tensor& fx) {
+void CudnnConvOp::forward_impl(const Device_GPU& dev, const std::vector<const Tensor*>& xs, Tensor& fx) {
+  if (mempool_ == NULL)
+    throw std::runtime_error("dynet::CudnnConvOp::mempool_ not set");
+
   const Tensor* x = xs[0]; 
   const Tensor* filter = xs[1];
   Tensor* y = &fx;
- 
   unsigned XN = x->d.bd;
   unsigned XC = x->d[2];
   unsigned XH = x->d[0];
@@ -56,45 +56,39 @@ void CudnnConvOp::forward_impl(const Device_GPU & dev, const std::vector<const T
   unsigned YH = fx.d[0];
   unsigned YW = fx.d[1];
 
+  int pad_h = 0, pad_w = 0;
+  bool h_odd = false, w_odd = false;
   // infer pad_h, pad_w
-  if (!is_valid) {
   // Total padding on rows and cols is
-  // Pr = (R' - 1) * S + Kr - R
-  // Pc = (C' - 1) * S + Kc - C
-  // where (R', C') are output dimensions, (R, C) are input dimensions, S
-  // is stride, (Kr, Kc) are filter dimensions.
-  // We pad Pr/2 on the left and Pr - Pr/2 on the right, Pc/2 on the top
-  // and Pc - Pc/2 on the bottom.  When Pr or Pc is odd, this means
+  // pad_h = (YH - 1) * stride[0] + FH - XH
+  // pad_w = (YW - 1) * stride[1] + FW - XW
+  // We pad pad_h/2 on the left and pad_h - pad_h/2 on the right, pad_w/2 on the top
+  // and pad_w - pad_w/2 on the bottom.  When pad_h or pad_w is odd, this means
   // we pad more on the right and bottom than on the top and left.
-    pad_h = std::max<int>(0, (YH - 1) * stride[0] + FH - XH);
-    pad_w = std::max<int>(0, (YW - 1) * stride[1] + FW - XW);
-    if (mempool_ == NULL) {
-      throw std::runtime_error("dynet::CudnnConvOp::mempool_ not set");
-    }
-    const bool h_odd = (pad_h % 2 != 0);
-    const bool w_odd = (pad_w % 2 != 0);
+  if (!is_valid_) {
+    pad_h = std::max<int>(0, (YH - 1) * stride_[0] + FH - XH);
+    pad_w = std::max<int>(0, (YW - 1) * stride_[1] + FW - XW);
+    h_odd = (pad_h % 2 != 0);
+    w_odd = (pad_w % 2 != 0);
     if (h_odd || w_odd) { // then we need to pad one row/col on the bottom/right
       unsigned new_XH = XH + h_odd;
       unsigned new_XW = XW + w_odd;
       void* temp = mempool_->allocate(sizeof(float) * new_XW * new_XH * XC * XN);
-      padded_x = Tensor(Dim({ new_XH, new_XW, XC }, XN), static_cast<float*>(temp), xs[0]->device, DeviceMempool::FXS);
+      Tensor padded_x = Tensor(Dim({new_XH, new_XW, XC}, XN), static_cast<float*>(temp), xs[0]->device, DeviceMempool::FXS);
       Eigen::array<std::pair<int, int>, 4> paddings;
       paddings[0] = std::make_pair(0, static_cast<int>(h_odd));
       paddings[1] = std::make_pair(0, static_cast<int>(w_odd));
       paddings[2] = std::make_pair(0, 0);
       paddings[3] = std::make_pair(0, 0);
       padded_x.tb<3>().device(*dev.edevice) = xs[0]->tb<3>().pad(paddings);
+      // re-point x to the padded input
       XH = new_XH;
       XW = new_XW;
       x = &padded_x;
     }
   }
 
-  if (xs.size() == 3) {
-    CUDNN_CHECK(cudnnSetTensor4dDescriptor(bias_desc_, 
-                CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
-                1, FYC, 1, 1));
-  }
+  // set cudnn descriptors
   CUDNN_CHECK(cudnnSetTensor4dDescriptor(x_desc_, 
               CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
               XN, XC, XW, XH));
@@ -105,13 +99,19 @@ void CudnnConvOp::forward_impl(const Device_GPU & dev, const std::vector<const T
               DataTypeToCudnnType<float>::value, CUDNN_TENSOR_NCHW,
               FYC, FXC, FW, FH));
   CUDNN_CHECK(cudnnSetConvolution2dDescriptor(conv_desc_,
-              pad_w/2, pad_h/2, stride[1], stride[0], 1, 1, 
+              pad_w/2, pad_h/2, stride_[1], stride_[0], 1, 1,
               CUDNN_CROSS_CORRELATION));
+  if (xs.size() == 3) {
+    CUDNN_CHECK(cudnnSetTensor4dDescriptor(bias_desc_,
+                CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
+                1, FYC, 1, 1));
+  }
 
-  //TODO(Hao Zhang): there should be an autotune function to determine
+  // TODO(Hao Zhang): there should be an autotune function to determine
   // the best convolution algorithm to use.
   // However, as DyNet changes CG for every sample (or every iteration),
   // This autotune function seems to be unnecessary.
+  // Note: this following computations are *NON-DETERMINISTIC*
   CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(dev.cudnnHandle,
               x_desc_, filter_desc_, conv_desc_, y_desc_,
               CUDNN_CONVOLUTION_FWD_PREFER_FASTEST, workspace_size_limit_bytes,
@@ -119,9 +119,7 @@ void CudnnConvOp::forward_impl(const Device_GPU & dev, const std::vector<const T
   CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(dev.cudnnHandle,
               x_desc_, filter_desc_, conv_desc_, y_desc_,
               fwd_algo_, &workspace_fwd_size_));
-  if (fwd_workspace == NULL) {
-    fwd_workspace = mempool_->allocate(workspace_fwd_size_);
-  }
+  fwd_workspace = mempool_->allocate(workspace_fwd_size_);
   float alpha = 1.f, beta = 0.f;
   CUDNN_CHECK(cudnnConvolutionForward(dev.cudnnHandle,
               &alpha, x_desc_, x->v, filter_desc_, filter->v,
@@ -133,92 +131,130 @@ void CudnnConvOp::forward_impl(const Device_GPU & dev, const std::vector<const T
   }
 }
 
+// We don't suppose backward_impl depends on the exeuction of forward_impl
+// i.e. backward_impl can be called independently
 void CudnnConvOp::backward_impl(const Device_GPU & dev, 
              const std::vector<const Tensor*>& xs,
              const Tensor& fx,
              const Tensor& dEdf,
              unsigned i,
              Tensor& dEdxi) {
+  if (mempool_ == NULL)
+    throw std::runtime_error("dynet::CudnnConvOp::mempool_ not set");
+
   const Tensor* x = xs[0]; 
   const Tensor* filter = xs[1];
   const Tensor* dy = &dEdf;
-  Tensor* dxi = &dEdxi;
+  void* dxi = NULL;
+
   unsigned XN = x->d.bd;
   unsigned XC = x->d[2];
   unsigned XH = x->d[0];
   unsigned XW = x->d[1];
-  const bool h_odd = (pad_h % 2 != 0);
-  const bool w_odd = (pad_w % 2 != 0);
-  void* dx_ptr = NULL;
-  if (mempool_ == NULL) 
-    throw std::runtime_error("dynet::CudnnConvOp::mempool_ not set");
-  if (h_odd || w_odd) {
-    unsigned new_XH = XH + h_odd;
-    unsigned new_XW = XW + w_odd;
-    DYNET_ASSERT(padded_x.d[0] == new_XH, "Tensor input_padded must have been padded");
-    DYNET_ASSERT(padded_x.d[1] == new_XW, "Tensor input_padded must have been padded");
-    x = &padded_x;
-    XH = new_XH;
-    XW = new_XW;
-    if (i == 0)
-      dx_ptr = mempool_->allocate(sizeof(float) * new_XW * new_XH * XC * XN);
-  }
-  // here we could reuse the descriptor we created for forward, because 
-  // they share the same size
-  float alpha = 1.f, beta = 0.f;
-  if (i == 1) {
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(dev.cudnnHandle,
-                x_desc_, y_desc_, conv_desc_, filter_desc_, 
-                CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST, 
-                workspace_size_limit_bytes, &bwd_f_algo_));
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(dev.cudnnHandle,
-                x_desc_, y_desc_, conv_desc_, filter_desc_,
-                bwd_f_algo_, &workspace_bwd_filter_size_));
-    // allocate space for backward compute
-    if (bwd_filter_workspace == NULL) {
-      bwd_filter_workspace = mempool_->allocate(sizeof(float) * workspace_bwd_filter_size_);
-    }
-    CUDNN_CHECK(cudnnConvolutionBackwardFilter(dev.cudnnHandle,
-                &alpha, x_desc_, x->v,
-                y_desc_, dy->v,
-                conv_desc_, bwd_f_algo_, bwd_filter_workspace, workspace_bwd_filter_size_,
-                &beta, filter_desc_, dxi->v));
-  } else if (i == 0) {            
-    CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(dev.cudnnHandle,
-                filter_desc_, y_desc_, conv_desc_, x_desc_,
-                CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST,
-                workspace_size_limit_bytes, &bwd_d_algo_));
-    CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(dev.cudnnHandle,
-                filter_desc_, y_desc_, conv_desc_, x_desc_,
-                bwd_d_algo_, &workspace_bwd_data_size_));
-    if (bwd_data_workspace == NULL) {
-      bwd_data_workspace = mempool_->allocate(sizeof(float) * workspace_bwd_data_size_);
-      }
+  unsigned FYC = filter->d[3];
+  unsigned FXC = filter->d[2];
+  unsigned FH = filter->d[0];
+  unsigned FW = filter->d[1];
+  unsigned YN = fx.d.bd;
+  unsigned YC = fx.d[2];
+  unsigned YH = fx.d[0];
+  unsigned YW = fx.d[1];
+
+  // create padded input if necessary
+  int pad_h = 0, pad_w = 0;
+  bool h_odd = false, w_odd = false;
+  if (!is_valid_) {
+    pad_h = std::max<int>(0, (YH - 1) * stride_[0] + FH - XH);
+    pad_w = std::max<int>(0, (YW - 1) * stride_[1] + FW - XW);
+    h_odd = (pad_h % 2 != 0);
+    w_odd = (pad_w % 2 != 0);
     if (h_odd || w_odd) {
-      CUDNN_CHECK(cudnnConvolutionBackwardData(dev.cudnnHandle,
-                  &alpha, filter_desc_, filter->v,
-                  y_desc_, dy->v,
-                  conv_desc_, bwd_d_algo_, bwd_data_workspace, workspace_bwd_data_size_,
-                  &beta, x_desc_, dx_ptr));
-      Tensor padded_dx = Tensor(Dim({XH, XW, XC}, XN), static_cast<float*>(dx_ptr), xs[0]->device, DeviceMempool::FXS);
-        
-      Eigen::array<int, 4> offsets = {0, 0, 0, 0};
-      Eigen::array<int, 4> extents = {static_cast<int>(XH), static_cast<int>(XW), static_cast<int>(XC), static_cast<int>(XN)};
-      dxi->tb<3>().device(*dev.edevice) = padded_dx.tb<3>().slice(offsets, extents);
-    } else {
-      CUDNN_CHECK(cudnnConvolutionBackwardData(dev.cudnnHandle,
-                  &alpha, filter_desc_, filter->v,
-                  y_desc_, dy->v,
-                  conv_desc_, bwd_d_algo_, bwd_data_workspace, workspace_bwd_data_size_,
-                  &beta, x_desc_, dxi->v));
+      unsigned new_XH = XH + h_odd;
+      unsigned new_XW = XW + w_odd;
+      void* temp = mempool_->allocate(sizeof(float) * new_XW * new_XH * XC * XN);
+      Tensor padded_x = Tensor(Dim({new_XH, new_XW, XC}, XN), static_cast<float*>(temp), xs[0]->device, DeviceMempool::FXS);
+      Eigen::array<std::pair<int, int>, 4> paddings;
+      paddings[0] = std::make_pair(0, static_cast<int>(h_odd));
+      paddings[1] = std::make_pair(0, static_cast<int>(w_odd));
+      paddings[2] = std::make_pair(0, 0);
+      paddings[3] = std::make_pair(0, 0);
+      padded_x.tb<3>().device(*dev.edevice) = xs[0]->tb<3>().pad(paddings);
+      // re-point x to the padded input
+      XH = new_XH;
+      XW = new_XW;
+      x = &padded_x;
     }
-  } else {
-    CUDNN_CHECK(cudnnConvolutionBackwardBias(dev.cudnnHandle,
-                &alpha, y_desc_, dy->v,
-                &beta, bias_desc_, dxi->v));  
+  }
+
+  CUDNN_CHECK(cudnnSetTensor4dDescriptor(x_desc_,
+              CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
+              XN, XC, XW, XH));
+  CUDNN_CHECK(cudnnSetTensor4dDescriptor(y_desc_,
+              CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
+              YN, YC, YW, YH));
+  CUDNN_CHECK(cudnnSetFilter4dDescriptor(filter_desc_,
+              DataTypeToCudnnType<float>::value, CUDNN_TENSOR_NCHW,
+              FYC, FXC, FW, FH));
+  CUDNN_CHECK(cudnnSetConvolution2dDescriptor(conv_desc_,
+              pad_w/2, pad_h/2, stride_[1], stride_[0], 1, 1,
+              CUDNN_CROSS_CORRELATION));
+  if (i == 2) {
+    CUDNN_CHECK(cudnnSetTensor4dDescriptor(bias_desc_,
+                CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
+                1, FYC, 1, 1));
+  }
+  float alpha = 1.f, beta = 0.f;
+  switch(i) {
+    case 0: { // grad w.r.t. feature maps
+      dxi = mempool_->allocate(sizeof(float) * XH * XW * XC * XN);
+      CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(dev.cudnnHandle,
+                  filter_desc_, y_desc_, conv_desc_, x_desc_,
+                  CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST,
+                  workspace_size_limit_bytes, &bwd_d_algo_));
+      CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(dev.cudnnHandle,
+                  filter_desc_, y_desc_, conv_desc_, x_desc_,
+                  bwd_d_algo_, &workspace_bwd_data_size_));
+      bwd_data_workspace = mempool_->allocate(workspace_bwd_data_size_);
+      CUDNN_CHECK(cudnnConvolutionBackwardData(dev.cudnnHandle,
+                  &alpha, filter_desc_, filter->v, y_desc_, dy->v,
+                  conv_desc_, bwd_d_algo_, bwd_data_workspace, workspace_bwd_data_size_,
+                  &beta, x_desc_, dxi));
+      Tensor padded_dx = Tensor(Dim({XH, XW, XC}, XN), static_cast<float*>(dxi), xs[0]->device, DeviceMempool::FXS);
+      std::cout << padded_dx.d << " " << dEdxi.d << std::endl;
+      Eigen::array<int, 4> offsets = {0, 0, 0, 0};
+      Eigen::array<int, 4> extents = {static_cast<int>(XH - h_odd), static_cast<int>(XW - w_odd), static_cast<int>(XC), static_cast<int>(XN)};
+      dEdxi.tb<3>().device(*dev.edevice) += padded_dx.tb<3>().slice(offsets, extents);
+    } break;
+    case 1: {// grad w.r.t. filters
+      dxi = mempool_->allocate(sizeof(float) * FYC * FXC * FW * FH);
+      CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(dev.cudnnHandle,
+                  x_desc_, y_desc_, conv_desc_, filter_desc_,
+                  CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST,
+                  workspace_size_limit_bytes, &bwd_f_algo_));
+      CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(dev.cudnnHandle,
+                  x_desc_, y_desc_, conv_desc_, filter_desc_,
+                  bwd_f_algo_, &workspace_bwd_filter_size_));
+      bwd_filter_workspace = mempool_->allocate(workspace_bwd_filter_size_);
+      CUDNN_CHECK(cudnnConvolutionBackwardFilter(dev.cudnnHandle,
+                  &alpha, x_desc_, x->v, y_desc_, dy->v,
+                  conv_desc_, bwd_f_algo_, bwd_filter_workspace, workspace_bwd_filter_size_,
+                  &beta, filter_desc_, dxi));
+      //accumlate the gradient
+      Tensor dxi_tensor = Tensor(Dim({FH, FW, FXC}, FYC), static_cast<float*>(dxi), xs[1]->device, DeviceMempool::FXS);
+      dEdxi.t<4>().device(*dev.edevice) += dxi_tensor.t<4>();
+    } break;
+    case 2: {// grad w.r.t. bias
+      dxi = mempool_->allocate(sizeof(float) * FYC);
+      CUDNN_CHECK(cudnnConvolutionBackwardBias(dev.cudnnHandle,
+                  &alpha, y_desc_, dy->v,
+                  &beta, bias_desc_, dxi));
+      CUDNN_CHECK(cudnnAddTensor(dev.cudnnHandle, &alpha,
+                  bias_desc_, dxi, &alpha, bias_desc_, dEdxi.v));
+    } break;
+    default:
+      throw std::runtime_error("dynet::CudnnConvOp::backward_impl, conv2d have at most 3 inputs");
   }
 }
-
 
 CudnnMaxPooling2DOp::CudnnMaxPooling2DOp(const std::vector<unsigned>& ksize, const std::vector<unsigned>& stride,
       const bool padding_type) {
@@ -255,15 +291,16 @@ void CudnnMaxPooling2DOp::forward_impl(const Device_GPU & dev, const std::vector
   unsigned YW = fx.d[1];
 
   // infer pad_h, pad_w
+  int pad_h = 0, pad_w = 0;
   if (!is_valid_) {
     pad_h = std::max<int>(0, (YH - 1) * stride_[0] + ksize_[0] - XH) / 2;
     pad_w = std::max<int>(0, (YW - 1) * stride_[1] + ksize_[1] - XW) / 2;
   }
 
-  CUDNN_CHECK(cudnnSetTensor4dDescriptor(x_desc_, 
+  CUDNN_CHECK(cudnnSetTensor4dDescriptor(x_desc_,
               CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
               XN, XC, XW, XH));
-  CUDNN_CHECK(cudnnSetTensor4dDescriptor(y_desc_, 
+  CUDNN_CHECK(cudnnSetTensor4dDescriptor(y_desc_,
               CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
               YN, YC, YW, YH));
   CUDNN_CHECK(cudnnSetPooling2dDescriptor(pooling_desc_,
@@ -281,18 +318,49 @@ void CudnnMaxPooling2DOp::backward_impl(const Device_GPU & dev,
               const Tensor& dEdf,
               unsigned i,
               Tensor& dEdxi) {
+  if (mempool_ == NULL)
+    throw std::runtime_error("dynet::CudnnMaxPooling2DOp::mempool_ not set");
   const Tensor* x = xs[0]; 
   const Tensor* y = &fx; 
   const Tensor* dy = &dEdf;
-  Tensor* dxi = &dEdxi;
+  void* dxi = NULL;
+
+  unsigned XN = x->d.bd;
+  unsigned XC = x->d[2];
+  unsigned XH = x->d[0];
+  unsigned XW = x->d[1];
+  unsigned YN = fx.d.bd;
+  unsigned YC = fx.d[2];
+  unsigned YH = fx.d[0];
+  unsigned YW = fx.d[1];
+
+  // infer pad_h, pad_w
+  int pad_h = 0, pad_w = 0;
+  if (!is_valid_) {
+    pad_h = std::max<int>(0, (YH - 1) * stride_[0] + ksize_[0] - XH) / 2;
+    pad_w = std::max<int>(0, (YW - 1) * stride_[1] + ksize_[1] - XW) / 2;
+  }
+
+  CUDNN_CHECK(cudnnSetTensor4dDescriptor(x_desc_,
+              CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
+              XN, XC, XW, XH));
+  CUDNN_CHECK(cudnnSetTensor4dDescriptor(y_desc_,
+              CUDNN_TENSOR_NCHW, DataTypeToCudnnType<float>::value,
+              YN, YC, YW, YH));
+  CUDNN_CHECK(cudnnSetPooling2dDescriptor(pooling_desc_,
+              CUDNN_POOLING_MAX, CUDNN_NOT_PROPAGATE_NAN,
+              ksize_[1], ksize_[0], pad_w, pad_h, stride_[1], stride_[0]));
+
   // here we could reuse the descriptor we created for forward, because 
   // they share the same size
   float alpha = 1.f, beta = 0.f;
+  dxi = mempool_->allocate(sizeof(float) * XN * XC * XH * XW);
   CUDNN_CHECK(cudnnPoolingBackward(dev.cudnnHandle, pooling_desc_,
-              &alpha, y_desc_, y->v, y_desc_, dy->v, 
-              x_desc_, x->v, &beta, x_desc_, dxi->v));
+              &alpha, y_desc_, y->v, y_desc_, dy->v,
+              x_desc_, x->v, &beta, x_desc_, dxi));
+  CUDNN_CHECK(cudnnAddTensor(dev.cudnnHandle, &alpha,
+              x_desc_, dxi, &alpha, x_desc_, dEdxi.v));
 }
-
 
 } // namespace dynet
 

--- a/dynet/cudnn-ops.h
+++ b/dynet/cudnn-ops.h
@@ -15,6 +15,7 @@ class CudnnConvOp {
   ~CudnnConvOp();
   /* call this function before using the CudnnConvOp */
   void set_pool(NodeMemPool* mempool) {
+    DYNET_ASSERT(mempool->used() == 0, "mempool must have been reset");
     mempool_ = mempool;
   }
   void forward_impl(const Device_GPU & dev, const std::vector<const Tensor*>& xs, Tensor& fx);
@@ -27,8 +28,8 @@ class CudnnConvOp {
   static const size_t workspace_size_limit_bytes = 8 * 1024 * 1024;
 
  protected:
-  std::vector<int> stride;
-  bool is_valid;
+  std::vector<int> stride_;
+  bool is_valid_;
 
   /* cuDNN resource */
   cudnnTensorDescriptor_t x_desc_, y_desc_;
@@ -48,10 +49,6 @@ class CudnnConvOp {
   void* bwd_data_workspace;
 
  private:
-  int pad_h = 0;
-  int pad_w = 0;
-  Tensor padded_x;
-  Tensor padded_dx;
   NodeMemPool* mempool_;
 };
 
@@ -62,6 +59,11 @@ class CudnnMaxPooling2DOp {
   explicit CudnnMaxPooling2DOp(const std::vector<unsigned>& ksize, const std::vector<unsigned>& stride,
       const bool padding_type);
   ~CudnnMaxPooling2DOp();
+  /* call this function before using the CudnnMaxPooling2DOp */
+  void set_pool(NodeMemPool* mempool) {
+    DYNET_ASSERT(mempool->used() == 0, "mempool must have been reset");
+    mempool_ = mempool;
+  }
   void forward_impl(const Device_GPU & dev, const std::vector<const Tensor*>& xs, Tensor& fx);
   void backward_impl(const Device_GPU & dev,
                 const std::vector<const Tensor*>& xs,
@@ -81,8 +83,6 @@ class CudnnMaxPooling2DOp {
 
  private:
   NodeMemPool* mempool_;
-  int pad_h = 0;
-  int pad_w = 0;
 };
 
 } // namespace dynet

--- a/dynet/nodes-maxpooling2d.cc
+++ b/dynet/nodes-maxpooling2d.cc
@@ -58,17 +58,7 @@ Dim MaxPooling2D::dim_forward(const vector<Dim>& xs) const {
 }
 
 size_t MaxPooling2D::aux_storage_size() const {
-  vector<unsigned> input_size(arity());
-  for (unsigned i = 0; i < arity(); ++i) {
-    input_size[i] = get_cg()->nodes[args[i]]->dim.size();
-  }
-  size_t nbytes = 0;
-#if HAVE_CUDNN
-  nbytes += 0;
-#else
-  nbytes += sizeof(float) * (2 * input_size[0] + 2 * input_size[1] + dim.size());
-#endif
-  return nbytes;
+  return sizeof(float) * (2 * get_cg()->nodes[args[0]]->dim.size() + dim.size());
 }
 #endif
 
@@ -77,17 +67,18 @@ void MaxPooling2D::forward_dev_impl(const MyDevice & dev, const vector<const Ten
   DYNET_ASSERT(xs.size() == 1, "Failed dimension check in MaxPooling2D::forward, exactly one input");
   DYNET_ASSERT(fx.d.bd == xs[0]->d.bd, "Failed dimension check in MaxPooling2D::forward, batchsize not match");
   DYNET_ASSERT(fx.d[2] == xs[0]->d[2], "Failed dimension check in MaxPooling2D::forward, #channel not match");
+  NodeMemPool aux_mem_pool = NodeMemPool(aux_storage_size(), aux_mem);
 #ifdef __CUDACC__
 #if HAVE_CUDNN
   if (cudnn_maxpool_op_ == NULL) {
     cudnn_maxpool_op_ = new CudnnMaxPooling2DOp(ksize, stride, is_valid);
   }
+  cudnn_maxpool_op_->set_pool(&aux_mem_pool);
   cudnn_maxpool_op_->forward_impl(dev, xs, fx);
 #else
   throw std::runtime_error("MaxPooling2D::forward_dev_impl not supported without CUDNN");
 #endif
 #else
-  NodeMemPool aux_mem_pool = NodeMemPool(aux_storage_size(), aux_mem);
   Eigen::PaddingType padding_type = is_valid ? Eigen::PADDING_VALID : Eigen::PADDING_SAME;
   // convert x from HWCN to CHWN
   void* CHWN_x_mem = aux_mem_pool.allocate(xs[0]->d.size() * sizeof(float));
@@ -115,9 +106,13 @@ void MaxPooling2D::backward_dev_impl(const MyDevice & dev,
   DYNET_ASSERT(dEdf.d == fx.d, "Failed dimension check in MaxPooling2D::backward");
   DYNET_ASSERT(dEdxi.d == xs[i]->d, "Failed dimension check in MaxPooling2D::backward");
   DYNET_ASSERT(i == 0, "Failed dimension check in MaxPooling2D::backward: i must be 0");
+  NodeMemPool aux_mem_pool = NodeMemPool(aux_storage_size(), aux_mem);
 #ifdef __CUDACC__
 #if HAVE_CUDNN
-  DYNET_ASSERT(cudnn_maxpool_op_ != NULL, "cudnn maxpool operator is not initialized");
+  if (cudnn_maxpool_op_ == NULL) {
+    cudnn_maxpool_op_ = new CudnnMaxPooling2DOp(ksize, stride, is_valid);
+  }
+  cudnn_maxpool_op_->set_pool(&aux_mem_pool);
   cudnn_maxpool_op_->backward_impl(dev, xs, fx, dEdf, i, dEdxi);
 #else
   throw std::runtime_error("MaxPooling2D::backward_dev_impl not supported without CUDNN");

--- a/dynet/op-helper.h
+++ b/dynet/op-helper.h
@@ -53,6 +53,10 @@ struct NodeMemPool {
     return capacity_;
   }
 
+  size_t used() {
+    return used_;
+  }
+
  private:
   size_t capacity_;
   size_t used_;

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1196,6 +1196,9 @@ BOOST_AUTO_TEST_CASE( conv2d_same_gradient ) {
                                          .111f, -.122f, -.033f, -.112f, -.022f, -.132f, -.113f, -.123f, -.133f,
                                          .211f, .222f, .233f, .212f, .222f, .232f};
   TensorTools::set_elements(param_kernel.get()->values, param_kernel_vals);
+  Parameter param_kernel2 = mod.add_parameters({2, 2, 3, 2});
+  TensorTools::set_elements(param_kernel2.get()->values, param_kernel_vals);
+
   std::vector<float> conv2d_batch_vals(2 * 50 * 50 * 2);
   for (unsigned i = 0; i < conv2d_batch_vals.size(); ++i) {
     conv2d_batch_vals[i] = i * 0.011f + (i+1) * 0.001f;
@@ -1204,8 +1207,10 @@ BOOST_AUTO_TEST_CASE( conv2d_same_gradient ) {
   Expression kernel = parameter(cg, param_kernel);
   vector<unsigned> stride = {4, 4}; bool is_valid = false;
   Expression y = conv2d(x, kernel, stride, is_valid);
-  Expression z = sum_batches(sum_elems(y));
-  BOOST_CHECK(check_grad(mod, z, 0));
+  Expression kernel2 = parameter(cg, param_kernel2);
+  Expression y2 = conv2d(y, kernel2, stride, is_valid);
+  Expression z = sum_batches(sum_elems(y2));
+  BOOST_CHECK(check_grad(mod, z, 5));
 }
 
 BOOST_AUTO_TEST_CASE( maxpooling2d_same_gradient ) {

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1210,7 +1210,7 @@ BOOST_AUTO_TEST_CASE( conv2d_same_gradient ) {
   Expression kernel2 = parameter(cg, param_kernel2);
   Expression y2 = conv2d(y, kernel2, stride, is_valid);
   Expression z = sum_batches(sum_elems(y2));
-  BOOST_CHECK(check_grad(mod, z, 5));
+  BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 BOOST_AUTO_TEST_CASE( maxpooling2d_same_gradient ) {


### PR DESCRIPTION
#594 

The commit refactors the conv2d and maxpooling2d code a bit. It also resolves two issues: 

- Allow the backward_impl function to execute independently of the forward function, so that you can call backward_impl function without calling foward_impl first (as long as you have a feasible dy)

- The gradients shall be accumulated instead of being assigned. The CPU implementation accumulates them properly but the GPU implementation not. This commit fixes that.