### PR TITLE
Made select_rows work with dimensions other than 2

### DIFF
--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -76,10 +76,11 @@ string SelectRows::as_string(const vector<string>& arg_names) const {
 }
 
 Dim SelectRows::dim_forward(const vector<Dim>& xs) const {
-  DYNET_ARG_CHECK(xs.size() == 1 && xs[0].ndims() == 2, "Bad arguments in SelectRows: " << xs);
+  DYNET_ARG_CHECK(xs.size() == 1, "Bad arguments in SelectRows: " << xs);
   unsigned nrows = prows->size();
-  if (xs[0].ndims() == 1) return Dim({nrows});
-  return Dim({nrows, xs[0].cols()});
+  Dim ret(xs[0]);
+  ret.d[0] = nrows;
+  return ret;
 }
 
 string SelectCols::as_string(const vector<string>& arg_names) const {

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1978,7 +1978,7 @@ void SelectRows::forward_dev_impl(const MyDevice & dev, const vector<const Tenso
   for (unsigned i = 0; i < rm.size(); ++i) {
     DYNET_ARG_CHECK(rm[i] < xs[0]->d.rows(),
                             "Out-of-bounds index " << rm[i] << " in SelectRows over expression of dimensions " << xs[0]->d);
-    fx.t<2>().chip<0>(i).device(*dev.edevice) = xs[0]->t<2>().chip<0>(rm[i]);
+    fx.t<4>().chip<0>(i).device(*dev.edevice) = xs[0]->t<4>().chip<0>(rm[i]);
   }
 }
 
@@ -1992,7 +1992,7 @@ void SelectRows::backward_dev_impl(const MyDevice & dev,
   DYNET_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectRows::backward");
   auto& rm = *prows;
   for (unsigned i = 0; i < rm.size(); ++i)
-    dEdxi.t<2>().chip<0>(rm[i]).device(*dev.edevice) += dEdf.t<2>().chip<0>(i);
+    dEdxi.t<4>().chip<0>(rm[i]).device(*dev.edevice) += dEdf.t<4>().chip<0>(i);
 }
 DYNET_NODE_INST_DEV_IMPL(SelectRows)
 


### PR DESCRIPTION
Before select_rows only worked with matrices, now it works with arbitrary tensors.