### PR TITLE
Fixed bug in autobatch crossent of different sizes

### DIFF
--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -742,7 +742,8 @@ Dim PickNegLogSoftmax::dim_forward(const vector<Dim>& xs) const {
 
 int PickNegLogSoftmax::autobatch_sig(const ComputationGraph & cg, SigMap &sm) const {
   Sig s(nt::pnls);
-  s.add_dim(dim);
+  const Dim &in_dim = cg.nodes[args[0]]->dim;
+  s.add_dim(in_dim);
   return sm.get_idx(s);
 }
 std::vector<int> PickNegLogSoftmax::autobatch_concat(const ComputationGraph & cg) const {
@@ -843,8 +844,8 @@ Dim PickRange::dim_forward(const vector<Dim>& xs) const {
 
 int PickRange::autobatch_sig(const ComputationGraph & cg, SigMap &sm) const {
   Sig s(nt::pickrange);
-  const Dim &dim = cg.nodes[args[0]]->dim;
-  s.add_dim(dim);
+  const Dim &in_dim = cg.nodes[args[0]]->dim;
+  s.add_dim(in_dim);
   s.add_node(start);
   s.add_node(end);
   return sm.get_idx(s);


### PR DESCRIPTION
This is another potential fix to https://github.com/clab/dynet/issues/584

Basically, when autobatching is checking whether two `pickneglogsoftmax` operations can be batched it is supposed to check if the inputs are the same dimension, but it was instead checking whether the outputs are the same dimension (which is always 1).