### PR TITLE
Support static libraries of boost.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,7 +3,10 @@ enable_testing()
 
 find_package(Boost COMPONENTS system filesystem unit_test_framework serialization REQUIRED)
 include_directories(${TEST_SOURCE_DIR}/src ${Boost_INCLUDE_DIRS})
-add_definitions(-DBOOST_TEST_DYN_LINK)
+
+if (NOT Boost_USE_STATIC_LIBS)
+  add_definitions(-DBOOST_TEST_DYN_LINK)
+endif()
 
 foreach(TESTNAME dynet exec io mem nodes params tensor trainers serialize rnn)
 


### PR DESCRIPTION
CMake provides Boost_USE_STATIC_LIBS option to make the program
link to boost statically. However, in the current version of
DyNet, BOOST_TEST_DYN_LINK option is set unconditionally. It
causes problem when Boost_USE_STATIC_LIBS is on.

This patch adds condition when setting BOOST_TEST_DYN_LINK. Now
DyNet can statically link to boost with Boost_USE_STATIC_LIBS.