### PR TITLE
Protected Dict attributes instead of private

### DIFF
--- a/dynet/dict.h
+++ b/dynet/dict.h
@@ -68,7 +68,7 @@ public:
   
   void clear() { words_.clear(); d_.clear(); }
 
-private:
+protected:
   bool frozen;
   bool map_unk; // if true, map unknown word to unk_id
   int unk_id; 


### PR DESCRIPTION
Hello,
I just made the switch to V2. I have a huge codebase that makes an extensive use of dynet Dicts. I moved to the new save/load method for my NN paramaters, however, for convenience reasons, I want to use boost::serialization for Dicts.
This commit only change the scope of Dict attributes from private to protected.

This allows me do to the following non-intrusive hack in my own code :
`
struct Dict : public dynet::Dict                
{  
     template<class Archive> 
     void serialize(Archive& ar, const unsigned int)                                                  
     {       
             ar & frozen;
             ar & map_unk;                       
             ar & unk_id;                        
             ar & words_;                        
             ar & d_;                            
     }                                           
};
`

Note : both documentation and example seems to be leaking of explanation about saving/loading dict.