### PR TITLE
Remove Boost from Python setup.py

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -76,7 +76,7 @@ ext_cpu = Extension(
         language="c++",              # this causes Pyrex/Cython to create C++ source
         include_dirs=["${PROJECT_SOURCE_DIR}", # this is the location of the main dynet directory.
                       "${EIGEN3_INCLUDE_DIR}", # this is the directory where eigen is saved.
-                      ], # this is the directory where boost is.
+                      ],
         libraries=LIBRARIES,             # ditto
         library_dirs=LIBRARY_DIRS,
         extra_link_args=EXTRA_LINK_ARGS,
@@ -91,7 +91,7 @@ ext_gpu = Extension(
         language="c++",              # this causes Pyrex/Cython to create C++ source
         include_dirs=["${PROJECT_SOURCE_DIR}", # this is the location of the main dynet directory.
                       "${EIGEN3_INCLUDE_DIR}", # this is the directory where eigen is saved.
-                      ], # this is the directory where boost is.
+                      ],
         libraries=GPULIBRARIES,             # ditto
         library_dirs=GPULIBRARY_DIRS,
         extra_link_args=EXTRA_LINK_ARGS,

--- a/setup.py
+++ b/setup.py
@@ -119,14 +119,6 @@ class build(_build):
             "-DEIGEN3_INCLUDE_DIR=" + os.path.join(self.build_dir, "eigen"),
             "-DPYTHON=" + self.py_executable,
             ]
-        boost_prefix = os.environ.get("BOOST")
-        if boost_prefix:
-            cmake_cmd += [
-                "-DBOOST_ROOT:PATHNAME=" + boost_prefix,
-                "-DBoost_NO_BOOST_CMAKE=TRUE",
-                "-DBoost_NO_SYSTEM_PATHS=TRUE",
-                "-DBoost_LIBRARY_DIRS:FILEPATH=" + boost_prefix + "/lib",
-            ]
         log.info("Configuring...")
         if run_process(cmake_cmd) != 0:
             raise DistutilsSetupError(" ".join(cmake_cmd))


### PR DESCRIPTION
Boost is only needed for unit tests. Since those are not run when installing using pip, the Boost option is not needed.