### PR TITLE
Some fixes and functionalities

### DIFF
--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -724,6 +724,7 @@ struct SimpleSGDTrainer : public Trainer {
 
 struct CyclicalSGDTrainer : public Trainer {
   explicit CyclicalSGDTrainer(ParameterCollection& m, real e0_min = 0.01, real e0_max = 0.1, real step_size = 2000, real gamma = 0.0, real edecay = 0.0);
+  void update(real scale = 1.0);
 };
 
 struct MomentumSGDTrainer : public Trainer {

--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -817,7 +817,9 @@ struct CoupledLSTMBuilder : public RNNBuilder {
 
   void copy(const RNNBuilder& params) override;
 
+  void set_dropout(float d);
   void set_dropout(float d, float d_h, float d_c);
+  void disable_dropout();
 
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;
@@ -858,7 +860,9 @@ struct VanillaLSTMBuilder : public RNNBuilder {
 
   void copy(const RNNBuilder & params) override;
 
+  void set_dropout(float d);
   void set_dropout(float d, float d_r);
+  void disable_dropout();
 
   // first index is layer, then ...
   std::vector<std::vector<Parameter>> params;

--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -444,6 +444,7 @@ Expression input(ComputationGraph& g, const Dim& d, const std::vector<unsigned i
 Expression parameter(ComputationGraph& g, Parameter p);
 Expression parameter(ComputationGraph& g, LookupParameter lp);
 Expression const_parameter(ComputationGraph& g, Parameter p);
+Expression const_parameter(ComputationGraph& g, LookupParameter lp);
 Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index);
 Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex);
 Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index);

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
@@ -71,6 +71,8 @@ object Expression {
   def parameter(lp: LookupParameter): Expression = makeExpr(cg => dn.parameter(cg, lp.lookupParameter), Seq(lp))
   def constParameter(p: Parameter): Expression =
     makeExpr(cg => dn.const_parameter(cg, p.parameter), Seq(p))
+  def constParameter(lp: LookupParameter): Expression =
+    makeExpr(cg => dn.const_parameter(cg, lp.lookupParameter), Seq(lp))
 
   def lookup(p: LookupParameter, index: Long) =
     makeExpr(cg => dn.lookup(cg, p.lookupParameter, index), Seq(p))

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Trainer.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Trainer.scala
@@ -15,6 +15,9 @@ class Trainer private[dynet](_trainer: internal.Trainer) {
 
   def clipThreshold: Float = _trainer.getClip_threshold
   def clipThreshold_=(x: Float): Unit = _trainer.setClip_threshold(x)
+
+  def eta:Float = _trainer.getEta()
+  def eta_=(x:Float): Unit = _trainer.setEta(x)
 }
 
 class SimpleSGDTrainer private[dynet] (private[dynet] val trainer: internal.SimpleSGDTrainer)
@@ -34,7 +37,7 @@ class CyclicalSGDTrainer private[dynet] (private[dynet] val trainer: internal.Cy
 }
 
 class MomentumSGDTrainer private[dynet] (private[dynet] val trainer: internal.MomentumSGDTrainer)
-    extends Trainer(trainer)
+  extends Trainer(trainer)
 {
   def this(m: ParameterCollection, e0: Float = 0.01f, mom: Float = 0.9f, edecay: Float = 0.0f) {
     this(new internal.MomentumSGDTrainer(m.model, e0, mom, edecay))
@@ -42,7 +45,7 @@ class MomentumSGDTrainer private[dynet] (private[dynet] val trainer: internal.Mo
 }
 
 class AdagradTrainer private[dynet] (private[dynet] val trainer: internal.AdagradTrainer)
-    extends Trainer(trainer)
+  extends Trainer(trainer)
 {
   def this(m: ParameterCollection, e0: Float = 0.1f, eps: Float = 1e-20f, edecay: Float = 0.0f) {
     this(new internal.AdagradTrainer(m.model, e0, eps, edecay))
@@ -58,7 +61,7 @@ class AdadeltaTrainer private[dynet] (private[dynet] val trainer: internal.Adade
 }
 
 class RMSPropTrainer private[dynet] (private[dynet] val trainer: internal.RMSPropTrainer)
-    extends Trainer(trainer)
+  extends Trainer(trainer)
 {
   def this(m: ParameterCollection, e0: Float = 0.001f, eps: Float = 1e-8f, rho: Float = 0.9f, edecay: Float = 0.0f) {
     this(new internal.RMSPropTrainer(m.model, e0, eps, rho, edecay))
@@ -66,10 +69,10 @@ class RMSPropTrainer private[dynet] (private[dynet] val trainer: internal.RMSPro
 }
 
 class AdamTrainer private[dynet] (private[dynet] val trainer: internal.AdamTrainer)
-    extends Trainer(trainer)
+  extends Trainer(trainer)
 {
   def this(m: ParameterCollection, e0: Float = 0.001f, beta1: Float = 0.9f, beta2: Float = 0.999f,
-    eps: Float = 1e-8f, edecay: Float = 0.0f) {
+           eps: Float = 1e-8f, edecay: Float = 0.0f) {
     this(new internal.AdamTrainer(m.model, e0, beta1, beta2, eps, edecay))
   }
 }


### PR DESCRIPTION
These commits
1) fix bug with CyclicalSGDTrainer.update(). Before this fix Trainer.update() was being called.
2) fix bug around set/disableDropout in LSTMBuilders.
3) add accessor to eta in Trainer.
4) add Expression.constParameter(lp: LookupParameter)

2 is a bit complicated. Before this fix, a) setDropout with one argument changed only dropout_rate, not dropout_rate_h or dropout_rate_c, b) if setDropout with multiple arguments is called and disableDropout and addInput are called after ComputationGraph.renew(), it results in an error inside native methods.
However, if I add one line in lstm.cc like this,
```
void VanillaLSTMBuilder::start_new_sequence_impl(const vector<Expression>& hinit) {
  cerr << "dropout_rate: " << dropout_rate << " dropout_rate_h: " << dropout_rate_h << "\n";
  h.clear();
  c.clear();
```
b) doesn't result in crash. Hopefully, with the fix things work as expected.