### PR TITLE
Skip saving zero gradients

### DIFF
--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -26,9 +26,7 @@ bool valid_pc_key(const std::string & s) {
 }
 
 bool grad_is_zero(const ParameterStorageBase & p){
-  float grad_norm;
-  p.g_squared_l2norm(&grad_norm);
-  return (grad_norm == 0);
+  return !p.has_grad();
 }
 
 void read_param_header(string line, string &type, string &name, Dim& dim,size_t& byte_count, bool& zero_grad){

--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -25,6 +25,26 @@ bool valid_pc_key(const std::string & s) {
   return valid_key(s);
 }
 
+bool grad_is_zero(const ParameterStorageBase & p){
+  float grad_norm;
+  p.g_squared_l2norm(&grad_norm);
+  return (grad_norm == 0);
+}
+
+void read_param_header(string line, string &type, string &name, Dim& dim,size_t& byte_count, bool& zero_grad){
+  // Read header
+  istringstream iss(line);
+  iss >> type >> name >> dim >> byte_count;
+  // Check whether gradient is 0
+  // Check for EOF (for backward compatibility)
+  string grad;
+  if (!iss.eof()){
+    iss >> grad;
+    if (grad == "ZERO_GRAD")
+      zero_grad = true;
+  }
+}
+
 TextFileSaver::TextFileSaver(const string & filename, bool append) :
         datastream(filename, append ? ofstream::app : ofstream::out) {
   if(!datastream)
@@ -69,9 +89,16 @@ void TextFileSaver::save(const ParameterStorage & p,
   std::ostringstream buffer;
   buffer.precision(FLOAT32_PRECISION);
   buffer << dynet::as_vector(p.values) << endl;
-  buffer << dynet::as_vector(p.g) << endl;
+  bool zero_grad = grad_is_zero(p);
+  if(!zero_grad)
+    buffer << dynet::as_vector(p.g) << endl;
   datastream << "#Parameter# " << (key.size() > 0 ? key : p.name) << ' '
-    << p.dim << ' ' << buffer.str().size() << endl;
+    << p.dim << ' ' << buffer.str().size();
+  if(zero_grad)
+    datastream << " ZERO_GRAD";
+  else
+    datastream << " FULL_GRAD";
+  datastream << endl;
   datastream.write(buffer.str().c_str(), buffer.str().size());
 }
 
@@ -80,8 +107,15 @@ void TextFileSaver::save(const LookupParameterStorage & p,
   std::ostringstream buffer;
   buffer.precision(FLOAT32_PRECISION);
   buffer << dynet::as_vector(p.all_values) << endl;
-  buffer << dynet::as_vector(p.all_grads) << endl;
-  datastream << "#LookupParameter# " << (key.size() > 0 ? key : p.name) << ' ' << p.all_dim << ' ' << buffer.str().size() << endl;
+  bool zero_grad = grad_is_zero(p);
+  if(!zero_grad)
+    buffer << dynet::as_vector(p.all_grads) << endl;
+  datastream << "#LookupParameter# " << (key.size() > 0 ? key : p.name) << ' ' << p.all_dim << ' ' << buffer.str().size();
+  if(zero_grad)
+    datastream << " ZERO_GRAD";
+  else
+    datastream << " FULL_GRAD";
+  datastream << endl;
   datastream.write(buffer.str().c_str(), buffer.str().size());
 }
 
@@ -92,6 +126,7 @@ void TextFileLoader::populate(ParameterCollection & model, const string & key) {
   ifstream datastream(dataname);
   if(!datastream) DYNET_RUNTIME_ERR("Could not read model from " << dataname);
   string line, type, name;
+  bool zero_grad = false;
   Dim dim;
   size_t byte_count = 0;
   vector<float> values;
@@ -101,7 +136,7 @@ void TextFileLoader::populate(ParameterCollection & model, const string & key) {
   string key_ = key;
   if (key_.back() != '/') key_ += "/";
   while(getline(datastream, line)) {
-    { istringstream iss(line); iss >> type >> name >> dim >> byte_count; }
+    read_param_header(line, type, name, dim, byte_count, zero_grad);
     // Skip ones that don't match
     if(key.size() != 0 && name.substr(0, key_.size()) != key_) {
       size_t offset = static_cast<size_t>(datastream.tellg()) + byte_count;
@@ -134,8 +169,12 @@ void TextFileLoader::populate(ParameterCollection & model, const string & key) {
     }
     { getline(datastream, line); istringstream iss(line); iss >> values; }
     TensorTools::set_elements(*value_t, values);
-    { getline(datastream, line); istringstream iss(line); iss >> values; }
-    TensorTools::set_elements(*grad_t, values);
+    if(!zero_grad){
+      { getline(datastream, line); istringstream iss(line); iss >> values; }
+      TensorTools::set_elements(*grad_t, values);
+    } else {
+      TensorTools::zero(*grad_t);
+    }
   }
   if(param_id != storage.params.size() || lookup_id != storage.lookup_params.size())
     DYNET_RUNTIME_ERR("Number of parameter/lookup parameter objects loaded from file (" << 
@@ -150,18 +189,23 @@ void TextFileLoader::populate(Parameter & param,
   ifstream datastream(dataname);
   if(!datastream) DYNET_RUNTIME_ERR("Could not read model from " << dataname);
   string line, type, name;
+  bool zero_grad=false;
   Dim dim;
   size_t byte_count = 0;
   while(getline(datastream, line)) {
-    { istringstream iss(line); iss >> type >> name >> dim >> byte_count; }
+    read_param_header(line, type, name, dim, byte_count, zero_grad);
     if(type == "#Parameter#" && name == key) {
       if(param.p->dim != dim)
         DYNET_RUNTIME_ERR("Attempted to populate parameter where arguments don't match (" << param.p->dim << " != " << dim << ")");
       vector<float> values(dim.size());
       { getline(datastream, line); istringstream iss(line); iss >> values; }
       TensorTools::set_elements(param.get_storage().values, values);
-      { getline(datastream, line); istringstream iss(line); iss >> values; }
-      TensorTools::set_elements(param.get_storage().g, values);
+      if(!zero_grad){
+        { getline(datastream, line); istringstream iss(line); iss >> values; }
+        TensorTools::set_elements(param.get_storage().g, values);
+      } else {
+        TensorTools::zero(param.get_storage().g);
+      }
       return;
     } else {
       size_t offset = static_cast<size_t>(datastream.tellg()) + byte_count;
@@ -178,18 +222,23 @@ void TextFileLoader::populate(LookupParameter & lookup_param,
   ifstream datastream(dataname);
   if(!datastream) DYNET_RUNTIME_ERR("Could not read model from " << dataname);
   string line, type, name;
+  bool zero_grad=false;
   Dim dim;
   size_t byte_count = 0;
   while(getline(datastream, line)) {
-    { istringstream iss(line); iss >> type >> name >> dim >> byte_count; }
+    read_param_header(line, type, name, dim, byte_count, zero_grad);
     if(type == "#LookupParameter#" && name == key) {
       if(lookup_param.p->all_dim != dim)
         DYNET_RUNTIME_ERR("Attempted to populate lookup parameter where arguments don't match (" << lookup_param.p->all_dim << " != " << dim << ")");
       vector<float> values(dim.size());
       { getline(datastream, line); istringstream iss(line); iss >> values; }
       TensorTools::set_elements(lookup_param.get_storage().all_values, values);
-      { getline(datastream, line); istringstream iss(line); iss >> values; }
-      TensorTools::set_elements(lookup_param.get_storage().all_grads, values);
+      if(!zero_grad){
+        { getline(datastream, line); istringstream iss(line); iss >> values; }
+        TensorTools::set_elements(lookup_param.get_storage().all_grads, values);
+      } else {
+        TensorTools::zero(lookup_param.get_storage().all_grads);
+      }
       return;
     } else {
       size_t offset = static_cast<size_t>(datastream.tellg()) + byte_count;
@@ -206,18 +255,23 @@ Parameter TextFileLoader::load_param(ParameterCollection & model,
   ifstream datastream(dataname);
   if(!datastream) DYNET_RUNTIME_ERR("Could not read model from " << dataname);
   string line, type, name;
+  bool zero_grad=false;
   Dim dim;
   size_t byte_count = 0;
   while(getline(datastream, line)) {
-    { istringstream iss(line); iss >> type >> name >> dim >> byte_count; }
+    read_param_header(line, type, name, dim, byte_count, zero_grad);
     if(type == "#Parameter#" && name == key) {
       Parameter param = model.add_parameters(dim);
       param.get_storage().name = name;
       vector<float> values(dim.size());
       { getline(datastream, line); istringstream iss(line); iss >> values; }
       TensorTools::set_elements(param.get_storage().values, values);
-      { getline(datastream, line); istringstream iss(line); iss >> values; }
-      TensorTools::set_elements(param.get_storage().g, values);
+      if(!zero_grad){
+        { getline(datastream, line); istringstream iss(line); iss >> values; }
+        TensorTools::set_elements(param.get_storage().g, values);
+      } else {
+        TensorTools::zero(param.get_storage().g);
+      }
       return param;
     } else {
       size_t offset = static_cast<size_t>(datastream.tellg()) + byte_count;
@@ -234,10 +288,11 @@ LookupParameter TextFileLoader::load_lookup_param(ParameterCollection & model,
   ifstream datastream(dataname);
   if(!datastream) DYNET_RUNTIME_ERR("Could not read model from " << dataname);
   string line, type, name;
+  bool zero_grad=false;
   Dim dim;
   size_t byte_count = 0;
   while(getline(datastream, line)) {
-    { istringstream iss(line); iss >> type >> name >> dim >> byte_count; }
+    read_param_header(line, type, name, dim, byte_count, zero_grad);
     if(type == "#LookupParameter#" && name == key) {
       vector<float> values(dim.size());
       size_t size = dim[dim.nd-1]; dim.nd--;
@@ -245,8 +300,12 @@ LookupParameter TextFileLoader::load_lookup_param(ParameterCollection & model,
       lookup_param.get_storage().name = name;
       { getline(datastream, line); istringstream iss(line); iss >> values; }
       TensorTools::set_elements(lookup_param.get_storage().all_values, values);
-      { getline(datastream, line); istringstream iss(line); iss >> values; }
-      TensorTools::set_elements(lookup_param.get_storage().all_grads, values);
+      if(!zero_grad){
+        { getline(datastream, line); istringstream iss(line); iss >> values; }
+        TensorTools::set_elements(lookup_param.get_storage().all_grads, values);
+      } else {
+        TensorTools::zero(lookup_param.get_storage().all_grads);
+      }
       return lookup_param;
     } else {
       size_t offset = static_cast<size_t>(datastream.tellg()) + byte_count;

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -70,6 +70,11 @@ struct ParameterStorageBase {
    */
   virtual bool is_updated() const = 0;
   /**
+   * @brief Check whether the gradient is zero or not (true if gradient is non-zero)
+   *
+   */
+  virtual bool has_grad() const = 0;
+  /**
    * @brief Get the size (number of scalar parameters)
    * @return Number of scalar parameters
    */
@@ -119,6 +124,7 @@ struct ParameterStorage : public ParameterStorageBase {
   void clear();
 
   bool is_updated() const override { return updated; }
+  bool has_grad() const override { return nonzero_grad; }
 
   std::string name; /**< Name of this parameter*/
 
@@ -127,10 +133,12 @@ struct ParameterStorage : public ParameterStorageBase {
    */
   void clip(float left, float right);
   
+
   Dim dim; /**< Dimensions of the parameter tensor*/
   Tensor values;/**< Values of the parameter */
   Tensor g;/**< Values of the gradient w.r.t. this parameter */
   bool updated; /**< Whether this is updated */
+  bool nonzero_grad; /**< Whether the gradient is zero */
   ParameterCollection* owner; /**< Pointer to the collection that "owns" this parameter */
 
 private:
@@ -216,6 +224,7 @@ struct LookupParameterStorage : public ParameterStorageBase {
   void initialize_lookups();
 
   bool is_updated() const override { return updated; }
+  bool has_grad() const override { return nonzero_grad; }
 
   std::string name; /**< Name of this parameter*/
   // Tensors for all dimensions at once
@@ -230,6 +239,7 @@ struct LookupParameterStorage : public ParameterStorageBase {
   std::unordered_set<unsigned> non_zero_grads; /**< Gradients are sparse, so track which components are nonzero */
   bool updated; /**< Whether this lookup parameter should be updated */
   bool all_updated; /** Whether all of the gradients have been updated. */
+  bool nonzero_grad; /**< Whether the gradient is zero */
   ParameterCollection* owner; /**< Pointer to the collection that "owns" this parameter */
 private:
   LookupParameterStorage() : updated(true), all_updated(false), owner(nullptr) {}

--- a/tests/test-io.cc
+++ b/tests/test-io.cc
@@ -155,6 +155,31 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter ) {
   DYNET_CHECK_EQUAL(m2c, mc);
 }
 
+BOOST_AUTO_TEST_CASE ( test_save_load_parameter_nonzerograd ) {
+  ParameterCollection m, m2;
+  Parameter ma = m.add_parameters({10}, "a");
+  ma.get_storage().nonzero_grad = true;
+  Parameter mb = m.add_parameters({3,7});
+  mb.get_storage().nonzero_grad = true;
+  LookupParameter mc = m.add_lookup_parameters(10, {2});
+  mc.get_storage().nonzero_grad = true;
+  Parameter m2a, m2b;
+  LookupParameter m2c;
+  {
+    dynet::TextFileSaver s("test.model");
+    s.save(m);
+  }
+  {
+    dynet::TextFileLoader s("test.model");
+    m2a = s.load_param(m2, ma.get_fullname());
+    m2b = s.load_param(m2, mb.get_fullname());
+    m2c = s.load_lookup_param(m2, mc.get_fullname());
+  }
+  DYNET_CHECK_EQUAL(m2a, ma);
+  DYNET_CHECK_EQUAL(m2b, mb);
+  DYNET_CHECK_EQUAL(m2c, mc);
+}
+
 BOOST_AUTO_TEST_CASE ( test_save1_perf ) {
   ParameterCollection m;
   for (int l = 0; l < 16; ++l)


### PR DESCRIPTION
This addresses #648 (in parts).

- Adds a `ZERO_GRAD`/`FULL_GRAD` flag in the parameter headers of serialized parameters. If the flag is set to  `ZERO_GRAD`, the gradient is not saved (and is set to zero upon loading)
- Adds a `nonzero_grad` field to ParameterStorage. This field is updated when calling `accumulate_grad` or `clear`

Wrt the second point, I initially checked the norm of the gradient before serializing but I think it might cause performance issues for big parameters, so I introduced the `nonzero_grad` field to keep track of the norm of the gradient.

One inconvenient of this approach is that if the value of the gradient is modified in any way other than with `accumulate_grad`, (like if the gradient is modified manually), this variable won't be updated.