### PR TITLE
Clean up includes for faster compile time

### DIFF
--- a/dynet/aligned-mem-pool.cc
+++ b/dynet/aligned-mem-pool.cc
@@ -1,6 +1,6 @@
 #include "aligned-mem-pool.h"
 
-#include <sstream>
+#include "dynet/except.h"
 
 using namespace dynet;
 

--- a/dynet/aligned-mem-pool.h
+++ b/dynet/aligned-mem-pool.h
@@ -1,10 +1,13 @@
 #ifndef DYNET_ALIGNED_MEM_POOL_H
 #define DYNET_ALIGNED_MEM_POOL_H
 
+#include <stddef.h>
 #include <iostream>
-#include "dynet/mem.h"
-#include "dynet/globals.h"
+#include <vector>
+
 #include "dynet/except.h"
+#include "dynet/globals.h"
+#include "dynet/mem.h"
 
 namespace dynet {
 

--- a/dynet/cfsm-builder.cc
+++ b/dynet/cfsm-builder.cc
@@ -1,9 +1,12 @@
 #include "dynet/cfsm-builder.h"
+
+#include <iostream>
+#include <string>
+
+#include "dynet/dynet.h"
 #include "dynet/except.h"
 #include "dynet/param-init.h"
-
-#include <fstream>
-#include <iostream>
+#include "dynet/tensor.h"
 
 using namespace std;
 

--- a/dynet/cfsm-builder.h
+++ b/dynet/cfsm-builder.h
@@ -1,14 +1,18 @@
 #ifndef DYNET_CFSMBUILDER_H
 #define DYNET_CFSMBUILDER_H
 
-#include <vector>
+#include <iosfwd>
 #include <string>
+#include <vector>
 
+#include "dynet/dict.h"
 #include "dynet/dynet.h"
 #include "dynet/expr.h"
-#include "dynet/dict.h"
+#include "dynet/model.h"
 
 namespace dynet {
+
+struct ComputationGraph;
 
 class SoftmaxBuilder {
 public:

--- a/dynet/cuda.cc
+++ b/dynet/cuda.cc
@@ -1,9 +1,11 @@
-#include <iostream>
-#include <vector>
+#include <stddef.h>
 #include <algorithm>
+#include <iostream>
+#include <stdexcept>
+#include <vector>
 
-#include "dynet/dynet.h"
-#include "dynet/cuda.h"
+#include "dynet/devices.h"
+#include "dynet/except.h"
 #include "dynet/init.h"
 
 using namespace std;

--- a/dynet/deep-lstm.cc
+++ b/dynet/deep-lstm.cc
@@ -1,11 +1,14 @@
 #include "dynet/deep-lstm.h"
+
+#include <iostream>
+#include <vector>
+
+#include "dynet/except.h"
 #include "dynet/param-init.h"
 
-#include <string>
-#include <vector>
-#include <iostream>
-
-#include "dynet/nodes.h"
+namespace dynet {
+struct ComputationGraph;
+}  // namespace dynet
 
 using namespace std;
 

--- a/dynet/deep-lstm.h
+++ b/dynet/deep-lstm.h
@@ -1,13 +1,17 @@
 #ifndef DYNET_DEEP_LSTM_H_
 #define DYNET_DEEP_LSTM_H_
 
+#include <vector>
+
 #include "dynet/dynet.h"
-#include "dynet/rnn.h"
 #include "dynet/expr.h"
+#include "dynet/model.h"
+#include "dynet/rnn.h"
 
 namespace dynet {
 
 class ParameterCollection;
+struct ComputationGraph;
 
 struct DeepLSTMBuilder : public RNNBuilder {
   DeepLSTMBuilder() = default;

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -1,13 +1,15 @@
 #include "dynet/devices.h"
 
 #include <iostream>
-#include <unsupported/Eigen/CXX11/Tensor>
+#include <string>
 
-#include "dynet/cuda.h"
+#include "dynet/aligned-mem-pool.h"
+#include "dynet/dim.h"
 #include "dynet/dynet.h"
-#include "dynet/expr.h"
 #include "dynet/except.h"
 #include "dynet/str-util.h"
+#include "dynet/tensor.h"
+#include "dynet/expr.h"
 
 using namespace std;
 

--- a/dynet/devices.h
+++ b/dynet/devices.h
@@ -1,13 +1,22 @@
 #ifndef DYNET_DEVICES_H
 #define DYNET_DEVICES_H
 
+#include <stddef.h>
+#include <iosfwd>
 #include <string>
+#include <vector>
+
 #include "dynet/aligned-mem-pool.h"
 #include "dynet/cuda.h"
+#include "dynet/mem.h"
+
+namespace dynet {
+class AlignedMemoryPool;
+}  // namespace dynet
 
 namespace Eigen {
-  struct DefaultDevice;
   class CudaStreamDevice;
+  struct DefaultDevice;
   struct GpuDevice;
 }
 

--- a/dynet/dict.cc
+++ b/dynet/dict.cc
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <vector>
-#include <sstream>
 
 using namespace std;
 

--- a/dynet/dict.h
+++ b/dynet/dict.h
@@ -1,11 +1,12 @@
 #ifndef DYNET_DICT_H_
 #define DYNET_DICT_H_
 
-#include <unordered_map>
-#include <string>
-#include <vector>
 #include <iostream>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "dynet/except.h"
 

--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -8,11 +8,12 @@
 #ifndef DYNET_DIM_H
 #define DYNET_DIM_H
 
-#include <initializer_list>
-#include <type_traits>
-#include <stdexcept>
-#include <iosfwd>
 #include <cstring>
+#include <initializer_list>
+#include <iosfwd>
+#include <ostream>
+#include <stdexcept>
+#include <type_traits>
 #include <vector>
 
 #include "dynet/except.h"

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -1,11 +1,13 @@
 #include "dynet/dynet.h"
 
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
 #include "dynet/exec.h"
-#include "dynet/nodes.h"
-#include "dynet/param-nodes.h"
-#include "dynet/aligned-mem-pool.h"
-#include "dynet/dynet-helper.h"
 #include "dynet/expr.h"
+#include "dynet/init.h"
+#include "dynet/param-nodes.h"
 
 using namespace std;
 

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -6,18 +6,21 @@
 #ifndef DYNET_DYNET_H_
 #define DYNET_DYNET_H_
 
-#include <string>
-#include <vector>
-#include <iostream>
+#include <stddef.h>
 #include <initializer_list>
+#include <iostream>
+#include <string>
+#include <type_traits>
 #include <utility>
+#include <vector>
 
-#include "dynet/init.h"
 #include "dynet/aligned-mem-pool.h"
-#include "dynet/tensor.h"
-#include "dynet/model.h"
 #include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/init.h"
+#include "dynet/model.h"
 #include "dynet/sig.h"
+#include "dynet/tensor.h"
 
 
 namespace dynet {
@@ -50,9 +53,9 @@ unsigned get_current_graph_id();
 extern Device* default_device; // where parameters go by default
 
 class ExecutionEngine;
-struct ParameterNodeBase;
-struct Node;
 struct Expression;
+struct Node;
+struct ParameterNodeBase;
 
 typedef unsigned VariableIndex;
 

--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -1,10 +1,21 @@
 #include "dynet/exec.h"
 
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <algorithm>
+#include <iostream>
+#include <map>
 #include <unordered_map>
-#include <queue>
+#include <utility>
 
-#include "dynet/param-nodes.h"
+#include "dynet/aligned-mem-pool.h"
+#include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/except.h"
 #include "dynet/globals.h"
+#include "dynet/init.h"
+#include "dynet/param-nodes.h"
 #include "dynet/timing.h"
 
 #ifdef HAVE_CUDA

--- a/dynet/exec.h
+++ b/dynet/exec.h
@@ -1,7 +1,12 @@
 #ifndef DYNET_EXEC_H
 #define DYNET_EXEC_H
 
+#include <stddef.h>
+#include <vector>
+
 #include "dynet/dynet.h"
+#include "dynet/sig.h"
+#include "dynet/tensor.h"
 
 namespace dynet {
 

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -1,13 +1,12 @@
 #include "dynet/expr.h"
-
-#include <initializer_list>
-
 #include "dynet/nodes.h"
 #include "dynet/nodes-conv.h"
 
+#include <iostream>
+
 namespace dynet {
 
-using std::vector;
+using namespace std;
 
 Expression input(ComputationGraph& g, real s) { return Expression(&g, g.add_input(s)); }
 Expression input(ComputationGraph& g, const real *ps) { return Expression(&g, g.add_input(ps)); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -18,10 +18,16 @@
 #ifndef DYNET_EXPR_H
 #define DYNET_EXPR_H
 
-#include "dynet/dynet.h"
-#include "dynet/nodes.h"
-#include "dynet/nodes-contract.h"
+#include <initializer_list>
 #include <stdexcept>
+#include <vector>
+
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
+#include "dynet/model.h"
+#include "dynet/nodes-contract.h"
+#include "dynet/nodes.h"
+#include "dynet/tensor.h"
 
 
 namespace dynet {
@@ -30,6 +36,14 @@ namespace dynet {
  * \brief Expressions are the building block of a Dynet computation graph
  * \details [long description]
  */
+struct AffineTransform;
+struct Average;
+struct Concatenate;
+struct ConcatenateToBatch;
+struct LogSumExp;
+struct Max;
+struct Sum;
+
 struct Expression {
   ComputationGraph *pg;
   VariableIndex i;

--- a/dynet/fast-lstm.cc
+++ b/dynet/fast-lstm.cc
@@ -1,11 +1,15 @@
 #include "dynet/fast-lstm.h"
+
+#include <stddef.h>
+#include <iostream>
+#include <vector>
+
+#include "dynet/except.h"
 #include "dynet/param-init.h"
 
-#include <string>
-#include <vector>
-#include <iostream>
-
-#include "dynet/nodes.h"
+namespace dynet {
+struct ComputationGraph;
+}  // namespace dynet
 
 using namespace std;
 

--- a/dynet/fast-lstm.h
+++ b/dynet/fast-lstm.h
@@ -1,13 +1,17 @@
 #ifndef DYNET_FAST_LSTM_H_
 #define DYNET_FAST_LSTM_H_
 
+#include <vector>
+
 #include "dynet/dynet.h"
-#include "dynet/rnn.h"
 #include "dynet/expr.h"
+#include "dynet/model.h"
+#include "dynet/rnn.h"
 
 namespace dynet {
 
 class ParameterCollection;
+struct ComputationGraph;
 
 /*
 FastLSTM replaces the matrices from cell to other units, by diagonal matrices.

--- a/dynet/globals.cc
+++ b/dynet/globals.cc
@@ -1,5 +1,5 @@
 #include "dynet/globals.h"
-#include "dynet/devices.h"
+
 #include "dynet/timing.h"
 
 namespace dynet {

--- a/dynet/globals.h
+++ b/dynet/globals.h
@@ -4,6 +4,8 @@
 #include <random>
 #include <vector>
 
+#include "dynet/timing.h"
+
 namespace dynet {
 
 class Device;

--- a/dynet/grad-check.cc
+++ b/dynet/grad-check.cc
@@ -1,12 +1,16 @@
 #include "dynet/grad-check.h"
 
-#include <iostream>
+#include <stddef.h>
 #include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <vector>
 
-#include "dynet/model.h"
+#include "dynet/dim.h"
 #include "dynet/dynet.h"
-#include "dynet/tensor.h"
 #include "dynet/expr.h"
+#include "dynet/model.h"
+#include "dynet/tensor.h"
 
 using namespace std;
 

--- a/dynet/grad-check.h
+++ b/dynet/grad-check.h
@@ -6,6 +6,7 @@
 namespace dynet {
 
 class ParameterCollection;
+struct Expression;
 struct ComputationGraph;
 
 // verbosity is zero for silence, one for only printing errors, two for everything

--- a/dynet/graph.cc
+++ b/dynet/graph.cc
@@ -1,7 +1,11 @@
 #include "dynet/graph.h"
-#include "dynet/dynet.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
 #include <vector>
-#include "dynet/dynet-helper.h"
+
+#include "dynet/dynet.h"
 
 using namespace std;
 

--- a/dynet/gru.cc
+++ b/dynet/gru.cc
@@ -1,12 +1,15 @@
 #include "dynet/gru.h"
 
-#include <string>
-#include <vector>
+#include <stddef.h>
 #include <iostream>
+#include <vector>
 
-#include "dynet/nodes.h"
-#include "dynet/training.h"
+#include "dynet/except.h"
 #include "dynet/param-init.h"
+
+namespace dynet {
+struct ComputationGraph;
+}  // namespace dynet
 
 using namespace std;
 

--- a/dynet/gru.h
+++ b/dynet/gru.h
@@ -1,12 +1,17 @@
 #ifndef DYNET_GRU_H_
 #define DYNET_GRU_H_
 
+#include <vector>
+
 #include "dynet/dynet.h"
+#include "dynet/expr.h"
+#include "dynet/model.h"
 #include "dynet/rnn.h"
 
 namespace dynet {
 
 class ParameterCollection;
+struct ComputationGraph;
 
 struct GRUBuilder : public RNNBuilder {
   GRUBuilder() = default;

--- a/dynet/hsm-builder.cc
+++ b/dynet/hsm-builder.cc
@@ -1,10 +1,14 @@
 #include "dynet/hsm-builder.h"
 
-#include <fstream>
+#include <stddef.h>
 #include <iostream>
-#include <sstream>
+#include <string>
+#include <utility>
 
+#include "dynet/dynet.h"
+#include "dynet/except.h"
 #include "dynet/param-init.h"
+#include "dynet/tensor.h"
 
 using namespace std;
 

--- a/dynet/hsm-builder.h
+++ b/dynet/hsm-builder.h
@@ -1,15 +1,20 @@
 #ifndef DYNET_HSMBUILDER_H
 #define DYNET_HSMBUILDER_H
 
-#include <vector>
+#include <iosfwd>
 #include <string>
 #include <unordered_map>
+#include <vector>
+
+#include "dynet/cfsm-builder.h"
+#include "dynet/dict.h"
 #include "dynet/dynet.h"
 #include "dynet/expr.h"
-#include "dynet/dict.h"
-#include "dynet/cfsm-builder.h"
+#include "dynet/model.h"
 
 namespace dynet {
+
+struct ComputationGraph;
 
 class Cluster {
 private:

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -1,16 +1,19 @@
 #include "dynet/init.h"
-#include "dynet/aligned-mem-pool.h"
-#include "dynet/dynet.h"
-#include "dynet/weight-decay.h"
-#include "dynet/globals.h"
 
 #include <iostream>
 #include <random>
-#include <cmath>
+#include <stdexcept>
+#include <string>
+
+#include "dynet/devices.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
+#include "dynet/globals.h"
 
 #if HAVE_CUDA
-#include "dynet/cuda.h"
 #include <device_launch_parameters.h>
+
+#include "dynet/cuda.h"
 #endif
 
 using namespace std;

--- a/dynet/init.h
+++ b/dynet/init.h
@@ -1,6 +1,7 @@
 #ifndef DYNET_EIGEN_INIT_H
 #define DYNET_EIGEN_INIT_H
 
+#include <iosfwd>
 #include <string>
 #include <vector>
 

--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -1,7 +1,12 @@
 #include "dynet/io.h"
-#include "dynet/tensor.h"
+
+#include <stddef.h>
+#include <string>
+
+#include "dynet/dim.h"
 #include "dynet/except.h"
 #include "dynet/str-util.h"
+#include "dynet/tensor.h"
 
 using namespace std;
 using namespace dynet;

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -1,20 +1,21 @@
 #ifndef DYNET_IO_H_
 #define DYNET_IO_H_
 
-#include <string>
-#include <vector>
-#include <sstream>
+#include <algorithm>
 #include <fstream>
 #include <iostream>
-#include <stdexcept>
-#include <unordered_map>
 #include <iterator>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
 
 #include "dynet/dim.h"
-#include "dynet/model.h"
-#include "dynet/tensor.h"
 #include "dynet/except.h"
+#include "dynet/model.h"
 #include "dynet/str-util.h"
+#include "dynet/tensor.h"
 
 namespace dynet {
 

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -1,12 +1,16 @@
 #include "dynet/lstm.h"
+
+#include <stddef.h>
+#include <iostream>
+#include <vector>
+
+#include "dynet/dim.h"
+#include "dynet/except.h"
 #include "dynet/param-init.h"
 
-#include <fstream>
-#include <string>
-#include <vector>
-#include <iostream>
-
-#include "dynet/nodes.h"
+namespace dynet {
+struct ComputationGraph;
+}  // namespace dynet
 
 using namespace std;
 

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -7,13 +7,18 @@
 #ifndef DYNET_LSTM_H_
 #define DYNET_LSTM_H_
 
+#include <vector>
+
 #include "dynet/dynet.h"
-#include "dynet/rnn.h"
 #include "dynet/expr.h"
+#include "dynet/model.h"
+#include "dynet/rnn.h"
 
 namespace dynet {
 
 class ParameterCollection;
+struct ComputationGraph;
+
 /**
  * \ingroup rnnbuilders
  * \brief CoupledLSTMBuilder creates an LSTM unit with coupled input and forget gate as well as peepholes connections.

--- a/dynet/mem.cc
+++ b/dynet/mem.cc
@@ -4,19 +4,18 @@
 #include <cstring>
 #include <iostream>
 #if !_WINDOWS
-#include <sys/shm.h>
 #include <sys/mman.h>
 #endif
 
-#include <fcntl.h>
 #if !_WINDOWS
 #include <mm_malloc.h>
 #endif
 #include "dynet/except.h"
 #if HAVE_CUDA
-#include "dynet/cuda.h"
 #include <cuda.h>
 #include <cuda_runtime.h>
+
+#include "dynet/cuda.h"
 #endif
 
 using namespace std;

--- a/dynet/mem.h
+++ b/dynet/mem.h
@@ -1,6 +1,7 @@
 #ifndef DYNET_MEM_H
 #define DYNET_MEM_H
 
+#include <stddef.h>
 #include <vector>
 
 namespace dynet {

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -2,7 +2,6 @@
 
 #include <math.h>
 #include <string.h>
-#include <__hash_table>
 #include <algorithm>
 #include <iostream>
 #include <stdexcept>

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -1,16 +1,22 @@
 #include "dynet/model.h"
-#include "dynet/tensor.h"
-#include "dynet/aligned-mem-pool.h"
-#include "dynet/dynet.h"
-#include "dynet/param-init.h"
-#include "dynet/io.h"
 
-#include <unordered_set>
-#include <iostream>
-#include <fstream>
-#include <sstream>
+#include <math.h>
+#include <string.h>
+#include <__hash_table>
 #include <algorithm>
+#include <iostream>
 #include <stdexcept>
+#include <unordered_set>
+
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/devices.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
+#include "dynet/init.h"
+#include "dynet/io.h"
+#include "dynet/mem.h"
+#include "dynet/param-init.h"
+#include "dynet/tensor.h"
 
 #define LOAD_INIT_FUNC() initialize_lookups()
 

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -7,15 +7,18 @@
 #ifndef DYNET_PARAMS_H_
 #define DYNET_PARAMS_H_
 
-#include <vector>
+#include <stddef.h>
+#include <iosfwd>
 #include <set>
-#include <unordered_set>
-#include <unordered_map>
-#include <string>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
-#include "dynet/weight-decay.h"
+#include "dynet/dim.h"
 #include "dynet/tensor.h"
+#include "dynet/weight-decay.h"
 
 namespace dynet {
 

--- a/dynet/mp.cc
+++ b/dynet/mp.cc
@@ -1,7 +1,6 @@
 #if !_WINDOWS
 #include "mp.h"
 
-#include <sys/_types/_time_t.h>
 #include <sys/types.h>
 #include <fstream>
 

--- a/dynet/mp.cc
+++ b/dynet/mp.cc
@@ -1,6 +1,12 @@
 #if !_WINDOWS
 #include "mp.h"
+
+#include <sys/_types/_time_t.h>
+#include <sys/types.h>
+#include <fstream>
+
 #include "dynet/except.h"
+
 using namespace std;
 using namespace boost::interprocess;
 

--- a/dynet/mp.h
+++ b/dynet/mp.h
@@ -1,30 +1,41 @@
 #pragma once
 #if !_WINDOWS
-#include "dynet/globals.h"
-#include "dynet/dynet.h"
-#include "dynet/training.h"
-#include "dynet/expr.h"
-#include "dynet/dict.h"
-#include "dynet/lstm.h"
 #include <boost/algorithm/string.hpp>
-#include <boost/interprocess/ipc/message_queue.hpp>
-#include <boost/interprocess/shared_memory_object.hpp>
-#include <boost/interprocess/mapped_region.hpp>
-#include <boost/interprocess/sync/interprocess_semaphore.hpp>
 #include <boost/interprocess/anonymous_shared_memory.hpp>
-
+#include <boost/interprocess/ipc/message_queue.hpp>
+#include <boost/interprocess/mapped_region.hpp>
+#include <boost/interprocess/shared_memory_object.hpp>
+#include <boost/interprocess/sync/interprocess_semaphore.hpp>
+#include <stdlib.h>
+#include <sys/_types/_timespec.h>
+#include <sys/shm.h>
 #include <sys/types.h>
 #include <sys/wait.h>
-#include <sys/shm.h>
-#include <iostream>
-#include <limits>
-#include <fstream>
-#include <vector>
-#include <utility>
-#include <sstream>
-#include <random>
+#include <unistd.h>
 #include <algorithm>
 #include <chrono>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <new>
+#include <numeric>
+#include <random>
+#include <sstream>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "boost/interprocess/creation_tags.hpp"
+#include "boost/interprocess/interprocess_fwd.hpp"
+#include "dynet/dict.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
+#include "dynet/expr.h"
+#include "dynet/globals.h"
+#include "dynet/lstm.h"
+#include "dynet/tensor.h"
+#include "dynet/training.h"
 
 namespace dynet {
   namespace mp {

--- a/dynet/mp.h
+++ b/dynet/mp.h
@@ -7,7 +7,6 @@
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <boost/interprocess/sync/interprocess_semaphore.hpp>
 #include <stdlib.h>
-#include <sys/_types/_timespec.h>
 #include <sys/shm.h>
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/dynet/nodes-affinetransform.cc
+++ b/dynet/nodes-affinetransform.cc
@@ -1,7 +1,16 @@
-#include "dynet/nodes.h"
+#include <string.h>
+#include <algorithm>
+#include <ostream>
+#include <vector>
 
+#include <Eigen/Core>
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
 #include "dynet/nodes-macros.h"
-#include "dynet/cuda-matrix-multiply.h"
+#include "dynet/nodes.h"
+#include "dynet/sig.h"
+#include "dynet/tensor.h"
 
 using namespace std;
 

--- a/dynet/nodes-affinetransform.cc
+++ b/dynet/nodes-affinetransform.cc
@@ -11,6 +11,7 @@
 #include "dynet/nodes.h"
 #include "dynet/sig.h"
 #include "dynet/tensor.h"
+#include "dynet/cuda-matrix-multiply.h"
 
 using namespace std;
 

--- a/dynet/nodes-common.cc
+++ b/dynet/nodes-common.cc
@@ -1,11 +1,14 @@
-#include "dynet/nodes.h"
-
-#include <limits>
-#include <cmath>
+#include <stddef.h>
+#include <algorithm>
 #include <sstream>
+#include <vector>
 
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
 #include "dynet/nodes-macros.h"
-#include "dynet/globals.h"
+#include "dynet/nodes.h"
+#include "dynet/sig.h"
 
 using namespace std;
 

--- a/dynet/nodes-contract.cc
+++ b/dynet/nodes-contract.cc
@@ -1,20 +1,24 @@
 #include "dynet/nodes-contract.h"
 
-#include <limits>
-#include <cmath>
+#include <algorithm>
+#include <array>
+#include <ostream>
 #include <stdexcept>
+#include <vector>
 
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/dim.h"
 #include "dynet/nodes-macros.h"
-#include "dynet/nodes.h"
+#include "dynet/tensor.h"
 
 // This file takes a long time to compile on GPU. Uncomment this line to skip it.
 #define DYNET_SKIP_CUDA_CONTRACTIONS
 
 
 #if defined(__CUDACC__) && !defined(DYNET_SKIP_CUDA_CONTRACTIONS)
-#include "dynet/nodes.cc"
 #include "dynet/cuda.h"
 #include "dynet/gpu-ops.h"
+#include "dynet/nodes.cc"
 #endif
 
 

--- a/dynet/nodes-contract.h
+++ b/dynet/nodes-contract.h
@@ -1,8 +1,10 @@
 #ifndef DYNET_NODES_CONTRACT_H_
 #define DYNET_NODES_CONTRACT_H_
 
-#include "dynet/dynet.h"
+#include <initializer_list>
+
 #include "dynet/devices.h"
+#include "dynet/dynet.h"
 #include "dynet/nodes-macros.h"
 
 // See nodes-macros.h for more details about DYNET_NODE_DEFINE_DEV_IMPL().

--- a/dynet/nodes-conv.cc
+++ b/dynet/nodes-conv.cc
@@ -1,15 +1,17 @@
 #include "dynet/nodes-conv.h"
 
-#include <sstream>
-#include <limits>
-#include <cmath>
-#include <stdexcept>
+#include <algorithm>
 #include <array>
+#include <functional>
+#include <sstream>
+#include <stdexcept>
 
-#include "dynet/functors.h"
+#include <Eigen/Core>
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/dim.h"
+#include "dynet/except.h"
 #include "dynet/nodes-macros.h"
-#include "third_party/eigen_spatial_convolutions.h"
-#include "third_party/eigen_backward_spatial_convolutions.h"
+#include "dynet/tensor.h"
 
 #if HAVE_CUDA
 #include "dynet/cuda.h"

--- a/dynet/nodes-conv.h
+++ b/dynet/nodes-conv.h
@@ -1,6 +1,10 @@
 #ifndef DYNET_NODES_CONV_H_
 #define DYNET_NODES_CONV_H_
 
+#include <stddef.h>
+#include <initializer_list>
+#include <vector>
+
 #include "dynet/dynet.h"
 #include "dynet/nodes-macros.h"
 #include "dynet/op-helper.h"

--- a/dynet/nodes-conv2d.cc
+++ b/dynet/nodes-conv2d.cc
@@ -1,16 +1,23 @@
-#include "dynet/nodes-conv.h"
-
+#include <stddef.h>
 #include <algorithm>
-#include <sstream>
-#include <limits>
-#include <cmath>
-#include <stdexcept>
 #include <array>
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
 
-#include "dynet/functors.h"
+#include <Eigen/Core>
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
+#include "dynet/nodes-conv.h"
 #include "dynet/nodes-macros.h"
-#include "third_party/eigen_spatial_convolutions.h"
+#include "dynet/op-helper.h"
+#include "dynet/tensor.h"
 #include "third_party/eigen_backward_spatial_convolutions.h"
+#include "third_party/eigen_spatial_convolutions.h"
 
 #if HAVE_CUDA
 #include "dynet/cuda.h"

--- a/dynet/nodes-hinge.cc
+++ b/dynet/nodes-hinge.cc
@@ -1,6 +1,14 @@
-#include "dynet/nodes.h"
+#include <stddef.h>
+#include <ostream>
+#include <vector>
 
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/except.h"
 #include "dynet/nodes-macros.h"
+#include "dynet/nodes.h"
+#include "dynet/tensor.h"
 
 using namespace std;
 

--- a/dynet/nodes-matrixmultiply.cc
+++ b/dynet/nodes-matrixmultiply.cc
@@ -10,6 +10,7 @@
 #include "dynet/nodes.h"
 #include "dynet/sig.h"
 #include "dynet/tensor.h"
+#include "dynet/cuda-matrix-multiply.h"
 
 using namespace std;
 

--- a/dynet/nodes-matrixmultiply.cc
+++ b/dynet/nodes-matrixmultiply.cc
@@ -1,7 +1,15 @@
-#include "dynet/nodes.h"
+#include <algorithm>
+#include <ostream>
+#include <vector>
 
+#include <Eigen/Core>
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
 #include "dynet/nodes-macros.h"
-#include "dynet/cuda-matrix-multiply.h"
+#include "dynet/nodes.h"
+#include "dynet/sig.h"
+#include "dynet/tensor.h"
 
 using namespace std;
 

--- a/dynet/nodes-maxpooling2d.cc
+++ b/dynet/nodes-maxpooling2d.cc
@@ -1,13 +1,19 @@
-#include "dynet/nodes-conv.h"
-
-#include <sstream>
-#include <limits>
-#include <cmath>
-#include <stdexcept>
+#include <stddef.h>
 #include <array>
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
 
-#include "dynet/functors.h"
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
+#include "dynet/nodes-conv.h"
 #include "dynet/nodes-macros.h"
+#include "dynet/op-helper.h"
+#include "dynet/tensor.h"
 #include "third_party/eigen_pooling.h"
 
 #if HAVE_CUDA

--- a/dynet/nodes-pickneglogsoftmax.cc
+++ b/dynet/nodes-pickneglogsoftmax.cc
@@ -1,6 +1,16 @@
-#include "dynet/nodes.h"
+#include <stddef.h>
+#include <ostream>
+#include <vector>
 
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
 #include "dynet/nodes-macros.h"
+#include "dynet/nodes.h"
+#include "dynet/sig.h"
+#include "dynet/tensor.h"
 
 #ifdef __CUDACC__
 #include "dynet/cuda.h"

--- a/dynet/nodes.cc
+++ b/dynet/nodes.cc
@@ -1,13 +1,20 @@
 #include "dynet/nodes.h"
 
-#include <limits>
+#include <algorithm>
+#include <array>
 #include <cmath>
-#include <stdexcept>
+#include <complex>
+#include <functional>
+#include <limits>
+#include <ostream>
+#include <random>
 
-#include "dynet/simd-functors.h"
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/devices.h"
 #include "dynet/functors.h"
-#include "dynet/nodes-macros.h"
 #include "dynet/globals.h"
+#include "dynet/nodes-macros.h"
+#include "dynet/simd-functors.h"
 
 #ifdef __CUDACC__
 #include "dynet/cuda.h"

--- a/dynet/nodes.h
+++ b/dynet/nodes.h
@@ -1,9 +1,17 @@
 #ifndef DYNET_NODES_H_
 #define DYNET_NODES_H_
 
-#include "dynet/dynet.h"
+#include <stddef.h>
+#include <initializer_list>
+#include <vector>
+
 #include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
+#include "dynet/except.h"
 #include "dynet/nodes-macros.h"
+#include "dynet/sig.h"
+#include "dynet/tensor.h"
 
 // See nodes-macros.h for more details about DYNET_NODE_DEFINE_DEV_IMPL().
 

--- a/dynet/param-init.cc
+++ b/dynet/param-init.cc
@@ -1,10 +1,16 @@
 #include "dynet/param-init.h"
+
+#include "dynet/devices.h"
+#include "dynet/dim.h"
 #include "dynet/tensor.h"
 
 using namespace dynet;
 using namespace std;
 
+#include <cmath>
 #include <fstream>
+#include <iterator>
+#include <string>
 
 void ParameterInitNormal::initialize_params(Tensor & values) const {
   TensorTools::randomize_normal(values, mean, sqrt(var));

--- a/dynet/param-init.h
+++ b/dynet/param-init.h
@@ -7,11 +7,11 @@
 #ifndef DYNET_PARAM_INIT_H_
 #define DYNET_PARAM_INIT_H_
 
-#include <stdexcept>
-#include <vector>
-#include <string>
 #include <fstream>
 #include <iterator>
+#include <stdexcept>
+#include <string>
+#include <vector>
 
 namespace dynet {
 

--- a/dynet/param-nodes.cc
+++ b/dynet/param-nodes.cc
@@ -1,11 +1,11 @@
 #include "dynet/param-nodes.h"
 
-#include <limits>
-#include <cmath>
-#include <stdexcept>
+#include <string.h>
+#include <ostream>
 
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/except.h"
 #include "dynet/nodes-macros.h"
-#include "dynet/weight-decay.h"
 
 #ifdef HAVE_CUDA
 #include "dynet/gpu-ops.h"

--- a/dynet/param-nodes.h
+++ b/dynet/param-nodes.h
@@ -1,9 +1,15 @@
 #ifndef DYNET_PARAM_NODES_H_
 #define DYNET_PARAM_NODES_H_
 
+#include <stddef.h>
+#include <vector>
+
+#include "dynet/dim.h"
 #include "dynet/dynet.h"
 #include "dynet/model.h"
 #include "dynet/nodes-macros.h"
+#include "dynet/sig.h"
+#include "dynet/tensor.h"
 
 namespace dynet {
 

--- a/dynet/pretrain.cc
+++ b/dynet/pretrain.cc
@@ -1,11 +1,14 @@
 #include "dynet/pretrain.h"
 
+#include <iostream>
+#include <fstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <iostream>
-#include <fstream>
+
+#include <Eigen/Core>
 #include "dynet/dict.h"
+#include "dynet/except.h"
 #include "dynet/model.h"
 
 using namespace std;

--- a/dynet/pretrain.h
+++ b/dynet/pretrain.h
@@ -1,13 +1,17 @@
 #ifndef DYNET_PRETRAIN_H
 #define DYNET_PRETRAIN_H
 
+#include <iosfwd>
 #include <string>
-#include <vector>
 #include <unordered_map>
+#include <vector>
+
 #include "dynet/dict.h"
 #include "dynet/model.h"
 
 namespace dynet {
+
+class Dict;
 
 void save_pretrained_embeddings(const std::string& fname,
     const Dict& d,

--- a/dynet/rnn-state-machine.cc
+++ b/dynet/rnn-state-machine.cc
@@ -1,16 +1,11 @@
 #include "dynet/rnn-state-machine.h"
 
-#include <iostream>
-
-#include "dynet/dynet.h"
-
-using namespace std;
+#include "dynet/except.h"
 
 namespace dynet {
 
 void RNNStateMachine::failure(RNNOp op) {
-  ostringstream oss; oss << "State transition error: currently in state " << q_ << " but received operation " << op;
-  throw std::invalid_argument(oss.str());
+  DYNET_RUNTIME_ERR("State transition error: currently in state " << q_ << " but received operation " << op);
 }
 
 } // namespace dynet

--- a/dynet/rnn.cc
+++ b/dynet/rnn.cc
@@ -1,13 +1,17 @@
 #include "dynet/rnn.h"
 
-#include <string>
-#include <vector>
+#include <stddef.h>
 #include <fstream>
-#include <iostream>
+#include <stdexcept>
+#include <vector>
 
-#include "dynet/nodes.h"
+#include "dynet/except.h"
 #include "dynet/expr.h"
 #include "dynet/param-init.h"
+
+namespace dynet {
+struct ComputationGraph;
+}  // namespace dynet
 
 using namespace std;
 using namespace dynet;

--- a/dynet/rnn.h
+++ b/dynet/rnn.h
@@ -9,13 +9,17 @@
 #ifndef DYNET_RNN_H_
 #define DYNET_RNN_H_
 
+#include <vector>
+
 #include "dynet/dynet.h"
-#include "dynet/rnn-state-machine.h"
 #include "dynet/expr.h"
+#include "dynet/model.h"
+#include "dynet/rnn-state-machine.h"
 
 namespace dynet {
 
 class ParameterCollection;
+struct ComputationGraph;
 
 typedef int RNNPointer;
 inline void swap(RNNPointer& i1, RNNPointer& i2) {

--- a/dynet/saxe-init.cc
+++ b/dynet/saxe-init.cc
@@ -1,11 +1,13 @@
 #include "dynet/saxe-init.h"
-#include "dynet/tensor.h"
-#include "dynet/globals.h"
 
+#include <algorithm>
 #include <random>
-#include <cstring>
 
+#include <Eigen/Core>
 #include <Eigen/SVD>
+#include "dynet/dim.h"
+#include "dynet/globals.h"
+#include "dynet/tensor.h"
 
 using namespace std;
 

--- a/dynet/shadow-params.cc
+++ b/dynet/shadow-params.cc
@@ -1,9 +1,12 @@
-#include "dynet/dynet.h"
-
 #include "dynet/shadow-params.h"
-#include "dynet/tensor.h"
-#include "dynet/aligned-mem-pool.h"
+
+#include <vector>
+
+#include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/dynet.h"
 #include "dynet/model.h"
+#include "dynet/tensor.h"
 
 #define LOAD_INIT_FUNC() initialize_lookups()
 

--- a/dynet/tensor.cc
+++ b/dynet/tensor.cc
@@ -1,13 +1,20 @@
 #include "dynet/tensor.h"
-#include "dynet/globals.h"
 
+#include <algorithm>
+#include <array>
+#include <cstring>
 #include <random>
 #include <vector>
-#include <cstring>
+
+#include <Eigen/Core>
+#include <Eigen/SVD>
+#include <unsupported/Eigen/CXX11/Tensor>
+#include "dynet/aligned-mem-pool.h"
+#include "dynet/globals.h"
 
 #ifdef __CUDACC__
-#include "dynet/gpu-ops.h"
 #include "dynet/cuda.h"
+#include "dynet/gpu-ops.h"
 #endif
 
 using namespace std;

--- a/dynet/tensor.h
+++ b/dynet/tensor.h
@@ -7,30 +7,33 @@
 #ifndef DYNET_EIGEN_TENSOR_H
 #define DYNET_EIGEN_TENSOR_H
 
+#include <stddef.h>
+#include <cmath>
 #include <initializer_list>
-#include <vector>
 #include <sstream>
 #include <stdexcept>
+#include <vector>
 
-#include "dynet/dim.h"
-#include "dynet/except.h"
 #include "dynet/aligned-mem-pool.h"
 #include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/except.h"
+#include <unsupported/Eigen/CXX11/Tensor>
 
 #if HAVE_CUDA
 #include <cuda.h>
 #include <cuda_runtime.h>
+
 #include "dynet/cuda.h"
 #endif
 
 // Following line is commented out because it causes errors with large nets (Antonis)
 //#define EIGEN_NO_MALLOC
 
-#ifndef __CUDACC__
-#include <Eigen/Eigen>
-#endif
+// #ifndef __CUDACC__
+// #include <Eigen/Eigen>
+// #endif
 
-#include <unsupported/Eigen/CXX11/Tensor>
 
 namespace dynet {
 

--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -1,8 +1,15 @@
 #include "dynet/training.h"
 
-// #include "dynet/gpu-ops.h"
-#include "dynet/param-nodes.h"
+#include <ostream>
+#include <stdexcept>
+
+#include "dynet/dynet.h"
+#include "dynet/model.h"
 #include "dynet/weight-decay.h"
+
+namespace Eigen {
+template <typename Derived> class MatrixBase;
+}  // namespace Eigen
 
 // Macros for defining parameter update functions
 #ifdef __CUDACC__

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -12,10 +12,21 @@
 #ifndef DYNET_TRAINING_H_
 #define DYNET_TRAINING_H_
 
+#include <stddef.h>
+#include <cmath>
+#include <iostream>
 #include <vector>
 
+#include "dynet/devices.h"
+#include "dynet/dim.h"
+#include "dynet/globals.h"
 #include "dynet/model.h"
 #include "dynet/shadow-params.h"
+#include "dynet/tensor.h"
+
+namespace dynet {
+class ParameterCollection;
+}  // namespace dynet
 
 #define DYNET_TRAINER_DEFINE_DEV_IMPL() \
   void update_params(real scale, real gscale, size_t idx) override; \

--- a/dynet/treelstm.cc
+++ b/dynet/treelstm.cc
@@ -1,10 +1,16 @@
-#include <string>
-#include <vector>
-#include <iostream>
-
-#include "dynet/nodes.h"
 #include "dynet/treelstm.h"
+
+#include <stdexcept>
+
+#include "dynet/except.h"
+#include "dynet/expr.h"
+#include "dynet/model.h"
+#include "dynet/rnn.h"
 #include "dynet/param-init.h"
+
+namespace dynet {
+struct ComputationGraph;
+}  // namespace dynet
 
 using namespace std;
 using namespace dynet;


### PR DESCRIPTION
Compile time for DyNet is somewhat slow. This PR speeds up compilation a bit by optimizing includes with include-what-you-use (https://include-what-you-use.org). There are still a number of places where we could move things from header files to .cc files though, which would further speed things up.