### PR TITLE
temporally fix a bug about negative padding in eigen conv2d

### DIFF
--- a/dynet/nodes-conv2d.cc
+++ b/dynet/nodes-conv2d.cc
@@ -175,7 +175,7 @@ void Conv2D::backward_dev_impl(const MyDevice & dev,
     CHWN_x.tb<3>().device(*dev.edevice) = xs[0]->tb<3>().shuffle(shuffles);
     void* NCHW_dEdxi_mem = aux_mem_pool.allocate(xs[1]->d.size() * sizeof(float));
     Tensor NCHW_dEdxi = Tensor(Dim({xs[1]->d[3], xs[1]->d[2], xs[1]->d[0], xs[1]->d[1]}), static_cast<float*>(NCHW_dEdxi_mem), dEdxi.device, DeviceMempool::FXS);
-    NCHW_dEdxi.t<4>().device(*dev.edevice) = Eigen::SpatialConvolutionBackwardKernel(CHWN_x.tb<3>(), CHWN_dy.tb<3>(), xs[1]->d[0], xs[1]->d[1], stride[0], stride[1]);
+    NCHW_dEdxi.t<4>().device(*dev.edevice) = Eigen::SpatialConvolutionBackwardKernel(CHWN_x.tb<3>(), CHWN_dy.tb<3>(), xs[1]->d[0], xs[1]->d[1], stride[0], stride[1], is_valid);
     void* HWCN_dEdxi_mem = aux_mem_pool.allocate(xs[1]->d.size() * sizeof(float));
     Tensor HWCN_dEdxi = Tensor(xs[1]->d, static_cast<float*>(HWCN_dEdxi_mem), dEdxi.device, DeviceMempool::FXS);
     shuffles[0] = 2; shuffles[1] = 3; shuffles[2] = 1; shuffles[3] = 0;

--- a/third_party/eigen_backward_spatial_convolutions.h
+++ b/third_party/eigen_backward_spatial_convolutions.h
@@ -166,6 +166,7 @@ SpatialConvolutionBackwardInput(
   eigen_assert(padding_bottom >= 0);
   eigen_assert(padding_right >= 0);
 
+
   // The kernel has dimensions filters X channels X patch_rows X patch_cols
   // We need to reverse the kernel along dimensions corresponding to rows and
   // cols.
@@ -352,7 +353,7 @@ SpatialConvolutionBackwardKernel(
     const Input& input, const OutputBackward& output_backward,
     typename internal::traits<Input>::Index kernelRows,
     typename internal::traits<Input>::Index kernelCols,
-    const DenseIndex row_stride = 1, const DenseIndex col_stride = 1,
+    const DenseIndex row_stride = 1, const DenseIndex col_stride = 1, const bool is_valid = true,
     const DenseIndex row_in_stride = 1, const DenseIndex col_in_stride = 1) {
   typedef typename internal::traits<Input>::Index TensorIndex;
   typedef typename internal::traits<OutputBackward>::Scalar OutScalar;
@@ -409,10 +410,11 @@ SpatialConvolutionBackwardKernel(
       kernelCols + (kernelCols - 1) * (col_in_stride - 1);
 
   // Computing the forward padding
-  const TensorIndex padRows = numext::maxi<Index>(
-      0, (outputRows - 1) * row_stride + kernelRowsEff - inputRows);
-  const TensorIndex padCols = numext::maxi<Index>(
-      0, (outputCols - 1) * col_stride + kernelColsEff - inputCols);
+  const TensorIndex padRows_tmp = (outputRows - 1) * row_stride + kernelRowsEff - inputRows;
+  const TensorIndex padCols_tmp = (outputCols - 1) * col_stride + kernelColsEff - inputCols;
+  const TensorIndex padRows = is_valid ? numext::maxi<Index>(0, padRows_tmp) : padRows_tmp;
+  const TensorIndex padCols = is_valid ? numext::maxi<Index>(0, padCols_tmp) : padCols_tmp;
+
   const TensorIndex padding_top = padRows / 2;
   const TensorIndex padding_bottom = padRows - padding_top;
   const TensorIndex padding_left = padCols / 2;


### PR DESCRIPTION
The bug only occurs in some very extreme cases.
More details see here: https://github.com/tensorflow/tensorflow/issues/11092

Before TF community gives a fix I think this patch can be a temporal workaround.