### PR TITLE
Minor fixes for Windows compile

### DIFF
--- a/dynet/gpu-ops.cu
+++ b/dynet/gpu-ops.cu
@@ -3,6 +3,8 @@
 #include "dynet/gpu-kernels.h"
 #include "dynet/functors.h"
 
+#include <algorithm>				// For std::min and std::max
+
 namespace dynet {
 namespace gpu {
 

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -14,7 +14,6 @@
  * On a small proportion of the IMDB data (2500 for training, 500 for dev.), this
  * model achieves 80% accuracy on two-way classification.
  */
-#include <unistd.h>
 #include "dynet/nodes.h"
 #include "dynet/dynet.h"
 #include "dynet/training.h"

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -1,4 +1,3 @@
-#include <unistd.h>
 #include <iostream>
 #include <fstream>
 #include <sstream>

--- a/examples/cpp/utils/getpid.h
+++ b/examples/cpp/utils/getpid.h
@@ -2,5 +2,6 @@
 // 
 #if _WINDOWS
     #include <process.h>
+#else
+	#include <unistd.h>
 #endif
-#include <unistd.h>


### PR DESCRIPTION
including unistd only when not Windows. Adding required include for std::min/max.