### PR TITLE
merge GPU files together for faster compilation. Merging is controlled by GPU_NUMFILES parameter to Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,12 @@ if (MKL OR MKL_ROOT)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DEIGEN_USE_MKL_ALL")
 endif()
 
+# There are about 30 files compiled for GPU. We merge them into less
+# for faster compilation. Set to 0 to mean no merging, or k to merge into k files. 
+if(NOT DEFINED GPU_NUMFILES)
+  set(GPU_NUMFILES 4)
+endif()
+
 
 ######## Platform-specific options
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,11 @@ endif()
 # There are about 30 files compiled for GPU. We merge them into less
 # for faster compilation. Set to 0 to mean no merging, or k to merge into k files. 
 if(NOT DEFINED GPU_NUMFILES)
-  set(GPU_NUMFILES 4)
+  if(MSVC)
+    set(GPU_NUMFILES 1)   # MSVC does serial compilation of CUDA, so minimize overhead
+  else()
+    set(GPU_NUMFILES 4)   # Should probably be set to number of jobs in parallel make
+  endif()
 endif()
 
 

--- a/doc/source/code_style.rst
+++ b/doc/source/code_style.rst
@@ -1,37 +1,6 @@
 Coding Tips and Style
 =====================
 
-Coding Tips
------------
-
-**Adding New Operations:**
-One of the most common things that one will want to do to modify DyNet is to add a new operation
-to calculate a new function.
-You can find more information on how to do so at the end of the tutorial slides
-`here <http://phontron.com/slides/emnlp2016-dynet-tutorial-part1.pdf>`_ (note that some file
-names are old).
-
-Taking a look at the existing operations in the ``nodes-XXX.h`` and ``nodes-XXX.cc`` files
-will be the best guide in creating new operations. Here are some fine-grained tips for
-those that want to dive into the process.
-
-1. ``fx`` is a pointer to the (preallocated) location for the result
-   of forward to be stored
-2. ``fx`` is not initialized, so after calling forward ``fx`` must contain the correct answer
-3. dEdxi MUST **ACCUMULATE** a result since multiple calls to forward may depend on
-   the same ``x_i``. Even, e.g., Identity must be implemented as ``dEdx1 += dEdf``.
-4. scalars results of forward are placed in ``fx.v[0]``
-5. DyNet manages its own memory, not Eigen, and it is configured with the
-   EIGEN_NO_MALLOC option. If you get an error about Eigen attempting to allocate
-   memory, it is (probably) because of an implicit creation of a temporary variable.
-   If you really do need a temporary variable, its capacity must be requested by
-   Node::aux_storage_size
-
-And here are some notes on debugging problems with new operations
-
-1. fx is uninitialized when forward is called- are you relying on it being 0?
-2. dEdxi must accumulate (see point 3 above!)
-
 Coding Practices
 ----------------
 
@@ -83,3 +52,47 @@ should be used in all code. It consists of 3 macros as follows (included in ``gl
   happen due to a programming error within DyNet itself, and should never be
   triggered by a user. ``expr`` is a condition, and ``msg`` is a message explaining
   the exception, with ``ostream``-style formatting.
+
+Coding Tips/How To
+------------------
+
+Adding New Operations
+~~~~~~~~~~~~~~~~~~~~~
+
+One of the most common things that one will want to do to modify DyNet is to add a new operation
+to calculate a new function.
+You can find more information on how to do so at the end of the tutorial slides
+`here <http://phontron.com/slides/emnlp2016-dynet-tutorial-part1.pdf>`_ (note that some file
+names are old).
+
+Taking a look at the existing operations in the ``nodes-XXX.h`` and ``nodes-XXX.cc`` files
+will be the best guide in creating new operations. Here are some fine-grained tips for
+those that want to dive into the process.
+
+1. ``fx`` is a pointer to the (preallocated) location for the result
+   of forward to be stored
+2. ``fx`` is not initialized, so after calling forward ``fx`` must contain the correct answer
+3. dEdxi MUST **ACCUMULATE** a result since multiple calls to forward may depend on
+   the same ``x_i``. Even, e.g., Identity must be implemented as ``dEdx1 += dEdf``.
+4. scalars results of forward are placed in ``fx.v[0]``
+5. DyNet manages its own memory, not Eigen, and it is configured with the
+   EIGEN_NO_MALLOC option. If you get an error about Eigen attempting to allocate
+   memory, it is (probably) because of an implicit creation of a temporary variable.
+   If you really do need a temporary variable, its capacity must be requested by
+   Node::aux_storage_size
+
+And here are some notes on debugging problems with new operations
+
+1. fx is uninitialized when forward is called- are you relying on it being 0?
+2. dEdxi must accumulate (see point 3 above!)
+
+Decreasing Compile Time
+~~~~~~~~~~~~~~~~~~~~~~~
+
+DyNet has a ``GPU_NUMFILES`` option that allows you to specify the number of separate
+files that are compiled when compiling for GPU. This is set to 4 on Linux/Mac and 1 on
+Windows (because MSVC doesn't support parallel compilation for GPU code). If you're
+developing new operations for DyNet, it might be a good idea to set ``GPU_NUMFILES``
+to zero, which will result in all ``nodes-XXX.cc`` files being compiled separately.
+In this case, if you change a single file, it will only recompile that file instead
+of recompiling all of the code in all of the ``nodes-XXX.cc`` files.

--- a/dynet/CMakeLists.txt
+++ b/dynet/CMakeLists.txt
@@ -164,10 +164,6 @@ set(dynet_gpu_SRCS
     cudnn-ops.cu
     gpu-ops.cu)
 
-foreach(FILENAME ${dynet_gen_file_prefix_SRCS})
-    list(APPEND dynet_gpu_SRCS ${PROJECT_BINARY_DIR}/dynet/gpu-${FILENAME}.cu)
-endforeach()
-
 file(GLOB TEST_SRCS RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} tests/*.cc)
 if (NOT MSVC)
   set(BUILD_SHARED_LIBS ON)
@@ -196,11 +192,28 @@ endif()
 # Build cpu library
 add_library(dynet ${dynet_library_SRCS} ${dynet_library_HDRS})
 target_link_libraries(dynet ${LIBS})
+
 if(WITH_CUDA_BACKEND)
-  foreach(FILENAME ${dynet_gen_file_prefix_SRCS})
-    set(FILEPREFIX ${FILENAME})
-    configure_file(gpu-file-template.cu.in gpu-${FILENAME}.cu)
-  endforeach()
+  if(${GPU_NUMFILES} EQUAL 0)
+    foreach(FILENAME ${dynet_gen_file_prefix_SRCS})
+      set(MERGEFILE ${PROJECT_BINARY_DIR}/dynet/gpu-${FILENAME}.cu)
+      file(WRITE ${MERGEFILE} "#include \"${PROJECT_SOURCE_DIR}/dynet/${FILENAME}.cc\"\n")
+      list(APPEND dynet_gpu_SRCS ${MERGEFILE})
+    endforeach()
+  else()
+    # merge into k merge files
+    set(COUNTER 0)
+    foreach(FILENAME ${dynet_gen_file_prefix_SRCS})
+      math(EXPR MERGENUM "${COUNTER} % ${GPU_NUMFILES}")
+      set(MERGEFILE ${PROJECT_BINARY_DIR}/dynet/gpu-merge${MERGENUM}.cu)
+      if(${COUNTER} EQUAL ${MERGENUM})   # This is the first line of this merge file
+        file(REMOVE ${MERGEFILE})        # Start with an empty file
+        list(APPEND dynet_gpu_SRCS ${MERGEFILE})
+      endif()
+      file(APPEND ${MERGEFILE} "#include \"${PROJECT_SOURCE_DIR}/dynet/${FILENAME}.cc\"\n")
+      math(EXPR COUNTER ${COUNTER}+1)
+    endforeach()
+  endif()
 
   # cuda flags
   set(CUDA_SEPARABLE_COMPILATION ON)

--- a/dynet/CMakeLists.txt
+++ b/dynet/CMakeLists.txt
@@ -123,7 +123,7 @@ if(ENABLE_BOOST)
   list(APPEND dynet_library_HDRS mp.h)
 endif()
   
-set(dynet_gen_file_prefix_SRCS
+set(dynet_gpu_mergeable_SRCS
     nodes-activations
     nodes-affinetransform
     nodes-arith-const
@@ -195,7 +195,7 @@ target_link_libraries(dynet ${LIBS})
 
 if(WITH_CUDA_BACKEND)
   if(${GPU_NUMFILES} EQUAL 0)
-    foreach(FILENAME ${dynet_gen_file_prefix_SRCS})
+    foreach(FILENAME ${dynet_gpu_mergeable_SRCS})
       set(MERGEFILE ${PROJECT_BINARY_DIR}/dynet/gpu-${FILENAME}.cu)
       file(WRITE ${MERGEFILE} "#include \"${PROJECT_SOURCE_DIR}/dynet/${FILENAME}.cc\"\n")
       list(APPEND dynet_gpu_SRCS ${MERGEFILE})
@@ -203,7 +203,7 @@ if(WITH_CUDA_BACKEND)
   else()
     # merge into k merge files
     set(COUNTER 0)
-    foreach(FILENAME ${dynet_gen_file_prefix_SRCS})
+    foreach(FILENAME ${dynet_gpu_mergeable_SRCS})
       math(EXPR MERGENUM "${COUNTER} % ${GPU_NUMFILES}")
       set(MERGEFILE ${PROJECT_BINARY_DIR}/dynet/gpu-merge${MERGENUM}.cu)
       if(${COUNTER} EQUAL ${MERGENUM})   # This is the first line of this merge file

--- a/dynet/gpu-file-template.cu.in
+++ b/dynet/gpu-file-template.cu.in
@@ -1,2 +1,0 @@
-// This is a dummy file that contains the same content as ${FILEPREFIX}.cc but compiled on CUDA
-#include "${PROJECT_SOURCE_DIR}/dynet/${FILEPREFIX}.cc"


### PR DESCRIPTION
Default values for GPU_NUMFILES are 1 for MSVC (since it compiles CUDA serially) and 4 for Linux (picked arbitrarily -- should probably be number of cores). A few questions:

1) Are you happy with the name "GPU_NUMFILES"
2) Where should we document this? The average user probably doesn't need to know about it. Only developers, who may prefer to set GPU_NUMFILES to 0 in order to get one file per .cc file
