### PR TITLE
Simplify training interface by removing weight decay and scaling

### DIFF
--- a/dynet/mp.h
+++ b/dynet/mp.h
@@ -259,7 +259,9 @@ namespace dynet {
           }
           if (do_update && trainer != nullptr) {
             shared_object->update_mutex.wait();
-            trainer->update(1.0 / counter); 
+            // TODO: The scaling was originally this
+            // trainer->update(1.0 / counter); 
+            trainer->update(); 
             shared_object->update_mutex.post();
           }
           if (batch_counter == header.report_frequency) {
@@ -334,7 +336,9 @@ namespace dynet {
             batch_loss += datum_loss;
             train_loss += datum_loss;
             if (++batch_counter == batch_size) {
-              trainer->update(1.0 / batch_size);
+              // TODO: The scaling was originally this
+              // trainer->update(1.0 / batch_size); 
+              trainer->update(); 
               batch_counter = 0;
             }
             data_processed++;

--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -7,25 +7,25 @@
 // Macros for defining parameter update functions
 #ifdef __CUDACC__
 #define DYNET_TRAINER_INST_DEV_IMPL(MyTrainer) \
-  template void MyTrainer::update_rule_dev<Device_GPU>(const Device_GPU & dev, real scale, real gscale, const std::vector<Tensor*> & values);
+  template void MyTrainer::update_rule_dev<Device_GPU>(const Device_GPU & dev, real gscale, const std::vector<Tensor*> & values);
 #elif defined(HAVE_CUDA)
 // This is correct, but dying when models are read and written.
-// if(values[0]->device->type == DeviceType::CPU) { update_rule_dev(*(Device_CPU*)values[0]->device,scale,gscale,values); } 
-// else if(values[0]->device->type == DeviceType::GPU) { update_rule_dev(*(Device_GPU*)values[0]->device,scale,gscale,values); } 
+// if(values[0]->device->type == DeviceType::CPU) { update_rule_dev(*(Device_CPU*)values[0]->device,gscale,values); } 
+// else if(values[0]->device->type == DeviceType::GPU) { update_rule_dev(*(Device_GPU*)values[0]->device,gscale,values); } 
 // else { throw std::runtime_error("Bad device in MyTrainer::update_rule"); }
 #define DYNET_TRAINER_INST_DEV_IMPL(MyTrainer) \
-  extern template void MyTrainer::update_rule_dev<Device_GPU>(const Device_GPU & dev, real scale, real gscale, const std::vector<Tensor*> & values); \
-  template void MyTrainer::update_rule_dev<Device_CPU>(const Device_CPU & dev, real scale, real gscale, const std::vector<Tensor*> & values); \
-  void MyTrainer::update_rule(real scale, real gscale, const std::vector<Tensor*> & values) { \
-    if(default_device->type == DeviceType::CPU) { update_rule_dev(*(Device_CPU*)default_device,scale,gscale,values); } \
-    else if(default_device->type == DeviceType::GPU) { update_rule_dev(*(Device_GPU*)default_device,scale,gscale,values); } \
+  extern template void MyTrainer::update_rule_dev<Device_GPU>(const Device_GPU & dev, real gscale, const std::vector<Tensor*> & values); \
+  template void MyTrainer::update_rule_dev<Device_CPU>(const Device_CPU & dev, real gscale, const std::vector<Tensor*> & values); \
+  void MyTrainer::update_rule(real gscale, const std::vector<Tensor*> & values) { \
+    if(default_device->type == DeviceType::CPU) { update_rule_dev(*(Device_CPU*)default_device,gscale,values); } \
+    else if(default_device->type == DeviceType::GPU) { update_rule_dev(*(Device_GPU*)default_device,gscale,values); } \
     else { throw std::runtime_error("Bad device in MyTrainer::update_rule"); } \
   }
 #else
 #define DYNET_TRAINER_INST_DEV_IMPL(MyTrainer) \
-  template void MyTrainer::update_rule_dev<Device_CPU>(const Device_CPU & dev, real scale, real gscale, const std::vector<Tensor*> & values); \
-  void MyTrainer::update_rule(real scale, real gscale, const std::vector<Tensor*> & values) { \
-    if(default_device->type == DeviceType::CPU) { update_rule_dev(*(Device_CPU*)default_device,scale,gscale,values); } \
+  template void MyTrainer::update_rule_dev<Device_CPU>(const Device_CPU & dev, real gscale, const std::vector<Tensor*> & values); \
+  void MyTrainer::update_rule(real gscale, const std::vector<Tensor*> & values) { \
+    if(default_device->type == DeviceType::CPU) { update_rule_dev(*(Device_CPU*)default_device,gscale,values); } \
     else { throw std::runtime_error("Bad device in MyTrainer::update_rule"); } \
   }
 #endif
@@ -57,7 +57,7 @@ void Trainer::rescale_and_reset_weight_decay() {
   model->get_weight_decay().reset_weight_decay();
 }
 
-float Trainer::clip_gradients(real scale) {
+float Trainer::clip_gradients() {
   float gscale = 1;
   if (clipping_enabled) {
     float gg = model->gradient_l2_norm();
@@ -65,17 +65,21 @@ float Trainer::clip_gradients(real scale) {
       ostringstream oss; oss << "Magnitude of gradient is bad: " << gg;
       throw std::runtime_error(oss.str());
     }
-    if (scale * gg > clip_threshold) {
+    if (gg > clip_threshold) {
       ++clips;
       ++clips_since_status;
-      gscale = clip_threshold / (scale * gg);
+      gscale = clip_threshold / gg;
     }
   }
   return gscale;
 }
 
+void Trainer::update_epoch(real r) {
+  cerr << "Trainer::update_epoch has been deprecated and doesn't do anything. Please remove it from your code, and control the learning rate of the trainer directly through the set_learning_rate() function." << endl;
+}
+
 // this calls the rule-specific updates over all updated parameters
-void Trainer::update(real scale) {
+void Trainer::update() {
   // Allocate if necessary
   if(!aux_allocated) {
     alloc_impl();
@@ -83,11 +87,11 @@ void Trainer::update(real scale) {
   }
 
   // Perform gradient clipping and cycle through parameters
-  const float gscale = clip_gradients(scale);
+  const float gscale = clip_gradients();
   const auto & params = model->parameters_list();
   for(size_t i = 0; i < params.size(); ++i) {
     if(params[i]->updated) {
-      update_params(scale, gscale, i);
+      update_params(gscale, i);
       params[i]->clear();
     }
   }
@@ -96,9 +100,9 @@ void Trainer::update(real scale) {
     auto &p = lparams[i];
     if(sparse_updates_enabled && p->updated && !p->all_updated) {
       for (auto j : p->non_zero_grads)
-        update_lookup_params(scale, gscale, i, j);
+        update_lookup_params(gscale, i, j);
     } else {
-      update_lookup_params(scale, gscale, i);
+      update_lookup_params(gscale, i);
     }
     p->clear();
   }
@@ -117,23 +121,23 @@ void Trainer::update(real scale) {
 
 // Perform update of ts[0]=parameters, ts[1]=gradients
 template <class MyDevice>
-void SimpleSGDTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, const std::vector<Tensor*> & ts) {
-  ts[0]->tvec().device(*dev.edevice) -= ts[1]->tvec() * (eta * scale * gscale / model->get_weight_decay().current_weight_decay());
+void SimpleSGDTrainer::update_rule_dev(const MyDevice & dev, real gscale, const std::vector<Tensor*> & ts) {
+  ts[0]->tvec().device(*dev.edevice) -= ts[1]->tvec() * (learning_rate * gscale / model->get_weight_decay().current_weight_decay());
 }
 DYNET_TRAINER_INST_DEV_IMPL(SimpleSGDTrainer)
 
 #ifndef __CUDACC__
-void SimpleSGDTrainer::update_params(real scale, real gscale, size_t idx) {
+void SimpleSGDTrainer::update_params(real gscale, size_t idx) {
   auto & p = model->parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values, &p->g});
+  update_rule(gscale, {&p->values, &p->g});
 }
-void SimpleSGDTrainer::update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) {
+void SimpleSGDTrainer::update_lookup_params(real gscale, size_t idx, size_t lidx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values[lidx], &p->grads[lidx]});
+  update_rule(gscale, {&p->values[lidx], &p->grads[lidx]});
 }
-void SimpleSGDTrainer::update_lookup_params(real scale, real gscale, size_t idx) {
+void SimpleSGDTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->all_values, &p->all_grads});
+  update_rule(gscale, {&p->all_values, &p->all_grads});
 }
 #endif
 
@@ -141,23 +145,23 @@ void SimpleSGDTrainer::update_lookup_params(real scale, real gscale, size_t idx)
 
 // Perform update of ts[0]=parameters, ts[1]=gradients
 template <class MyDevice>
-void CyclicalSGDTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, const std::vector<Tensor*> & ts) {
-  ts[0]->tvec().device(*dev.edevice) -= ts[1]->tvec() * (eta * scale * gscale / model->get_weight_decay().current_weight_decay());
+void CyclicalSGDTrainer::update_rule_dev(const MyDevice & dev, real gscale, const std::vector<Tensor*> & ts) {
+  ts[0]->tvec().device(*dev.edevice) -= ts[1]->tvec() * (learning_rate * gscale / model->get_weight_decay().current_weight_decay());
 }
 DYNET_TRAINER_INST_DEV_IMPL(CyclicalSGDTrainer)
 
 #ifndef __CUDACC__
-void CyclicalSGDTrainer::update_params(real scale, real gscale, size_t idx) {
+void CyclicalSGDTrainer::update_params(real gscale, size_t idx) {
   auto & p = model->parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values, &p->g});
+  update_rule(gscale, {&p->values, &p->g});
 }
-void CyclicalSGDTrainer::update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) {
+void CyclicalSGDTrainer::update_lookup_params(real gscale, size_t idx, size_t lidx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values[lidx], &p->grads[lidx]});
+  update_rule(gscale, {&p->values[lidx], &p->grads[lidx]});
 }
-void CyclicalSGDTrainer::update_lookup_params(real scale, real gscale, size_t idx) {
+void CyclicalSGDTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->all_values, &p->all_grads});
+  update_rule(gscale, {&p->all_values, &p->all_grads});
 }
 #endif
 
@@ -165,24 +169,24 @@ void CyclicalSGDTrainer::update_lookup_params(real scale, real gscale, size_t id
 
 // Perform update of ts[0]=parameters, ts[1]=gradients, ts[2]=momentum
 template <class MyDevice>
-void MomentumSGDTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, const std::vector<Tensor*> & ts) {
-  ts[2]->tvec().device(*dev.edevice) = ts[2]->tvec() * momentum - ts[1]->tvec() * (eta * scale * gscale);
+void MomentumSGDTrainer::update_rule_dev(const MyDevice & dev, real gscale, const std::vector<Tensor*> & ts) {
+  ts[2]->tvec().device(*dev.edevice) = ts[2]->tvec() * momentum - ts[1]->tvec() * (learning_rate * gscale);
   ts[0]->tvec().device(*dev.edevice) += ts[2]->tvec() / model->get_weight_decay().current_weight_decay();
 }
 DYNET_TRAINER_INST_DEV_IMPL(MomentumSGDTrainer)
 
 #ifndef __CUDACC__
-void MomentumSGDTrainer::update_params(real scale, real gscale, size_t idx) {
+void MomentumSGDTrainer::update_params(real gscale, size_t idx) {
   auto & p = model->parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values, &p->g, &vp[idx].h});
+  update_rule(gscale, {&p->values, &p->g, &vp[idx].h});
 }
-void MomentumSGDTrainer::update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) {
+void MomentumSGDTrainer::update_lookup_params(real gscale, size_t idx, size_t lidx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values[lidx], &p->grads[lidx], &vlp[idx].h[lidx]});
+  update_rule(gscale, {&p->values[lidx], &p->grads[lidx], &vlp[idx].h[lidx]});
 }
-void MomentumSGDTrainer::update_lookup_params(real scale, real gscale, size_t idx) {
+void MomentumSGDTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->all_values, &p->all_grads, &vlp[idx].all_h});
+  update_rule(gscale, {&p->all_values, &p->all_grads, &vlp[idx].all_h});
 }
 void MomentumSGDTrainer::alloc_impl() {
   vp = allocate_shadow_parameters(*model);
@@ -194,25 +198,25 @@ void MomentumSGDTrainer::alloc_impl() {
 
 // Perform update of ts[0]=parameters, ts[1]=gradients, ts[2]=stddev
 template <class MyDevice>
-void AdagradTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, const std::vector<Tensor*> & ts) {
-  ts[1]->tvec().device(*dev.edevice) = ts[1]->tvec() * (scale * gscale);
+void AdagradTrainer::update_rule_dev(const MyDevice & dev, real gscale, const std::vector<Tensor*> & ts) {
+  ts[1]->tvec().device(*dev.edevice) = ts[1]->tvec() * gscale;
   ts[2]->tvec().device(*dev.edevice) += ts[1]->tvec().square();
-  ts[0]->tvec().device(*dev.edevice) += ts[1]->tvec() / (ts[2]->tvec() + epsilon).sqrt() * (-eta / model->get_weight_decay().current_weight_decay());
+  ts[0]->tvec().device(*dev.edevice) += ts[1]->tvec() / (ts[2]->tvec() + epsilon).sqrt() * (-learning_rate / model->get_weight_decay().current_weight_decay());
 }
 DYNET_TRAINER_INST_DEV_IMPL(AdagradTrainer)
 
 #ifndef __CUDACC__
-void AdagradTrainer::update_params(real scale, real gscale, size_t idx) {
+void AdagradTrainer::update_params(real gscale, size_t idx) {
   auto & p = model->parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values, &p->g, &vp[idx].h});
+  update_rule(gscale, {&p->values, &p->g, &vp[idx].h});
 }
-void AdagradTrainer::update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) {
+void AdagradTrainer::update_lookup_params(real gscale, size_t idx, size_t lidx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values[lidx], &p->grads[lidx], &vlp[idx].h[lidx]});
+  update_rule(gscale, {&p->values[lidx], &p->grads[lidx], &vlp[idx].h[lidx]});
 }
-void AdagradTrainer::update_lookup_params(real scale, real gscale, size_t idx) {
+void AdagradTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->all_values, &p->all_grads, &vlp[idx].all_h});
+  update_rule(gscale, {&p->all_values, &p->all_grads, &vlp[idx].all_h});
 }
 void AdagradTrainer::alloc_impl() {
   vp = allocate_shadow_parameters(*model);
@@ -224,8 +228,8 @@ void AdagradTrainer::alloc_impl() {
 
 // Perform update of ts[0]=parameters, ts[1]=gradients, ts[2]=hg, ts[3]=hd
 template <class MyDevice>
-void AdadeltaTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, const std::vector<Tensor*> & ts) {
-  ts[1]->tvec().device(*dev.edevice) = ts[1]->tvec() * (scale * gscale);
+void AdadeltaTrainer::update_rule_dev(const MyDevice & dev, real gscale, const std::vector<Tensor*> & ts) {
+  ts[1]->tvec().device(*dev.edevice) = ts[1]->tvec() * gscale;
   ts[2]->tvec().device(*dev.edevice) = ts[2]->tvec() * rho + ts[1]->tvec().square() * (1.f - rho);
   ts[1]->tvec().device(*dev.edevice) = - ts[1]->tvec() * (ts[3]->tvec() + epsilon).sqrt() / (ts[2]->tvec() + epsilon).sqrt();
   ts[3]->tvec().device(*dev.edevice) = ts[3]->tvec() * rho + ts[1]->tvec().square() * (1.f - rho);
@@ -234,17 +238,17 @@ void AdadeltaTrainer::update_rule_dev(const MyDevice & dev, real scale, real gsc
 DYNET_TRAINER_INST_DEV_IMPL(AdadeltaTrainer)
 
 #ifndef __CUDACC__
-void AdadeltaTrainer::update_params(real scale, real gscale, size_t idx) {
+void AdadeltaTrainer::update_params(real gscale, size_t idx) {
   auto & p = model->parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values, &p->g, &hg[idx].h, &hd[idx].h});
+  update_rule(gscale, {&p->values, &p->g, &hg[idx].h, &hd[idx].h});
 }
-void AdadeltaTrainer::update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) {
+void AdadeltaTrainer::update_lookup_params(real gscale, size_t idx, size_t lidx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values[lidx], &p->grads[lidx], &hlg[idx].h[lidx], &hld[idx].h[lidx]});
+  update_rule(gscale, {&p->values[lidx], &p->grads[lidx], &hlg[idx].h[lidx], &hld[idx].h[lidx]});
 }
-void AdadeltaTrainer::update_lookup_params(real scale, real gscale, size_t idx) {
+void AdadeltaTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->all_values, &p->all_grads, &hlg[idx].all_h, &hld[idx].all_h});
+  update_rule(gscale, {&p->all_values, &p->all_grads, &hlg[idx].all_h, &hld[idx].all_h});
 }
 void AdadeltaTrainer::alloc_impl() {
   hg = allocate_shadow_parameters(*model);
@@ -260,30 +264,30 @@ void AdadeltaTrainer::alloc_impl() {
 
 // Perform update of ts[0]=parameters, ts[1]=gradients
 template <class MyDevice>
-void RMSPropTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, const std::vector<Tensor*> & ts) {
-  ts[1]->tvec().device(*dev.edevice) = ts[1]->tvec() * (scale * gscale); // Scale gradient
+void RMSPropTrainer::update_rule_dev(const MyDevice & dev, real gscale, const std::vector<Tensor*> & ts) {
+  ts[1]->tvec().device(*dev.edevice) = ts[1]->tvec() * gscale; // Scale gradient
   ts[2]->tvec().device(*dev.edevice) = ts[2]->tvec() * rho + ts[1]->tvec().square() * (1.f - rho); // Update square gradient exponential average
   ts[1]->tvec().device(*dev.edevice) = - ts[1]->tvec() / (ts[2]->tvec() + epsilon).sqrt(); // Divide by the RMS
-  ts[0]->tvec().device(*dev.edevice) += eta * ts[1]->tvec() / model->get_weight_decay().current_weight_decay(); // Apply weight decay (should we do this?)
+  ts[0]->tvec().device(*dev.edevice) += learning_rate * ts[1]->tvec() / model->get_weight_decay().current_weight_decay(); // Apply weight decay (should we do this?)
   // real& d2 = hg[pi++];
   // real g2 = p->g.vec().squaredNorm();
   // d2 = rho * d2 + (1.f - rho) * g2;
-  // p->values.vec() -= ((eta * scale * gscale / sqrt(d2 + epsilon)) * p->g.vec()) / model->get_weight_decay().current_weight_decay();
+  // p->values.vec() -= ((learning_rate * gscale / sqrt(d2 + epsilon)) * p->g.vec()) / model->get_weight_decay().current_weight_decay();
 }
 DYNET_TRAINER_INST_DEV_IMPL(RMSPropTrainer)
 
 #ifndef __CUDACC__
-void RMSPropTrainer::update_params(real scale, real gscale, size_t idx) {
+void RMSPropTrainer::update_params(real gscale, size_t idx) {
   auto & p = model->parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values, &p->g, &hmsg[idx].h});
+  update_rule(gscale, {&p->values, &p->g, &hmsg[idx].h});
 }
-void RMSPropTrainer::update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) {
+void RMSPropTrainer::update_lookup_params(real gscale, size_t idx, size_t lidx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values[lidx], &p->grads[lidx], &hlmsg[idx].h[lidx]});
+  update_rule(gscale, {&p->values[lidx], &p->grads[lidx], &hlmsg[idx].h[lidx]});
 }
-void RMSPropTrainer::update_lookup_params(real scale, real gscale, size_t idx) {
+void RMSPropTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->all_values, &p->all_grads, &hlmsg[idx].all_h});
+  update_rule(gscale, {&p->all_values, &p->all_grads, &hlmsg[idx].all_h});
 }
 void RMSPropTrainer::alloc_impl() {
   hmsg = allocate_shadow_parameters(*model);
@@ -295,27 +299,27 @@ void RMSPropTrainer::alloc_impl() {
 
 // Perform update of ts[0]=parameters, ts[1]=gradients, ts[2]=mean, ts[3]=variance
 template <class MyDevice>
-void AdamTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, const std::vector<Tensor*> & ts) {
-  ts[1]->tvec().device(*dev.edevice) = ts[1]->tvec() * (scale * gscale);
+void AdamTrainer::update_rule_dev(const MyDevice & dev, real gscale, const std::vector<Tensor*> & ts) {
+  ts[1]->tvec().device(*dev.edevice) = ts[1]->tvec() * gscale;
   ts[2]->tvec().device(*dev.edevice) = ts[2]->tvec() * beta_1 + ts[1]->tvec() * (1.f - beta_1);
   ts[3]->tvec().device(*dev.edevice) = ts[3]->tvec() * beta_2 + ts[1]->tvec().square() * (1.f - beta_2);
-  float lr_t = eta * sqrt(1-pow(beta_2, updates+1))/(1-pow(beta_1, updates+1))/ model->get_weight_decay().current_weight_decay();
+  float lr_t = learning_rate * sqrt(1-pow(beta_2, updates+1))/(1-pow(beta_1, updates+1))/ model->get_weight_decay().current_weight_decay();
   ts[0]->tvec().device(*dev.edevice) -= ts[2]->tvec() / (ts[3]->tvec().sqrt() + epsilon) * lr_t;
 }
 DYNET_TRAINER_INST_DEV_IMPL(AdamTrainer)
 
 #ifndef __CUDACC__
-void AdamTrainer::update_params(real scale, real gscale, size_t idx) {
+void AdamTrainer::update_params(real gscale, size_t idx) {
   auto & p = model->parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values, &p->g, &m[idx].h, &v[idx].h});
+  update_rule(gscale, {&p->values, &p->g, &m[idx].h, &v[idx].h});
 }
-void AdamTrainer::update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) {
+void AdamTrainer::update_lookup_params(real gscale, size_t idx, size_t lidx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values[lidx], &p->grads[lidx], &lm[idx].h[lidx], &lv[idx].h[lidx]});
+  update_rule(gscale, {&p->values[lidx], &p->grads[lidx], &lm[idx].h[lidx], &lv[idx].h[lidx]});
 }
-void AdamTrainer::update_lookup_params(real scale, real gscale, size_t idx) {
+void AdamTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->all_values, &p->all_grads, &lm[idx].all_h, &lv[idx].all_h});
+  update_rule(gscale, {&p->all_values, &p->all_grads, &lm[idx].all_h, &lv[idx].all_h});
 }
 void AdamTrainer::alloc_impl() {
   m = allocate_shadow_parameters(*model);
@@ -327,9 +331,9 @@ void AdamTrainer::alloc_impl() {
 
 // --- EGTrainer
 template <class MyDevice>
-void EGTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, const std::vector<Tensor*> & ts) {
+void EGTrainer::update_rule_dev(const MyDevice & dev, real gscale, const std::vector<Tensor*> & ts) {
   // Add momentum
-  ts[2]->tvec().device(*dev.edevice) = ts[2]->tvec() * momentum - ts[1]->tvec() * (eta * scale * gscale);
+  ts[2]->tvec().device(*dev.edevice) = ts[2]->tvec() * momentum - ts[1]->tvec() * (learning_rate * gscale);
   ts[0]->tvec().device(*dev.edevice) = ts[0]->tvec().log() + ts[2]->tvec() / model->get_weight_decay().current_weight_decay();// with momentum only
   TensorTools::logsumexp_dev(dev, *ts[0], *ts[3], *ts[4]);// z refers to logZ
   ts[0]->tvec().device(*dev.edevice) = (ts[0]->tvec() - as_scalar(*ts[4])).exp();// FIXME: other way(s) of not using as_scalar(z)?
@@ -337,17 +341,17 @@ void EGTrainer::update_rule_dev(const MyDevice & dev, real scale, real gscale, c
 DYNET_TRAINER_INST_DEV_IMPL(EGTrainer)
 
 #ifndef __CUDACC__
-void EGTrainer::update_params(real scale, real gscale, size_t idx) {
+void EGTrainer::update_params(real gscale, size_t idx) {
   auto & p = model->parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values, &p->g, &hp[idx].h, &meg, &zeg});
+  update_rule(gscale, {&p->values, &p->g, &hp[idx].h, &meg, &zeg});
 }
-void EGTrainer::update_lookup_params(real scale, real gscale, size_t idx, size_t lidx) {
+void EGTrainer::update_lookup_params(real gscale, size_t idx, size_t lidx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->values[lidx], &p->grads[lidx], &hlp[idx].h[lidx], &meg, &zeg});
+  update_rule(gscale, {&p->values[lidx], &p->grads[lidx], &hlp[idx].h[lidx], &meg, &zeg});
 }
-void EGTrainer::update_lookup_params(real scale, real gscale, size_t idx) {
+void EGTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
-  update_rule(scale, gscale, {&p->all_grads, &p->all_grads, &hlp[idx].all_h, &meg, &zeg});
+  update_rule(gscale, {&p->all_grads, &p->all_grads, &hlp[idx].all_h, &meg, &zeg});
 }
 void EGTrainer::alloc_impl() {
   hp = allocate_shadow_parameters(*model);

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -282,7 +282,7 @@ int main(int argc, char** argv) {
       Expression loss_expr = engine.objective(cg, inst, logits);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update(1.0);
+      sgd->update();
       ++lines;
       ++ttags;
     }

--- a/examples/cpp/mlc/train_mlc.cc
+++ b/examples/cpp/mlc/train_mlc.cc
@@ -130,8 +130,7 @@ int main(int argc, char** argv) {
 
   //AdadeltaTrainer sgd(m);
   SimpleSGDTrainer sgd(m);
-  sgd.eta0 = 0.001;
-  sgd.eta = 0.001;
+  sgd.learning_rate = 0.001;
 
   unsigned report_every_i = 50;
   unsigned si = train.size();
@@ -171,7 +170,7 @@ int main(int argc, char** argv) {
       Expression loss_expr = sparsemax_loss(u, &xy.labels);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd.update(1.0);
+      sgd.update();
     }
     cerr << "[epoch=" << (ti / train.size()) << "] E=" << (loss / instances) << ' ';
   }

--- a/examples/cpp/nlm/train_nlm.cc
+++ b/examples/cpp/nlm/train_nlm.cc
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
       loss += as_scalar(cg.forward(nerr));
       cg.backward(nerr);
       ++n;
-      sgd.update(1.0);
+      sgd.update();
       if (n == 2500) break;
     }
     loss /= n;

--- a/examples/cpp/read-write/train_read-write.cc
+++ b/examples/cpp/read-write/train_read-write.cc
@@ -58,7 +58,7 @@ public:
 
     float return_loss = as_scalar(cg.forward(loss));
     cg.backward(loss);
-    sgd.update(1.0);
+    sgd.update();
     return return_loss;
   }
 

--- a/examples/cpp/rnnlm-batch-nce/train_rnnlm-batch-nce.cc
+++ b/examples/cpp/rnnlm-batch-nce/train_rnnlm-batch-nce.cc
@@ -215,6 +215,5 @@ int main(int argc, char** argv) {
       cg.backward(loss_exp);
       trainer.update();
     }
-    trainer.update_epoch(1.0);
   }
 }

--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -202,7 +202,7 @@ int main(int argc, char** argv) {
   }
 
   Trainer* sgd = new SimpleSGDTrainer(model);
-  sgd->eta0 = sgd->eta = params.eta0;
+  sgd->learning_rate = params.eta0;
   RNNLanguageModel<LSTMBuilder> lm(model);
 
   bool has_model_to_load = params.model_file != "";
@@ -269,7 +269,7 @@ int main(int argc, char** argv) {
           cerr << "**SHUFFLE\n";
           completed_epoch++;
           if (eta_decay_onset_epoch && completed_epoch >= (int)eta_decay_onset_epoch)
-            sgd->eta *= eta_decay_rate;
+            sgd->learning_rate *= eta_decay_rate;
           shuffle(order.begin(), order.end(), *rndeng);
         }
 
@@ -285,7 +285,7 @@ int main(int argc, char** argv) {
         ++lines;
       }
       report++;
-      cerr << '#' << report << " [epoch=" << (lines / training.size()) << " eta=" << sgd->eta << "] E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
+      cerr << '#' << report << " [epoch=" << (lines / training.size()) << " lr=" << sgd->learning_rate << "] E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
 
       // show score on dev data?
       if (report % dev_every_i_reports == 0) {

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -223,7 +223,7 @@ int main(int argc, char** argv) {
       Expression loss_expr = lm.BuildTaggingGraph(sent.first, sent.second, cg, &correct, &ttags);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update(1.0);
+      sgd->update();
       ++lines;
     }
     sgd->status();

--- a/examples/cpp/tok-embed/train_tok-embed.cc
+++ b/examples/cpp/tok-embed/train_tok-embed.cc
@@ -288,7 +288,7 @@ int main(int argc, char** argv) {
       ttags += 1;
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update(1.0);
+      sgd->update();
       ++lines;
     }
     sgd->status();

--- a/examples/cpp/xor-autobatch/train_xor-autobatch.cc
+++ b/examples/cpp/xor-autobatch/train_xor-autobatch.cc
@@ -69,9 +69,8 @@ int main(int argc, char** argv) {
     // Calculate the loss. Batching will automatically be done here.
     float loss = as_scalar(cg.forward(loss_expr)) / 4;
     cg.backward(loss_expr);
-    sgd.update(1.0);
+    sgd.update();
 
-    sgd.update_epoch();
     cerr << "E = " << loss << endl;
   }
 

--- a/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
+++ b/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
@@ -65,8 +65,7 @@ int main(int argc, char** argv) {
   for (unsigned iter = 0; iter < ITERATIONS; ++iter) {
     vector<float> losses = as_vector(cg.forward(sum_loss));
     cg.backward(sum_loss);
-    sgd.update(0.25);
-    sgd.update_epoch();
+    sgd.update();
     float loss = 0;
     for(auto l : losses)
       loss += l;

--- a/examples/cpp/xor-batch/train_xor-batch.cc
+++ b/examples/cpp/xor-batch/train_xor-batch.cc
@@ -59,8 +59,7 @@ int main(int argc, char** argv) {
   for (unsigned iter = 0; iter < ITERATIONS; ++iter) {
     float my_loss = as_scalar(cg.forward(sum_loss)) / 4;
     cg.backward(sum_loss);
-    sgd.update(0.25);
-    sgd.update_epoch();
+    sgd.update();
     cerr << "E = " << my_loss << endl;
   }
 

--- a/examples/cpp/xor-simple-mp/train_xor-simple-mp.cc
+++ b/examples/cpp/xor-simple-mp/train_xor-simple-mp.cc
@@ -86,7 +86,7 @@ public:
 
 class Learner : public ILearner<Datum, SufficientStats> {
 public:
-  Learner(XorModel* xor_model, ParameterCollection& dynet_model, const Trainer* const trainer, bool quiet) : xor_model(xor_model), dynet_model(dynet_model), trainer(trainer), quiet(quiet) {}
+  Learner(XorModel* xor_model, ParameterCollection& dynet_model, const Trainer* const trainer, bool quiet) : xor_model(xor_model) {}
   ~Learner() {}
   SufficientStats LearnFromDatum(const Datum& datum, bool learn) {
     ComputationGraph cg;
@@ -104,9 +104,9 @@ public:
 
 private:
   XorModel* xor_model;
-  ParameterCollection& dynet_model; 
-  const Trainer* const trainer;
-  bool quiet;
+  // ParameterCollection& dynet_model; 
+  // const Trainer* const trainer;
+  // bool quiet;
 };
 
 int main(int argc, char** argv) {
@@ -133,7 +133,7 @@ int main(int argc, char** argv) {
   Learner learner(xor_model, dynet_model, trainer, false);
   for (unsigned i = 0; i < ITERATIONS; ++i) {
     SufficientStats ss = run_mp_minibatch<Datum>(num_cores, &learner, data);
-    trainer->update(1.0 / data.size());
+    trainer->update();
     cout << ss << endl;
   }
 }

--- a/examples/cpp/xor-xent/train_xor-xent.cc
+++ b/examples/cpp/xor-xent/train_xor-xent.cc
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
       y_value = (x1 != x2) ? 1 : 0;
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd.update(1.0);
+      sgd.update();
     }
     sgd.update_epoch();
     loss /= 4;

--- a/examples/cpp/xor/train_xor.cc
+++ b/examples/cpp/xor/train_xor.cc
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
       y_value = (x1 != x2) ? 1 : -1;
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd.update(1.0);  // 1.0 means don't scale the gradient.
+      sgd.update();
     }
     loss /= 4;
     cerr << "E = " << loss << endl;

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -187,36 +187,36 @@ cdef extern from "dynet/dynet.h" namespace "dynet":
 
 cdef extern from "dynet/training.h" namespace "dynet":
     cdef cppclass CTrainer "dynet::Trainer":
-        CTrainer(CModel& m, float e0, float edecay) # TODO removed lam, update docs.
+        CTrainer(CModel& m, float learning_rate) # TODO removed lam, update docs.
         float clip_threshold
         bool clipping_enabled
         bool sparse_updates_enabled
-        void update(float s) except +
+        void update() except +
         #void update(vector[unsigned]& uparam, vector[unsigned]& ulookup, float s) except +
         void update_epoch(float r)
         void status()
 
 
     cdef cppclass CSimpleSGDTrainer "dynet::SimpleSGDTrainer" (CTrainer):
-        CSimpleSGDTrainer(CModel& m, float e0, float edecay) # TODO removed lam, update docs.
+        CSimpleSGDTrainer(CModel& m, float learning_rate) # TODO removed lam, update docs.
 
     cdef cppclass CCyclicalSGDTrainer "dynet::CyclicalSGDTrainer" (CTrainer):
-        CCyclicalSGDTrainer(CModel& m, float e0_min, float e0_max, float step_size, float gamma, float edecay) # TODO removed lam, update docs.
+        CCyclicalSGDTrainer(CModel& m, float learning_rate_min, float learning_rate_max, float step_size, float gamma) # TODO removed lam, update docs.
 
     cdef cppclass CMomentumSGDTrainer "dynet::MomentumSGDTrainer" (CTrainer):
-        CMomentumSGDTrainer(CModel& m, float e0, float mom, float edecay) # TODO removed lam, update docs
+        CMomentumSGDTrainer(CModel& m, float learning_rate, float mom) # TODO removed lam, update docs
 
     cdef cppclass CAdagradTrainer "dynet::AdagradTrainer" (CTrainer):
-        CAdagradTrainer(CModel& m, float e0, float eps, float edecay) # TODO removed lam, update docs
+        CAdagradTrainer(CModel& m, float learning_rate, float eps) # TODO removed lam, update docs
 
     cdef cppclass CAdadeltaTrainer "dynet::AdadeltaTrainer" (CTrainer):
-        CAdadeltaTrainer(CModel& m, float eps, float rho, float edecay) # TODO removed lam, update docs
+        CAdadeltaTrainer(CModel& m, float eps, float rho) # TODO removed lam, update docs
 
     cdef cppclass CRMSPropTrainer "dynet::RMSPropTrainer" (CTrainer):
-        CRMSPropTrainer(CModel& m, float e0, float eps, float rho, float edecay) # TODO removed lam, update docs
+        CRMSPropTrainer(CModel& m, float learning_rate, float eps, float rho) # TODO removed lam, update docs
 
     cdef cppclass CAdamTrainer "dynet::AdamTrainer" (CTrainer):
-        CAdamTrainer(CModel& m, float alpha, float beta_1, float beta_2, float eps, float edecay) # TODO removed lam, update docs
+        CAdamTrainer(CModel& m, float alpha, float beta_1, float beta_2, float eps) # TODO removed lam, update docs
 
 
 cdef extern from "dynet/expr.h" namespace "dynet":

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -191,6 +191,7 @@ cdef extern from "dynet/training.h" namespace "dynet":
         float clip_threshold
         bool clipping_enabled
         bool sparse_updates_enabled
+        float learning_rate
         void update() except +
         #void update(vector[unsigned]& uparam, vector[unsigned]& ulookup, float s) except +
         void update_epoch(float r)

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -4584,6 +4584,9 @@ cdef class StackedRNNState:
 cdef class Trainer:
     """
     Generic trainer
+
+    Attributes:
+        learning_rate(number): Global learning rate for all parameters 
     """
     cdef CTrainer *thisptr
     def __dealloc__(self):
@@ -4648,6 +4651,14 @@ cdef class Trainer:
             number: Gradient clipping threshold
         """
         return self.thisptr.clip_threshold
+
+    @property
+    def learning_rate(self):
+        return self.thisptr.learning_rate
+
+    @learning_rate.setter
+    def learning_rate(self, value):
+        self.thisptr.learning_rate = value
 
 cdef class SimpleSGDTrainer(Trainer):
     """Stochastic gradient descent trainer

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -4588,17 +4588,14 @@ cdef class Trainer:
     cdef CTrainer *thisptr
     def __dealloc__(self):
         del self.thisptr
-    cpdef update(self, float s=1.0):
+    cpdef update(self):
         """Update the parameters
         
         The update equation is different for each trainer, check the online c++ documentation for more details on what each trainer does
-        
-        Keyword Args:
-            s(number): Optional scaling factor to apply on the gradient. (default: 1.0)
         """
-        self.thisptr.update(s)
+        self.thisptr.update()
 
-    cpdef update_subset(self, updated_params, updated_lookups, float s=1.0):
+    cpdef update_subset(self, updated_params, updated_lookups):
         """Update a subset of parameters
         
         Only use this in last resort, a more elegant way to update only a subset of parameters is to use the "update" keyword in dy.parameter or Parameter.expr() to specify which parameters need to be updated __during the creation of the computation graph__
@@ -4606,22 +4603,14 @@ cdef class Trainer:
         Args:
             updated_params(list): Indices of parameters to update
             updated_lookups(list): Indices of lookup parameters to update
-        
-        Keyword Args:
-            s(number): Optional scaling factor to apply on the gradient. (default: 1.0)
         """
         cdef vector[unsigned] uparamvec
         for i in updated_params: uparamvec.push_back(i)
         cdef vector[unsigned] ulookupvec
         for i in updated_lookups: ulookupvec.push_back(i)
-        #self.thisptr.update(uparamvec, ulookupvec, s)
-    cpdef update_epoch(self, float r = 1.0):
-        """Update trainers hyper-parameters that depend on epochs
-        
-        Basically learning rate decay.
-        
-        Keyword Args:
-            r(number): Number of epoch that passed (default: 1.0)
+        # self.thisptr.update(uparamvec, ulookupvec)
+    cpdef update_epoch(self, r):
+        """DEPRECATED: do not use.
         """
         self.thisptr.update_epoch(r)
     cpdef status(self):
@@ -4669,11 +4658,10 @@ cdef class SimpleSGDTrainer(Trainer):
         m(dynet.ParameterCollection): ParameterCollection to be trained
     
     Keyword Args:
-        e0(number): Initial learning rate (default: 0.1)
-        edecay(number): Learning rate decay parameter (default: 0.0)
+        learning_rate(number): Initial learning rate (default: 0.1)
     """
-    def __cinit__(self, ParameterCollection m, float e0 = 0.1, float edecay = 0.0):
-        self.thisptr = new CSimpleSGDTrainer(m.thisptr, e0, edecay)
+    def __cinit__(self, ParameterCollection m, float learning_rate = 0.1):
+        self.thisptr = new CSimpleSGDTrainer(m.thisptr, learning_rate)
     def whoami(self):
         return "SimpleSGDTrainer"
 
@@ -4696,17 +4684,16 @@ cdef class CyclicalSGDTrainer(Trainer):
         m(dynet.ParameterCollection): ParameterCollection to be trained
     
     Keyword Args:
-        e0_min (number): Lower learning rate (default: {0.01})
-        e0_max (number): Upper learning rate (default: {0.1})
+        learning_rate_min (number): Lower learning rate (default: {0.01})
+        learning_rate_max (number): Upper learning rate (default: {0.1})
         step_size (number): Period of the triangular function in number of iterations (__not__ epochs). According to the original paper, this should be set around (2-8) x (training iterations in epoch) (default: {2000})
         gamma (number): Learning rate upper bound decay parameter (default: {0.0})
-        edecay (number): Learning rate decay parameter. Ideally you shouldn't use this with cyclical learning rate since decay is already handled by :math:`\gamma` (default: {0.0})
     """
     cdef CCyclicalSGDTrainer *thischildptr
-    def __cinit__(self, ParameterCollection m, float e0_min = 0.01, float e0_max = 0.1, float step_size = 2000, float gamma = 0.0, float edecay = 0.0):
-        self.thischildptr = self.thisptr = new CCyclicalSGDTrainer(m.thisptr, e0_min, e0_max, step_size, gamma, edecay)
-    cpdef update(self, float s=1.0):
-        self.thischildptr.update(s)
+    def __cinit__(self, ParameterCollection m, float learning_rate_min = 0.01, float learning_rate_max = 0.1, float step_size = 2000, float gamma = 0.0):
+        self.thischildptr = self.thisptr = new CCyclicalSGDTrainer(m.thisptr, learning_rate_min, learning_rate_max, step_size, gamma)
+    cpdef update(self):
+        self.thischildptr.update()
     def whoami(self):
         return "CyclicalSGDTrainer"
 
@@ -4719,13 +4706,12 @@ cdef class MomentumSGDTrainer(Trainer):
         m(dynet.ParameterCollection): ParameterCollection to be trained
     
     Keyword Args:
-        e0(number): Initial learning rate (default: 0.1)
+        learning_rate(number): Initial learning rate (default: 0.1)
         mom(number): Momentum (default: 0.9)
-        edecay(number): Learning rate decay parameter (default: 0.0)
 
     """
-    def __cinit__(self, ParameterCollection m, float e0 = 0.01, float mom = 0.9, float edecay = 0.0):
-        self.thisptr = new CMomentumSGDTrainer(m.thisptr, e0, mom, edecay)
+    def __cinit__(self, ParameterCollection m, float learning_rate = 0.01, float mom = 0.9):
+        self.thisptr = new CMomentumSGDTrainer(m.thisptr, learning_rate, mom)
     def whoami(self):
         return "MomentumSGDTrainer"
 
@@ -4739,12 +4725,11 @@ cdef class AdagradTrainer(Trainer):
         m(dynet.ParameterCollection): ParameterCollection to be trained
     
     Keyword Args:
-        e0(number): Initial learning rate (default: 0.1)
+        learning_rate(number): Initial learning rate (default: 0.1)
         eps(number): Epsilon parameter to prevent numerical instability (default: 1e-20)
-        edecay(number): Learning rate decay parameter (default: 0.0)
     """
-    def __cinit__(self, ParameterCollection m, float e0 = 0.1, float eps = 1e-20, float edecay = 0.0):
-        self.thisptr = new CAdagradTrainer(m.thisptr, e0, eps, edecay)
+    def __cinit__(self, ParameterCollection m, float learning_rate = 0.1, float eps = 1e-20):
+        self.thisptr = new CAdagradTrainer(m.thisptr, learning_rate, eps)
     def whoami(self):
         return "AdagradTrainer"
 
@@ -4760,10 +4745,9 @@ cdef class AdadeltaTrainer(Trainer):
     Keyword Args:
         eps(number): Epsilon parameter to prevent numerical instability (default: 1e-6)
         rho(number): Update parameter for the moving average of updates in the numerator (default: 0.95)
-        edecay(number): Learning rate decay parameter (default: 0.0)
     """
-    def __cinit__(self, ParameterCollection m, float eps = 1e-6, float rho = 0.95, float edecay = 0.0):
-        self.thisptr = new CAdadeltaTrainer(m.thisptr, eps, rho, edecay)
+    def __cinit__(self, ParameterCollection m, float eps = 1e-6, float rho = 0.95):
+        self.thisptr = new CAdadeltaTrainer(m.thisptr, eps, rho)
     def whoami(self):
         return "AdadeltaTrainer"
 
@@ -4776,13 +4760,12 @@ cdef class RMSPropTrainer(Trainer):
         m(dynet.ParameterCollection): ParameterCollection to be trained
     
     Keyword Args:
-        e0(number): Initial learning rate (default: 0.001)
+        learning_rate(number): Initial learning rate (default: 0.001)
         eps(number): Epsilon parameter to prevent numerical instability (default: 1e-8)
         rho(number): Update parameter for the moving average (`rho = 0` is equivalent to using Adagrad) (default: 0.9)
-        edecay(number): Learning rate decay parameter (default: 0.0)
     """
-    def __cinit__(self, ParameterCollection m, float e0 = 0.001,float eps = 1e-8, float rho = 0.9, float edecay = 0.0):
-        self.thisptr = new CRMSPropTrainer(m.thisptr, e0, eps, rho, edecay)
+    def __cinit__(self, ParameterCollection m, float learning_rate = 0.001,float eps = 1e-8, float rho = 0.9):
+        self.thisptr = new CRMSPropTrainer(m.thisptr, learning_rate, eps, rho)
     def whoami(self):
         return "RMSPropTrainer"
 
@@ -4799,10 +4782,9 @@ cdef class AdamTrainer(Trainer):
         beta_1(number): Moving average parameter for the mean (default: 0.9)
         beta_2(number): Moving average parameter for the variance (default: 0.999)
         eps(number): Epsilon parameter to prevent numerical instability (default: 1e-8)
-        edecay(number): Learning rate decay parameter (default: 0.0)
     """
-    def __cinit__(self, ParameterCollection m, float alpha = 0.001, float beta_1 = 0.9, float beta_2 = 0.999, float eps = 1e-8, float edecay = 0.0 ):
-        self.thisptr = new CAdamTrainer(m.thisptr, alpha, beta_1, beta_2, eps, edecay)
+    def __cinit__(self, ParameterCollection m, float alpha = 0.001, float beta_1 = 0.9, float beta_2 = 0.999, float eps = 1e-8 ):
+        self.thisptr = new CAdamTrainer(m.thisptr, alpha, beta_1, beta_2, eps)
     def whoami(self):
         return "AdamTrainer"
 

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -93,7 +93,7 @@ class TestParameters(unittest.TestCase):
         self.lp1 = self.m.add_lookup_parameters((10, 10), init=dy.ConstInitializer(1))
         self.lp2 = self.m.add_lookup_parameters((10, 10), init=dy.ConstInitializer(1))
         # Trainer
-        self.trainer = dy.SimpleSGDTrainer(self.m, e0=0.1)
+        self.trainer = dy.SimpleSGDTrainer(self.m, learning_rate=0.1)
         self.trainer.set_clip_threshold(-1)
 
     def test_grad(self):

--- a/tests/test-io.cc
+++ b/tests/test-io.cc
@@ -6,6 +6,7 @@
 #include <stdexcept>
 
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 
 #include <dynet/dynet.h>
 #include <dynet/expr.h>
@@ -180,7 +181,15 @@ BOOST_AUTO_TEST_CASE ( test_save_load_parameter_nonzerograd ) {
   DYNET_CHECK_EQUAL(m2c, mc);
 }
 
-BOOST_AUTO_TEST_CASE ( test_save1_perf, *boost::unit_test::disabled() ) {
+#if BOOST_VERSION >= 105900
+#define BOOST_PERF_TEST_CASE(testname) \
+  BOOST_AUTO_TEST_CASE ( testname, *boost::unit_test::disabled() )
+#else
+#define BOOST_PERF_TEST_CASE(testname) \
+  BOOST_AUTO_TEST_CASE ( testname )
+#endif
+
+BOOST_PERF_TEST_CASE ( test_save1_perf ) {
   ParameterCollection m;
   for (int l = 0; l < 16; ++l)
     m.add_parameters({1024, 1024});
@@ -195,7 +204,7 @@ BOOST_AUTO_TEST_CASE ( test_save1_perf, *boost::unit_test::disabled() ) {
   std::cout << "elapsed time: " << elapsed_seconds.count() << "ms" << std::endl;
 }
 
-BOOST_AUTO_TEST_CASE ( test_load1_perf, *boost::unit_test::disabled() ) {
+BOOST_PERF_TEST_CASE ( test_load1_perf ) {
   ParameterCollection m, m_l;
   Parameter param;
   Parameter param_l = m_l.add_parameters({1024, 1024});
@@ -217,7 +226,7 @@ BOOST_AUTO_TEST_CASE ( test_load1_perf, *boost::unit_test::disabled() ) {
   DYNET_CHECK_EQUAL(param, param_l);
 }
 
-BOOST_AUTO_TEST_CASE ( test_save2_perf, *boost::unit_test::disabled() ) {
+BOOST_PERF_TEST_CASE ( test_save2_perf ) {
   ParameterCollection m;
   for (int l = 0; l < 512; ++l)
     m.add_parameters({128, 128});
@@ -232,7 +241,7 @@ BOOST_AUTO_TEST_CASE ( test_save2_perf, *boost::unit_test::disabled() ) {
   std::cout << "elapsed time: " << elapsed_seconds.count() << "ms" << std::endl;
 }
 
-BOOST_AUTO_TEST_CASE ( test_load2_perf, *boost::unit_test::disabled() ) {
+BOOST_PERF_TEST_CASE ( test_load2_perf ) {
   ParameterCollection m, m_l;
   Parameter param;
   Parameter param_l = m_l.add_parameters({128, 128});

--- a/tests/test-mem.cc
+++ b/tests/test-mem.cc
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE( expand_test ) {
     Expression z = sum_rows(sum_cols(x));
     cg.forward(z);
     cg.backward(z);
-    trainer.update(0.1);
+    trainer.update();
   }
 }
 

--- a/tests/test-trainers.cc
+++ b/tests/test-trainers.cc
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE( simple_sgd_direction ) {
   Expression z = y*x;
   float before = as_scalar(cg.forward(z));
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   float after = as_scalar(cg.forward(z));
   BOOST_CHECK_LT(after, before);
 }
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE( simple_sgd_update_subset ) {
   Expression y = input(cg, {1,3}, ones_vals);
   Expression z = y*(x1+x2);
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   vector<float> param_after = as_vector(param.get_storage().values);
   vector<float> param2_after = as_vector(param2.get_storage().values);
   for(size_t i = 0; i < param_after.size(); ++i)
@@ -96,7 +96,7 @@ BOOST_AUTO_TEST_CASE( cyclical_sgd_direction ) {
   Expression z = y*x;
   float before = as_scalar(cg.forward(z));
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   float after = as_scalar(cg.forward(z));
   BOOST_CHECK_LT(after, before);
 }
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE( momentum_sgd_direction ) {
   Expression z = y*x;
   float before = as_scalar(cg.forward(z));
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   float after = as_scalar(cg.forward(z));
   BOOST_CHECK_LT(after, before);
 }
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE( adagrad_direction ) {
   Expression z = y*x;
   float before = as_scalar(cg.forward(z));
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   float after = as_scalar(cg.forward(z));
   BOOST_CHECK_LT(after, before);
 }
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE( adadelta_direction ) {
   Expression z = y*x;
   float before = as_scalar(cg.forward(z));
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   float after = as_scalar(cg.forward(z));
   BOOST_CHECK_LT(after, before);
 }
@@ -160,7 +160,7 @@ BOOST_AUTO_TEST_CASE( rmsprop_direction ) {
   Expression z = y*x;
   float before = as_scalar(cg.forward(z));
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   float after = as_scalar(cg.forward(z));
   BOOST_CHECK_LT(after, before);
 }
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE( adam_direction ) {
   Expression z = y*x;
   float before = as_scalar(cg.forward(z));
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   float after = as_scalar(cg.forward(z));
   BOOST_CHECK_LT(after, before);
 }
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE( eg_direction ) {
   Expression z = y*x;
   float before = as_scalar(cg.forward(z));
   cg.backward(z);
-  trainer.update(0.1);
+  trainer.update();
   float after = as_scalar(cg.forward(z));
   BOOST_CHECK_EQUAL(after, before);
   param_vals = {1.1f,-2.2f,3.3f};// revert back to original values


### PR DESCRIPTION
There is some confusion regarding the interface of the "Trainer" class:
https://github.com/clab/dynet/issues/641
https://github.com/clab/dynet/issues/684

I agree that it's difficult to understand. This commit removes the rate decay and gradient scaling functionality that implicitly changes the learning rate in non-transparent ways. Here is an example of the before/after behavior:

*Rate Decay Before*

    // At beginning of training
    Trainer trainer(initial_learning_rate, rate_decay)
    // After every epoch
    trainer.update_epoch()

*Rate Decay After*

    // At beginning of training
    Trainer trainer(initial_learning_rate)
    // After every epoch
    trainer.learning_rate /= (1 - rate_decay)

*Gradient Scaling Before*:

    cg.backward(loss)
    trainer.update(scaling_factor)

*Gradient Scaling After*:

    cg.backward(loss * scaling_factor)
    trainer.update()