### PR TITLE
Update Scala bindings

### DIFF
--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -559,7 +559,6 @@ Expression pick(const Expression& x, unsigned v, unsigned d = 0);
 Expression pick(const Expression& x, const std::vector<unsigned>& v, unsigned d = 0);
 Expression pick(const Expression& x, const unsigned* v, unsigned d = 0);
 Expression pick_range(const Expression& x, unsigned s, unsigned e, unsigned d = 0);
-Expression pickrange(const Expression& x, unsigned v, unsigned u);
 
 // Concatenate and ConcatenateCols got changed around, need to implement
 // explicitly now.

--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -692,16 +692,13 @@ struct ComputationGraph {
 // Need to disable constructor as SWIG gets confused otherwise
 %nodefaultctor Trainer;
 struct Trainer {
-  void update(real scale = 1.0);
-  void update_epoch(real r = 1);
+  virtual void update();
+  void update_epoch(real r = 1.0);
 
-  float clip_gradients(real scale);
+  float clip_gradients();
   void rescale_and_reset_weight_decay();
 
-  real eta0;
-  real eta;
-  real eta_decay;
-  real epoch;
+  real learning_rate;
 
   bool clipping_enabled;
   real clip_threshold;
@@ -720,32 +717,32 @@ struct Trainer {
 };
 
 struct SimpleSGDTrainer : public Trainer {
-  explicit SimpleSGDTrainer(ParameterCollection& m, real e0 = 0.1, real edecay = 0.0);
+  explicit SimpleSGDTrainer(ParameterCollection& m, real learning_rate = 0.1);
 };
 
 struct CyclicalSGDTrainer : public Trainer {
-  explicit CyclicalSGDTrainer(ParameterCollection& m, real e0_min = 0.01, real e0_max = 0.1, real step_size = 2000, real gamma = 0.0, real edecay = 0.0);
-  void update(real scale = 1.0);
+  explicit CyclicalSGDTrainer(ParameterCollection& m, float learning_rate_min = 0.01, float learning_rate_max = 0.1, float step_size = 2000, float gamma = 0.0, float edecay = 0.0);
+  void update() override;
 };
 
 struct MomentumSGDTrainer : public Trainer {
-  explicit MomentumSGDTrainer(ParameterCollection& m, real e0 = 0.01, real mom = 0.9, real edecay = 0.0);
+  explicit MomentumSGDTrainer(ParameterCollection& m, real learning_rate = 0.01, real mom = 0.9);
 };
 
 struct AdagradTrainer : public Trainer {
-  explicit AdagradTrainer(ParameterCollection& m, real e0 = 0.1, real eps = 1e-20, real edecay = 0.0);
+  explicit AdagradTrainer(ParameterCollection& m, real learning_rate = 0.1, real eps = 1e-20);
 };
 
 struct AdadeltaTrainer : public Trainer {
-  explicit AdadeltaTrainer(ParameterCollection& m, real eps = 1e-6, real rho = 0.95, real edecay = 0.0);
+  explicit AdadeltaTrainer(ParameterCollection& m, real eps = 1e-6, real rho = 0.95);
 };
 
 struct RMSPropTrainer : public Trainer {
-   explicit RMSPropTrainer(ParameterCollection& m, real e0 = 0.001, real eps = 1e-08, real rho = 0.9, real edecay = 0.0);
+   explicit RMSPropTrainer(ParameterCollection& m, real learning_rate = 0.1, real eps = 1e-20, real rho = 0.95);
 };
 
 struct AdamTrainer : public Trainer {
-  explicit AdamTrainer(ParameterCollection& m, float e0 = 0.001, float beta_1 = 0.9, float beta_2 = 0.999, float eps = 1e-8, real edecay = 0.0);
+  explicit AdamTrainer(ParameterCollection& m, float learning_rate = 0.001, float beta_1 = 0.9, float beta_2 = 0.999, float eps = 1e-8);
 };
 
 ///////////////////////////////////

--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -558,6 +558,7 @@ Expression sum_batches(const Expression& x);
 Expression pick(const Expression& x, unsigned v, unsigned d = 0);
 Expression pick(const Expression& x, const std::vector<unsigned>& v, unsigned d = 0);
 Expression pick(const Expression& x, const unsigned* v, unsigned d = 0);
+Expression pick_range(const Expression& x, unsigned s, unsigned e, unsigned d = 0);
 Expression pickrange(const Expression& x, unsigned v, unsigned u);
 
 // Concatenate and ConcatenateCols got changed around, need to implement

--- a/contrib/swig/src/main/java/edu/cmu/dynet/examples/XorExample.java
+++ b/contrib/swig/src/main/java/edu/cmu/dynet/examples/XorExample.java
@@ -76,7 +76,7 @@ public class XorExample {
         floatp_assign(y_value, (x1 != x2) ? 1 : -1);
         loss += as_scalar(cg.forward(loss_expr));
         cg.backward(loss_expr);
-        sgd.update(1.0f);
+        sgd.update();
       }
       sgd.update_epoch();
       loss /= 4;

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
@@ -79,7 +79,9 @@ object Expression {
   def lookup(p: LookupParameter, pindex: UnsignedPointer) =
     makeExpr(cg => dn.lookup(cg, p.lookupParameter, pindex.uintp), Seq(p, pindex))
   def constLookup(p: LookupParameter, index: Long) =
-    makeExpr(cg => dn.lookup(cg, p.lookupParameter, index), Seq(p))
+    makeExpr(cg => dn.const_lookup(cg, p.lookupParameter, index), Seq(p))
+  def constLookup(p: LookupParameter, pindex: UnsignedPointer) =
+    makeExpr(cg => dn.const_lookup(cg, p.lookupParameter, pindex.uintp), Seq(p, pindex))
   // def constLookup
   def lookup(p: LookupParameter, indices: UnsignedVector) =
     makeExpr(cg => dn.lookup(cg, p.lookupParameter, indices.vector), Seq(p, indices))
@@ -219,8 +221,11 @@ object Expression {
     unary(x, x => dn.pick(x, v.vector, d))
   def pick(x: Expression, v: UnsignedPointer, d: Long): Expression =
     unary(x, x => dn.pick(x, v.uintp, d))
-  def pickrange(x: Expression, v: Long, u: Long): Expression =
-    unary(x, x => dn.pickrange(x, v, u))
+  def pickRange(x: Expression, v: Long, u: Long, d: Long = 0l): Expression =
+    unary(x, x => dn.pick_range(x, v, u, d))
+  // kept for backward compatibility
+  def pickrange(x: Expression, v: Long, u: Long, d: Long = 0l): Expression =
+    unary(x, x => dn.pick_range(x, v, u, d))
 
   def concatenateCols(v: ExpressionVector): Expression = vectory(v, dn.concatenate_cols)
   def concatenateCols(exprs: Expression*): Expression = concatenateCols(new ExpressionVector(exprs))

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
@@ -221,9 +221,6 @@ object Expression {
     unary(x, x => dn.pick(x, v.vector, d))
   def pick(x: Expression, v: UnsignedPointer, d: Long): Expression =
     unary(x, x => dn.pick(x, v.uintp, d))
-  def pickRange(x: Expression, v: Long, u: Long, d: Long = 0l): Expression =
-    unary(x, x => dn.pick_range(x, v, u, d))
-  // kept for backward compatibility
   def pickrange(x: Expression, v: Long, u: Long, d: Long = 0l): Expression =
     unary(x, x => dn.pick_range(x, v, u, d))
 

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Trainer.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Trainer.scala
@@ -2,10 +2,10 @@ package edu.cmu.dynet
 
 /** Interface for [[edu.cmu.dynet.ParameterCollection]] trainers. You want to use a specific subclass. */
 class Trainer private[dynet](_trainer: internal.Trainer) {
-  def update(scale: Float = 1.0f): Unit = _trainer.update(scale)
+  def update(): Unit = _trainer.update()
   def updateEpoch(r: Float = 1.0f): Unit = _trainer.update_epoch(r)
 
-  def clipGradients(scale: Float = 1.0f): Float = _trainer.clip_gradients(scale)
+  def clipGradients(): Float = _trainer.clip_gradients()
   def rescaleAndResetWeightDecay(): Unit = _trainer.rescale_and_reset_weight_decay()
 
   def status(): Unit = _trainer.status()
@@ -16,63 +16,63 @@ class Trainer private[dynet](_trainer: internal.Trainer) {
   def clipThreshold: Float = _trainer.getClip_threshold
   def clipThreshold_=(x: Float): Unit = _trainer.setClip_threshold(x)
 
-  def eta:Float = _trainer.getEta()
-  def eta_=(x:Float): Unit = _trainer.setEta(x)
+  def learningRate:Float = _trainer.getLearning_rate()
+  def eta_=(x:Float): Unit = _trainer.setLearning_rate(x)
 }
 
 class SimpleSGDTrainer private[dynet] (private[dynet] val trainer: internal.SimpleSGDTrainer)
   extends Trainer(trainer)
 {
-  def this(m: ParameterCollection, e0: Float = 0.1f, edecay: Float = 0.0f) {
-    this(new internal.SimpleSGDTrainer(m.model, e0, edecay))
+  def this(m: ParameterCollection, learningRate: Float = 0.1f) {
+    this(new internal.SimpleSGDTrainer(m.model, learningRate))
   }
 }
 
 class CyclicalSGDTrainer private[dynet] (private[dynet] val trainer: internal.CyclicalSGDTrainer)
   extends Trainer(trainer)
 {
-  def this(m: ParameterCollection, e0_min: Float = 0.01f, e0_max: Float = 0.1f, step_size: Float = 2000f, gamma: Float = 0.0f, edecay: Float = 0.0f) {
-    this(new internal.CyclicalSGDTrainer(m.model, e0_min, e0_max, step_size, gamma, edecay))
+  def this(m: ParameterCollection, learningRateMin: Float = 0.01f, learningRateMax: Float = 0.1f, stepSize: Float = 2000f, gamma: Float = 0.0f, edecay: Float = 0.0f) {
+    this(new internal.CyclicalSGDTrainer(m.model, learningRateMin, learningRateMax, stepSize, gamma, edecay))
   }
 }
 
 class MomentumSGDTrainer private[dynet] (private[dynet] val trainer: internal.MomentumSGDTrainer)
   extends Trainer(trainer)
 {
-  def this(m: ParameterCollection, e0: Float = 0.01f, mom: Float = 0.9f, edecay: Float = 0.0f) {
-    this(new internal.MomentumSGDTrainer(m.model, e0, mom, edecay))
+  def this(m: ParameterCollection, learningRate: Float = 0.01f, mom: Float = 0.9f) {
+    this(new internal.MomentumSGDTrainer(m.model, learningRate, mom))
   }
 }
 
 class AdagradTrainer private[dynet] (private[dynet] val trainer: internal.AdagradTrainer)
   extends Trainer(trainer)
 {
-  def this(m: ParameterCollection, e0: Float = 0.1f, eps: Float = 1e-20f, edecay: Float = 0.0f) {
-    this(new internal.AdagradTrainer(m.model, e0, eps, edecay))
+  def this(m: ParameterCollection, learningRate: Float = 0.1f, eps: Float = 1e-20f) {
+    this(new internal.AdagradTrainer(m.model, learningRate, eps))
   }
 }
 
 class AdadeltaTrainer private[dynet] (private[dynet] val trainer: internal.AdadeltaTrainer)
   extends Trainer(trainer)
 {
-  def this(m: ParameterCollection, eps: Float = 1e-6f, rho:Float = 0.95f, edecay: Float = 0.0f) {
-    this(new internal.AdadeltaTrainer(m.model, eps, rho, edecay))
+  def this(m: ParameterCollection, eps: Float = 1e-6f, rho:Float = 0.95f) {
+    this(new internal.AdadeltaTrainer(m.model, eps, rho))
   }
 }
 
 class RMSPropTrainer private[dynet] (private[dynet] val trainer: internal.RMSPropTrainer)
   extends Trainer(trainer)
 {
-  def this(m: ParameterCollection, e0: Float = 0.001f, eps: Float = 1e-8f, rho: Float = 0.9f, edecay: Float = 0.0f) {
-    this(new internal.RMSPropTrainer(m.model, e0, eps, rho, edecay))
+  def this(m: ParameterCollection, learningRate: Float = 0.001f, eps: Float = 1e-8f, rho: Float = 0.9f) {
+    this(new internal.RMSPropTrainer(m.model, learningRate, eps, rho))
   }
 }
 
 class AdamTrainer private[dynet] (private[dynet] val trainer: internal.AdamTrainer)
   extends Trainer(trainer)
 {
-  def this(m: ParameterCollection, e0: Float = 0.001f, beta1: Float = 0.9f, beta2: Float = 0.999f,
-           eps: Float = 1e-8f, edecay: Float = 0.0f) {
-    this(new internal.AdamTrainer(m.model, e0, beta1, beta2, eps, edecay))
+  def this(m: ParameterCollection, learningRate: Float = 0.001f, beta1: Float = 0.9f, beta2: Float = 0.999f,
+           eps: Float = 1e-8f) {
+    this(new internal.AdamTrainer(m.model, learningRate, beta1, beta2, eps))
   }
 }

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Trainer.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Trainer.scala
@@ -17,7 +17,7 @@ class Trainer private[dynet](_trainer: internal.Trainer) {
   def clipThreshold_=(x: Float): Unit = _trainer.setClip_threshold(x)
 
   def learningRate:Float = _trainer.getLearning_rate()
-  def eta_=(x:Float): Unit = _trainer.setLearning_rate(x)
+  def learningRate_=(x:Float): Unit = _trainer.setLearning_rate(x)
 }
 
 class SimpleSGDTrainer private[dynet] (private[dynet] val trainer: internal.SimpleSGDTrainer)

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/examples/XorScala.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/examples/XorScala.scala
@@ -52,7 +52,7 @@ object XorScala {
         y_value.set(if (x1 != x2) 1 else -1)
         loss += ComputationGraph.forward(loss_expr).toFloat
         ComputationGraph.backward(loss_expr)
-        sgd.update(1.0f)
+        sgd.update()
       }
       sgd.updateEpoch()
       loss /= 4

--- a/contrib/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/contrib/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -66,6 +66,7 @@ class SerializationSpec extends FlatSpec with Matchers {
 
     val saver = new ModelSaver(path)
     saver.addModel(mod1)
+    saver.done()
 
     val loader = new ModelLoader(path)
     val mod2 = new ParameterCollection()
@@ -85,6 +86,7 @@ class SerializationSpec extends FlatSpec with Matchers {
     val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
     val saver = new ModelSaver(path)
     saver.addModel(mod1)
+    saver.done()
 
     val loader = new ModelLoader(path)
     val mod2 = new ParameterCollection()


### PR DESCRIPTION
1. adapt to changes in training interface
2. fix Expression.constLookup, let Expression.pickrange use pick_range instead of pickrange
3. fix #683.

It turned out that saver.done() was missing from SerializationSpec.scala and it caused the error. 
The last line of the model is not written to the file until ModelSaver.done() is called, and if a ModelLoader reads the file before the saver is done and tries to populate a new model, it fills missing values with the ones from the last parameter in the unfinished file. 
I guess it was passing the test before #663 because what's not written to the model file until ModelSaver.done() was the gradient.

I think Expression.pickrange should be renamed to Expression.pickRange, but kept it as is for compatibility.
If nobody mind I'll change them and send another PR.