### PR TITLE
add verbose error message to even-length BiRNN hidden dim assertion

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -4302,7 +4302,7 @@ class BiRNNBuilder(object): # {{{
         """Args:
             num_layers: depth of the BiRNN
             input_dim: size of the inputs
-            hidden_dim: size of the outputs (and intermediate layer representations)
+            hidden_dim: size of the outputs (and intermediate layer representations.) This hidden dim is split evenly between the two constituent RNNs, and thus must be even. 
             model
             rnn_builder_factory: RNNBuilder subclass, e.g. LSTMBuilder
             builder_layers: list of (forward, backward) pairs of RNNBuilder instances to directly initialize layers

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -4311,7 +4311,7 @@ class BiRNNBuilder(object): # {{{
         model = self.model = model.add_subcollection("birnn")
         if builder_layers is None:
             assert num_layers > 0
-            assert hidden_dim % 2 == 0
+            assert hidden_dim % 2 == 0, "BiRNN hidden dimension must be even."
             self.builder_layers = []
             f = rnn_builder_factory(1, input_dim, hidden_dim/2, model)
             b = rnn_builder_factory(1, input_dim, hidden_dim/2, model)


### PR DESCRIPTION
This may be domain knowledge, but I was unaware that the hidden dimension of a BiRNN was considered to be split between the two constituent RNNs (instead of, say, assigning the full dimension assigned to each.)

When an odd dimension is given to BiRNN builder 
 - *Previous behavior:* die with Python assertion, no message 
 - *New behavior:*  die with Python assertion, descriptive message

I also added the constraint (and splitting-the-dimension behavior) to the BiRNN docs. 