### PR TITLE
Made text saving be fixed-width for efficiency

### DIFF
--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -10,6 +10,7 @@ using namespace dynet;
 // We should probably use std::hexfloat, but it's not supported by some
 // older incomplete implementations of C++11.
 static const int FLOAT32_PRECISION = 8;
+static const int FLOAT32_EXPONENT = 2;
 
 bool valid_key(const std::string & s) {
   if (s.size() == 0) return true;
@@ -87,7 +88,10 @@ void TextFileSaver::save(const LookupParameter & param,
 void TextFileSaver::save(const ParameterStorage & p,
                          const string & key) {
   datastream << "#Parameter# " << (key.size() > 0 ? key : p.name) << ' ' << p.dim << ' ';
-  size_t strsize = p.dim.size() * (FLOAT32_PRECISION + 8) + 1;
+  // A single float is "[+-]X.YYYe[+-]ZZZ " where the length of YYY is
+  // FLOAT32_PRECISION, and length of ZZZ is FLOAT32_EXPONENT. We additionally
+  // add a newline at the end of the line, so the total size is as below.
+  size_t strsize = p.dim.size() * (FLOAT32_PRECISION + FLOAT32_EXPONENT + 6) + 1;
   bool zero_grad = grad_is_zero(p);
   if(zero_grad)
     datastream << strsize << " ZERO_GRAD";


### PR DESCRIPTION
Addresses  https://github.com/clab/dynet/issues/715 by making floats fixed-width in the saved file and pre-calculating the size in bytes:

Here are some stats to help whether this is a good way of doing things:
* Memory required on save for above example: Old=308MB, New=16MB
* Space on disk required for above example: Old=50MB, New=64MB
* Time required for `tests/test-io`'s `test_save1_perf`: Old=9.40s, New=9.28s (stddev: ~0.14)

So this is faster, and more importantly doesn't have the memory spike, but results in a non-trivial increase in disk space. I'd tend to favor incorporating this, as memory spiking on model saving could cause processes to crash or hang after an epoch of training, which could be quite annoying.