### PR TITLE
Make compiling C++ examples optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ before_script:
   - 'if [[ "$PYTHON_INSTALL" == "manual" ]]; then
       mkdir build;
       cd build;
-      cmake .. -DEIGEN3_INCLUDE_DIR=/usr/local/include/eigen3 -DENABLE_BOOST=ON -DPYTHON=`which python` || travis_terminate 1;
+      cmake .. -DEIGEN3_INCLUDE_DIR=/usr/local/include/eigen3 -DENABLE_BOOST=ON -DENABLE_CPP_EXAMPLES=ON -DPYTHON=`which python` || travis_terminate 1;
     else
       pip install -v . || travis_terminate 1;
     fi'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,9 +182,15 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.cmake ${CMAKE_CURRENT_BINARY
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_subdirectory(dynet)
-add_subdirectory(examples)
-add_subdirectory(tutorial)
-add_subdirectory(python)
+
+if(ENABLE_CPP_EXAMPLES)
+  add_subdirectory(tutorial)
+  add_subdirectory(examples)
+endif(ENABLE_CPP_EXAMPLES)
+
+if(PYTHON)
+  add_subdirectory(python)
+endif(PYTHON)
 
 if(ENABLE_SWIG)
   message("-- Enabling SWIG")

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -56,14 +56,16 @@ To get and build DyNet, clone the repository
     git clone https://github.com/clab/dynet.git
 
 then enter the directory and use ```cmake`` <http://www.cmake.org/>`__
-to generate the makefiles
+to generate the makefiles. When you run ``cmake``, you will need to specify
+the path to Eigen, and will probably want to specify ``ENABLE_CPP_EXAMPLES``
+to compile the C++ examples.
 
 ::
 
     cd dynet
     mkdir build
     cd build
-    cmake .. -DEIGEN3_INCLUDE_DIR=/path/to/eigen
+    cmake .. -DEIGEN3_INCLUDE_DIR=/path/to/eigen -DENABLE_CPP_EXAMPLES=ON
 
 
 Then compile, where "2" can be replaced by the number of cores on your


### PR DESCRIPTION
A good portion of compile time is spent compiling the C++ examples, which are not necessary for most people (particularly those working in other languages). This commit makes compiling these examples optional (off by default). I left it on in Travis CI, as it's important to ensure that they do compile.