### PR TITLE
Better way to set configuration from python.

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -29,6 +29,7 @@ if(PYTHON)
   
   # Things to copy the files
   file(GLOB DepFiles ${CMAKE_CURRENT_SOURCE_DIR}/dynet.py
+                     ${CMAKE_CURRENT_SOURCE_DIR}/dynet_config.py
                      ${CMAKE_CURRENT_SOURCE_DIR}/_dynet.pyx
                      ${CMAKE_CURRENT_SOURCE_DIR}/_dynet.pxd
                      ${CMAKE_CURRENT_SOURCE_DIR}/dynet_viz.py

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -16,7 +16,8 @@ import os.path
 from _dynet cimport *
 cimport _dynet as dynet
 
-
+# TODO: make this class hidden from users?
+#       (by prepending with _, and removing from docs)
 cdef class DynetParams: # {{{
     """This object holds the global parameters of Dynet
 
@@ -31,6 +32,22 @@ cdef class DynetParams: # {{{
     def __init__(self):
         pass
 
+    # TODO conf, defined in dynet_config, can be
+    #      made much more "pythonic" and then this
+    #      should be adapted.
+    cpdef from_config(self, conf):
+        """TODO
+        """
+        self.cparams.mem_descriptor = str(conf["mem"]).encode()
+        self.cparams.random_seed=conf["seed"]
+        self.cparams.autobatch = conf["autobatch"]
+        self.cparams.autobatch_debug = conf["autobatch_debug"]
+        self.cparams.weight_decay = conf["weight_decay"]
+        self.cparams.shared_parameters = conf["shared_params"]
+        self.set_requested_gpus(conf["requested_gpus"])
+        self.set_gpu_mask(conf["gpu_mask"])
+
+    # TODO can this be removed?
     cpdef from_args(self, shared_parameters=None):
         """Gets parameters from the command line arguments
         
@@ -171,6 +188,7 @@ def init_from_params(DynetParams params):
     """
     params.init()
 # }}}
+
 
 # Dimensions {{{
 cdef CDim Dim(dim, unsigned int batch_size=1):

--- a/python/dynet.py
+++ b/python/dynet.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import sys
 import dynet_config
 
@@ -20,7 +21,7 @@ if '--dynet-viz' in sys.argv:
 elif _GPU:
     def print_graphviz(**kwarge):
         print("Run with --dynet-viz to get the visualization behavior.")
-    print "importing gdy"
+    print("importing gdy")
     from _gdynet import *
 else:
     def print_graphviz(**kwarge):

--- a/python/dynet.py
+++ b/python/dynet.py
@@ -1,15 +1,26 @@
 import sys
+import dynet_config
+
+_GPU = False
+_CONF = dynet_config.get()
+
+if dynet_config.gpu():
+    _GPU=True
+# TODO I'm not quite sure what the "use GPU" logic should be.
+if _CONF and _CONF["requested_gpus"]:
+    _GPU=True
+
+_GPU = _GPU or ("--dynet-gpu" in sys.argv) # the python gpu switch.
+_GPU = _GPU or ('--dynet-gpus' in sys.argv or '--dynet-gpu-ids' in sys.argv) # but using the c++ gpu switches suffices to trigger gpu.
+if '--dynet-gpu' in sys.argv: sys.argv.remove('--dynet-gpu')
+
 if '--dynet-viz' in sys.argv:
     sys.argv.remove('--dynet-viz')
     from dynet_viz import *
-elif '--dynet-gpu' in sys.argv:  # the python gpu switch.
-    sys.argv.remove('--dynet-gpu')
+elif _GPU:
     def print_graphviz(**kwarge):
         print("Run with --dynet-viz to get the visualization behavior.")
-    from _gdynet import *
-elif '--dynet-gpus' in sys.argv or '--dynet-gpu-ids' in sys.argv: # but using the c++ gpu switches suffices to trigger gpu.
-    def print_graphviz(**kwarge):
-        print("Run with --dynet-viz to get the visualization behavior.")
+    print "importing gdy"
     from _gdynet import *
 else:
     def print_graphviz(**kwarge):
@@ -18,4 +29,9 @@ else:
 
 __version__ = 2.0
 
-init()
+if _CONF is None:
+    init()
+else:
+    _params = DynetParams()
+    _params.from_config(_CONF)
+    _params.init()

--- a/python/dynet_config.py
+++ b/python/dynet_config.py
@@ -1,0 +1,22 @@
+def set(mem="0", random_seed=0, autobatch=0,
+        autobatch_debug=0, weight_decay=0, shared_parameters=0,
+        requested_gpus=0, gpu_mask=None):
+
+    # TODO read "gpu_mask" from list of IDs?
+    __builtins__["__DYNET_CONFIG"] = {
+            "mem":mem, "seed": random_seed, "autobatch": autobatch,
+            "autobatch_debug":autobatch_debug, "weight_decay": weight_decay,
+            "shared_params": shared_parameters,
+            "requested_gpus": requested_gpus,
+            "gpu_mask": gpu_mask if gpu_mask else list(),
+            }
+
+def set_gpu(flag=True):
+    __builtins__["__DYNET_GPU"]=flag
+
+def gpu(): return __builtins__["__DYNET_GPU"]
+
+def get():
+    if "__DYNET_CONFIG" in __builtins__:
+        return __builtins__["__DYNET_CONFIG"]
+    return None

--- a/python/dynet_config.py
+++ b/python/dynet_config.py
@@ -14,7 +14,10 @@ def set(mem="0", random_seed=0, autobatch=0,
 def set_gpu(flag=True):
     __builtins__["__DYNET_GPU"]=flag
 
-def gpu(): return __builtins__["__DYNET_GPU"]
+def gpu():
+    if "__DYNET_GPU" in __builtins__:
+        return __builtins__["__DYNET_GPU"]
+    return None
 
 def get():
     if "__DYNET_CONFIG" in __builtins__:

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -108,5 +108,5 @@ if "${WITH_CUDA_BACKEND}"=="1": # if cuda requested
 setup(ext_modules = TARGET,
         cmdclass = {'build_ext': build_ext},
         name="dyNET",
-        py_modules = ['dynet','dynet_viz'],
+        py_modules = ['dynet','dynet_viz', 'dynet_config'],
 )


### PR DESCRIPTION
Instead of the `import _dynet/_gdynet` and then setting `DynetParams` followed by
`init`, vs `import dynet` with commandline args, we can now do:

```
    import dynet # as before
```

or:
```
    import dynet_config
    dynet_config.set_gpu()
    dynet_config.set(mem=4,random_seed=9)
    import dynet
```