### PR TITLE
Make conv2d with a single channel accept 2-dimensional inputs

### DIFF
--- a/dynet/nodes-conv2d.cc
+++ b/dynet/nodes-conv2d.cc
@@ -39,17 +39,17 @@ Dim Conv2D::dim_forward(const vector<Dim>& xs) const {
     ostringstream s; s << "Conv2D requires either two or three inputs: " << xs;
     throw std::invalid_argument(s.str());
   }
-  if (xs[0].ndims() != 3 || xs[1].ndims() != 4 ||
-      xs[1].d[2] != xs[0].d[2]) {
+  if ((xs[0].ndims() != 2 && xs[0].ndims() != 3) || xs[1].ndims() != 4 ||
+      xs[1][2] != xs[0][2]) {
     ostringstream s; s << "Bad input dimensions in Conv2D: " << xs;
     throw std::invalid_argument(s.str());
   }
-  if (is_valid && (xs[0].d[0] < xs[1].d[0] || xs[0].d[1] < xs[1].d[1])) {
+  if (is_valid && (xs[0][0] < xs[1][0] || xs[0][1] < xs[1][1])) {
     ostringstream s; s << "Bad input dimensions in Conv2D: in VALID convolution, the filter size must not be greater than the feature map size" << xs;
     throw std::invalid_argument(s.str());
   }
   if (xs.size() == 3) { //has bias term
-    if (xs[2].d[0] != xs[1].d[3] || xs[2].ndims() != 1) {
+    if (xs[2][0] != xs[1][3] || xs[2].ndims() != 1) {
       ostringstream s; s << "Bad input dimensions in Conv2D: " << xs;
       throw std::invalid_argument(s.str());
     }

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1292,6 +1292,26 @@ BOOST_AUTO_TEST_CASE( conv2d_valid_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression conv2d(const Expression& x ,const Expression& f, const std::vector<unsigned>& stride, bool is_valid);
+BOOST_AUTO_TEST_CASE( conv2d_valid_singlefilter_gradient ) {
+  dynet::ComputationGraph cg;
+  Parameter param_kernel = mod.add_parameters({2, 4, 1, 3});
+  std::vector<float> param_kernel_vals = {.011f, .022f, .033f, .012f, .022f, .032f, .013f, .023f, .033f,
+                                         .111f, -.122f, -.033f, -.112f, -.022f, -.132f, -.113f, -.123f, -.133f,
+                                         .211f, .222f, .233f, .212f, .222f, .232f};
+  TensorTools::set_elements(param_kernel.get_storage().values, param_kernel_vals);
+  std::vector<float> conv2d_batch_vals(50 * 100 * 1 * 2);
+  for (unsigned i = 0; i < conv2d_batch_vals.size(); ++i) {
+    conv2d_batch_vals[i] = i * 0.011f + (i+1) * 0.001f;
+  }
+  Expression x = input(cg, Dim({50, 100}, 2), conv2d_batch_vals);
+  Expression kernel = parameter(cg, param_kernel);
+  vector<unsigned> stride = {3, 3}; bool is_valid = true;
+  Expression y = conv2d(x, kernel, stride, is_valid);
+  Expression z = sum_batches(sum_elems(y));
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 BOOST_AUTO_TEST_CASE( conv2d_same_gradient ) {
   dynet::ComputationGraph cg;
   Parameter param_kernel = mod.add_parameters({2, 2, 2, 3});


### PR DESCRIPTION
Sometimes, particularly when handling text, we'll have a 2-dimensional array as input to conv2d, which is treated as having a single channel. This allows us to pass this as-is without reshaping to a 3-dimensional tensor.