### PR TITLE
Autobatch CompactLSTMBuilder

### DIFF
--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -353,11 +353,16 @@ const Tensor& BatchedExecutionEngine::incremental_forward() {
 void BatchedExecutionEngine::garbage_collect() {
   // free any old memory if this is a new CG
   for(auto & batch : batches) {
-    if(batch.pseudo_node != nullptr)
+    if(batch.pseudo_node != nullptr) {
       delete batch.pseudo_node;
-    for(size_t i = 0; i < batch.arg_nfxs.size(); ++i)
-      if(batch.concat[i])
+      batch.pseudo_node = nullptr;
+    }
+    for(size_t i = 0; i < batch.arg_nfxs.size(); ++i) {
+      if(batch.concat[i] != 0) {
         delete batch.arg_nfxs[i];
+        batch.arg_nfxs[i] = nullptr;
+      }
+    }
   }
   for(Device* dev : dynet::devices)
     dev->pools[(int)DeviceMempool::FXS]->free();
@@ -392,7 +397,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
     int* active_un_begin = node2depth + uptop1;
     int* active_un_end = active_un_begin;
     float* prof2avg = (float*)(active_un_begin + uptop1);
-    float* prof2cnt = prof2avg + upto - node_id + 2;
+    float* prof2cnt = prof2avg + uptop1;
 
     // More intelligent batching?
     if(autobatch_strategy == 1 || autobatch_strategy == 3) {

--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -377,6 +377,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
     string current_batch_name;
 
     size_t uptop1 = upto + 1;
+    size_t uptop1psig = uptop1 + sigmap.size();
 
     nfx_cache.resize(uptop1);
     node2batch.resize(uptop1);
@@ -389,15 +390,15 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
     batches.resize(upto - num_nodes_evaluated + num_batches_evaluated + 1);
 
     // Allocate temporary memory for bookkeeping
-    size_t temp_data_size = (uptop1)*4*sizeof(int) + (upto+2)*2*sizeof(float);
+    size_t temp_data_size = (uptop1)*4*sizeof(int) + (uptop1psig)*2*sizeof(float);
     int* node2profid = (int*)malloc(temp_data_size);
     memset(node2profid, 0, temp_data_size);
     int* node2left = node2profid + uptop1;
     int* node2depth = node2left + uptop1;
     int* active_un_begin = node2depth + uptop1;
     int* active_un_end = active_un_begin;
-    float* prof2avg = (float*)(active_un_begin + uptop1);
-    float* prof2cnt = prof2avg + uptop1;
+    float* prof2avg = (float*)(active_un_begin + uptop1psig);
+    float* prof2cnt = prof2avg + uptop1psig;
 
     // More intelligent batching?
     if(autobatch_strategy == 1 || autobatch_strategy == 3) {

--- a/dynet/nodes-lstm.cc
+++ b/dynet/nodes-lstm.cc
@@ -344,6 +344,16 @@ namespace dynet {
     return xs[0];
   }
 
+  int VanillaLSTMC::autobatch_sig(const ComputationGraph & cg, SigMap &sm) const {
+    Sig s(nt::vanilla_lstm_h);
+    s.add_dim(cg.nodes[args[0]]->dim);
+    return sm.get_idx(s);
+  }
+  
+  std::vector<int> VanillaLSTMC::autobatch_concat(const ComputationGraph & cg) const {
+    return vector<int>(2, 1);
+  }
+
 #endif
 
   template<class MyDevice>
@@ -413,6 +423,16 @@ namespace dynet {
     DYNET_ARG_CHECK(xs[0].size()*4 == xs[1].size(), "VanillaLSTMH: gates_t expected 4 times as big as c_t, but " << xs[0].size() << "*4 != " << xs[1].size());
     DYNET_ARG_CHECK(xs[0].bd == xs[1].bd, "VanillaLSTMH: gates_t and c_t expected to have equal batch size, but " << xs[0].bd << " != " << xs[1].bd);
     return xs[0];
+  }
+
+  int VanillaLSTMH::autobatch_sig(const ComputationGraph & cg, SigMap &sm) const {
+    Sig s(nt::vanilla_lstm_h);
+    s.add_dim(cg.nodes[args[0]]->dim);
+    return sm.get_idx(s);
+  }
+  
+  std::vector<int> VanillaLSTMH::autobatch_concat(const ComputationGraph & cg) const {
+    return vector<int>(2, 1);
   }
 
 #endif

--- a/dynet/nodes-lstm.h
+++ b/dynet/nodes-lstm.h
@@ -9,17 +9,44 @@ namespace dynet {
 struct VanillaLSTMGates : public Node {
   explicit VanillaLSTMGates(const std::initializer_list<VariableIndex>& a, real weightnoise_std) : Node(a), weightnoise_std(weightnoise_std) {}
   virtual bool supports_multibatch() const override { return true; }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override;
+  virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override;
+  virtual void autobatch_reshape(const ComputationGraph & cg,
+                                 const std::vector<VariableIndex> & batch_ids,
+                                 const std::vector<int> & concat,
+                                 std::vector<const Tensor*>& xs,
+                                 Tensor& fx) const override {
+    autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
+  }
   real weightnoise_std;
   DYNET_NODE_DEFINE_DEV_IMPL()
 };
 struct VanillaLSTMC : public Node {
   explicit VanillaLSTMC(const std::initializer_list<VariableIndex>& a) : Node(a) {}
   virtual bool supports_multibatch() const override { return true; }
+  // virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override;
+  // virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override;
+  // virtual void autobatch_reshape(const ComputationGraph & cg,
+  //                                const std::vector<VariableIndex> & batch_ids,
+  //                                const std::vector<int> & concat,
+  //                                std::vector<const Tensor*>& xs,
+  //                                Tensor& fx) const override {
+  //   autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
+  // }
   DYNET_NODE_DEFINE_DEV_IMPL()
 };
 struct VanillaLSTMH : public Node {
   explicit VanillaLSTMH(const std::initializer_list<VariableIndex>& a) : Node(a) {}
   virtual bool supports_multibatch() const override { return true; }
+  // virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override;
+  // virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override;
+  // virtual void autobatch_reshape(const ComputationGraph & cg,
+  //                                const std::vector<VariableIndex> & batch_ids,
+  //                                const std::vector<int> & concat,
+  //                                std::vector<const Tensor*>& xs,
+  //                                Tensor& fx) const override {
+  //   autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
+  // }
   DYNET_NODE_DEFINE_DEV_IMPL()
 };
 

--- a/dynet/nodes-lstm.h
+++ b/dynet/nodes-lstm.h
@@ -24,29 +24,29 @@ struct VanillaLSTMGates : public Node {
 struct VanillaLSTMC : public Node {
   explicit VanillaLSTMC(const std::initializer_list<VariableIndex>& a) : Node(a) {}
   virtual bool supports_multibatch() const override { return true; }
-  // virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override;
-  // virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override;
-  // virtual void autobatch_reshape(const ComputationGraph & cg,
-  //                                const std::vector<VariableIndex> & batch_ids,
-  //                                const std::vector<int> & concat,
-  //                                std::vector<const Tensor*>& xs,
-  //                                Tensor& fx) const override {
-  //   autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
-  // }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override;
+  virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override;
+  virtual void autobatch_reshape(const ComputationGraph & cg,
+                                 const std::vector<VariableIndex> & batch_ids,
+                                 const std::vector<int> & concat,
+                                 std::vector<const Tensor*>& xs,
+                                 Tensor& fx) const override {
+    autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
+  }
   DYNET_NODE_DEFINE_DEV_IMPL()
 };
 struct VanillaLSTMH : public Node {
   explicit VanillaLSTMH(const std::initializer_list<VariableIndex>& a) : Node(a) {}
   virtual bool supports_multibatch() const override { return true; }
-  // virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override;
-  // virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override;
-  // virtual void autobatch_reshape(const ComputationGraph & cg,
-  //                                const std::vector<VariableIndex> & batch_ids,
-  //                                const std::vector<int> & concat,
-  //                                std::vector<const Tensor*>& xs,
-  //                                Tensor& fx) const override {
-  //   autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
-  // }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override;
+  virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override;
+  virtual void autobatch_reshape(const ComputationGraph & cg,
+                                 const std::vector<VariableIndex> & batch_ids,
+                                 const std::vector<int> & concat,
+                                 std::vector<const Tensor*>& xs,
+                                 Tensor& fx) const override {
+    autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
+  }
   DYNET_NODE_DEFINE_DEV_IMPL()
 };
 

--- a/dynet/sig.h
+++ b/dynet/sig.h
@@ -15,6 +15,7 @@ namespace dynet {
       input, scalar_input, lookup, 
       COMPLEX,
       affine, matmul,
+      vanilla_lstm_gates, vanilla_lstm_h, vanilla_lstm_c,
     };
   }
 


### PR DESCRIPTION
This adds autobatching support for CompactLSTMBuilder. It also fixes an edge case memory out of bounds exception in autobatching that happened when the number of autobatching signatures was larger than the size of the graph. (FYI: @msperber, @yoavg)