### PR TITLE
Made sigmoid more numerically stable

### DIFF
--- a/dynet/functors.h
+++ b/dynet/functors.h
@@ -243,7 +243,7 @@ struct FSoftSignBackward {
 
 struct FLogisticSigmoid {
   DYNET_DEVICE_FUNC inline float operator()(float x) const {
-    return 1.f / (1.f + expf(-x));
+    return 0.5 + 0.5 * tanh(x * 0.5);
   }
 };
 

--- a/dynet/simd-functors.h
+++ b/dynet/simd-functors.h
@@ -75,14 +75,14 @@ template<typename Scalar> struct scalar_logistic_sigmoid_op {
   EIGEN_EMPTY_STRUCT_CTOR(scalar_logistic_sigmoid_op)
   DYNET_DEVICE_FUNC inline const Scalar operator() (const Scalar& x) const {
     using std::exp;
-    const Scalar one = Scalar(1);
-    return one / (one + exp(-x));
+    const Scalar half = Scalar(0.5);
+    return half + half * tanh(x * half);
   }
   template <typename Packet>
   DYNET_DEVICE_FUNC inline Packet packetOp(const Packet& x) const {
     using namespace Eigen::internal;
-    const Packet one = pset1<Packet>(1);
-    return pdiv(one, padd(one, pexp(pnegate(x))));
+    const Packet half = pset1<Packet>(0.5);
+    return padd(half, pmul(half, ptanh(pmul(x, half))));
   }
 };
 }


### PR DESCRIPTION
Taking an exponent in the sigmoid layer can cause NaNs. This uses the more numerically stable tanh-based version of the sigmoid.