### PR TITLE
Scratch memory for noise() and logsumexp()

### DIFF
--- a/dynet/nodes-logsumexp.h
+++ b/dynet/nodes-logsumexp.h
@@ -12,7 +12,6 @@ struct LogSumExp : public Node {
   template <typename T> explicit LogSumExp(const T& a) : Node(a) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
   virtual bool supports_multibatch() const override { return true; }
-  size_t aux_storage_size() const override;
 };
 
 } // namespace dynet

--- a/dynet/nodes-random.h
+++ b/dynet/nodes-random.h
@@ -11,7 +11,6 @@ namespace dynet {
 struct GaussianNoise : public Node {
   explicit GaussianNoise(const std::initializer_list<VariableIndex>& a, real stddev) : Node(a), stddev(stddev) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
-  size_t aux_storage_size() const override;
   virtual bool supports_multibatch() const override { return true; }
   real stddev;
 };


### PR DESCRIPTION
Using scratch memory instead of permanent memory