### PR TITLE
Fix eigen gcc version

### DIFF
--- a/dynet/CMakeLists.txt
+++ b/dynet/CMakeLists.txt
@@ -225,17 +225,7 @@ if(WITH_CUDA_BACKEND)
   if(CUDNN_FOUND)
     list(APPEND CUDA_NVCC_FLAGS "-DHAVE_CUDNN")
   endif()
-  if(CMAKE_COMPILER_IS_GNUCXX)
-    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.9 OR CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 4.9)
-      # gcc 4.9 or later versions raise SEGV due to the optimization problem.
-      # Use -O1 instead for now.
-      list(APPEND CUDA_NVCC_FLAGS "-O1")
-    else()
-      list(APPEND CUDA_NVCC_FLAGS "-O2")
-    endif()
-  else()
-    list(APPEND CUDA_NVCC_FLAGS "-O2")
-  endif()
+  list(APPEND CUDA_NVCC_FLAGS "-O2")
   if(MSVC)
     # If MSVC, we need the boost flag because nvcc doesn't properly parse part of the boost template definitions
     list(APPEND CUDA_NVCC_FLAGS "-DBOOST_NO_CXX11_ALLOCATOR")

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -98,7 +98,9 @@ Device_GPU::Device_GPU(int my_id, const DeviceMempoolSizes & mbs, int device_id)
   CUDA_CHECK(cudaMemcpyAsync(kSCALAR_ZERO, &zero, sizeof(float), cudaMemcpyHostToDevice));
 
   // Initialize the Eigen device
-  estream = new Eigen::CudaStreamDevice(device_id);
+  CUDA_CHECK(cudaStreamCreate(stream));
+  estream = new EigenCudaStreamDevice(device_id);
+  estream->set_stream(&stream);
   edevice = new Eigen::GpuDevice(estream);
 
   // this is the big memory allocation.

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -2,7 +2,6 @@
 
 #include <iostream>
 #include <string>
-#include <unsupported/Eigen/CXX11/Tensor>
 
 #include "dynet/cuda.h"
 #include "dynet/dynet.h"
@@ -98,7 +97,7 @@ Device_GPU::Device_GPU(int my_id, const DeviceMempoolSizes & mbs, int device_id)
   CUDA_CHECK(cudaMemcpyAsync(kSCALAR_ZERO, &zero, sizeof(float), cudaMemcpyHostToDevice));
 
   // Initialize the Eigen device
-  CUDA_CHECK(cudaStreamCreate(stream));
+  CUDA_CHECK(cudaStreamCreate(&stream));
   estream = new EigenCudaStreamDevice(device_id);
   estream->set_stream(&stream);
   edevice = new Eigen::GpuDevice(estream);

--- a/dynet/devices.h
+++ b/dynet/devices.h
@@ -6,6 +6,7 @@
 #include "dynet/aligned-mem-pool.h"
 #include "dynet/cuda.h"
 #include "dynet/globals.h"
+#include <unsupported/Eigen/CXX11/Tensor>
 
 namespace Eigen {
   struct DefaultDevice;

--- a/dynet/devices.h
+++ b/dynet/devices.h
@@ -51,9 +51,91 @@ class Device {
 };
 
 #if HAVE_CUDA
+static const cudaStream_t default_stream = cudaStreamDefault;
+
+class EigenCudaStreamDevice : public Eigen::StreamInterface {
+ public:
+  // Use the default stream on the current device
+  EigenCudaStreamDevice()
+      : stream_(&default_stream), scratch_(NULL), semaphore_(NULL) {
+    cudaGetDevice(&device_);
+    Eigen::initializeDeviceProp();
+  }
+  // Use the default stream on the specified device
+  explicit EigenCudaStreamDevice(int device)
+      : stream_(&default_stream),
+        device_(device),
+        scratch_(NULL),
+        semaphore_(NULL) {
+    Eigen::initializeDeviceProp();
+  }
+  // Use the specified stream. Note that it's the
+  // caller responsibility to ensure that the stream can run on
+  // the specified device. If no device is specified the code
+  // assumes that the stream is associated to the current gpu device.
+  explicit EigenCudaStreamDevice(const cudaStream_t* stream, int device = -1)
+      : stream_(stream), device_(device), scratch_(NULL), semaphore_(NULL) {
+    if (device < 0) {
+      cudaGetDevice(&device_);
+    } else {
+      int num_devices;
+      cudaGetDeviceCount(&num_devices);
+      device_ = device;
+    }
+    Eigen::initializeDeviceProp();
+  }
+
+  virtual ~EigenCudaStreamDevice() {
+    if (scratch_) {
+      deallocate(scratch_);
+    }
+  }
+
+  const cudaStream_t& stream() const { return *stream_; }
+
+  void set_stream(const cudaStream_t* cuda_stream) { stream_ = cuda_stream; }
+  
+  const cudaDeviceProp& deviceProperties() const {
+    return Eigen::m_deviceProperties[device_];
+  }
+  virtual void* allocate(size_t num_bytes) const {
+    cudaSetDevice(device_);
+    void* result;
+    cudaMalloc(&result, num_bytes);
+    return result;
+  }
+  virtual void deallocate(void* buffer) const {
+    cudaSetDevice(device_);
+    cudaFree(buffer);
+  }
+
+  virtual void* scratchpad() const {
+    if (scratch_ == NULL) {
+      scratch_ = allocate(Eigen::kCudaScratchSize + sizeof(unsigned int));
+    }
+    return scratch_;
+  }
+
+  virtual unsigned int* semaphore() const {
+    if (semaphore_ == NULL) {
+      char* scratch =
+          static_cast<char*>(scratchpad()) + Eigen::kCudaScratchSize;
+      semaphore_ = reinterpret_cast<unsigned int*>(scratch);
+      cudaMemsetAsync(semaphore_, 0, sizeof(unsigned int), *stream_);
+    }
+    return semaphore_;
+  }
+
+ private:
+  const cudaStream_t* stream_;
+  int device_;
+  mutable void* scratch_;
+  mutable unsigned int* semaphore_;
+};
+
 class Device_GPU : public Device {
  public:
-  typedef Eigen::CudaStreamDevice EigenDevice;
+  typedef EigenCudaStreamDevice EigenDevice;
   explicit Device_GPU(int my_id, const DeviceMempoolSizes & mb, int device_id);
   ~Device_GPU();
   int cuda_device_id;
@@ -62,7 +144,8 @@ class Device_GPU : public Device {
   cudnnHandle_t cudnnHandle;
 #endif
   Eigen::GpuDevice* edevice;
-  Eigen::CudaStreamDevice* estream;
+  EigenCudaStreamDevice* estream;
+  cudaStream_t stream;
   GPUAllocator gpu_mem;
 };
 #endif


### PR DESCRIPTION
Fix #59 
I am a committer of paddle. When I work on refactoring paddle code using unsupported tensor module of Eigen3, I meet the same problem. GCC5.4 with -O1 is good, but -O2 will cause segment fault.

I found that Tensorflow also used tensor module of eigen3, but have no such error. Tensorflow has implemented [EigenCudaStreamDevice](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/common_runtime/gpu/gpu_device.cc#L77). 
It's interesting that in the constructor of [EigenCudaStreamDevice](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/common_runtime/gpu/gpu_device.cc#L79), no cuda stream will passed, but in [Reinitialize](https://github.com/tensorflow/tensorflow/blob/master/tensorflow/core/common_runtime/gpu/gpu_device.cc#L84), a cuda stream will be passed.

So, I make a test, use default stream(means initialize in constructor) or set a created stream later(just implement a class EigenCudaStreamDevice like tensorflow).

The gcc version is 5.4.

In  branch [just_for_debug](https://github.com/QiJune/dynet/tree/just_for_debug), example/train_xor will cause segment fault.
In branch [fix_eigen_gcc_version](https://github.com/QiJune/dynet/tree/fix_eigen_gcc_version), example/train_xor works good.

In paddle, the solution also works good. So, maybe dynet can have a test to verify my solution.

