### PR TITLE
Fix broken Scala serialization tests.

### DIFF
--- a/contrib/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/contrib/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -62,10 +62,10 @@ class SerializationSpec extends FlatSpec with Matchers {
     val rnn1 = new SimpleRnnBuilder(1, 10, 10, mod1)
 
     val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
-    println(path)
 
     val saver = new ModelSaver(path)
     saver.addModel(mod1)
+    saver.done()
 
     val loader = new ModelLoader(path)
     val mod2 = new ParameterCollection()
@@ -85,6 +85,7 @@ class SerializationSpec extends FlatSpec with Matchers {
     val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
     val saver = new ModelSaver(path)
     saver.addModel(mod1)
+    saver.done()
 
     val loader = new ModelLoader(path)
     val mod2 = new ParameterCollection()


### PR DESCRIPTION
These tests are failing in v2.0 because the ModelSaver wasn't being cleaned up after saving. Also removed a (probably errant?) println.