### PR TITLE
Fix msvc: remove hardcoded /tmp path and invalid string::back() call on empty string.

### DIFF
--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -76,7 +76,7 @@ void TextFileSaver::save(const ParameterCollection & model,
   if (!valid_pc_key(key))
     DYNET_INVALID_ARG("Key should start with '/' and could not include ' ' or '#': " << key);
   std::string key_ = key;
-  if (key_.back() != '/') key_ += "/";
+  if (key_.size() != 0 && key_.back() != '/') key_ += "/";
   const ParameterCollectionStorage & storage = model.get_storage();
   if(key.size() == 0) {
     for (auto & p : storage.params) save(*p, key);
@@ -152,7 +152,7 @@ void TextFileLoader::populate(ParameterCollection & model, const std::string & k
   size_t param_id = 0, lookup_id = 0;
   ParameterCollectionStorage & storage = model.get_storage();
   std::string key_ = key;
-  if (key_.back() != '/') key_ += "/";
+  if (key_.size() != 0 && key_.back() != '/') key_ += "/";
   while(std::getline(datastream, line)) {
     read_param_header(line, type, name, dim, byte_count, zero_grad);
     // Skip ones that don't match

--- a/examples/cpp/embed-cl/train_embed-cl.cc
+++ b/examples/cpp/embed-cl/train_embed-cl.cc
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-	TextFileSaver saver("/tmp/embed-cl.model");
+	TextFileSaver saver("embed-cl.model");
 	saver.save(model);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -256,7 +256,7 @@ int main(int argc, char** argv) {
   bool first = true;
   int report = 0;
   unsigned lines = 0;
-  TextFileSaver saver("/tmp/imdb.model");
+  TextFileSaver saver("imdb.model");
   while (1) {
     Timer iteration("completed in");
     double loss = 0;

--- a/examples/cpp/read-write/train_read-write.cc
+++ b/examples/cpp/read-write/train_read-write.cc
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
     cerr << "E = " << loss << endl;
   }
 
-  string outfile = "/tmp/out.model";
+  string outfile = "read-write.model";
   cerr << "Written model to File: " << outfile << endl;
   WriteToFile(outfile, m);  // Writing objects to file
 

--- a/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
+++ b/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
@@ -217,7 +217,7 @@ int main(int argc, char** argv) {
       // If the dev loss is lower than the previous ones, save the model
       if (dloss < best) {
         best = dloss;
-        TextFileSaver saver("/tmp/rnnlm-batch.model");
+        TextFileSaver saver("rnnlm-batch.model");
         saver.save(model);
       }
       // Print informations

--- a/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
+++ b/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
@@ -237,7 +237,7 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-	TextFileSaver saver("/tmp/rnnlm-givenbag.model");
+	TextFileSaver saver("rnnlm-givenbag.model");
 	saver.save(model);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -309,7 +309,7 @@ int main(int argc, char** argv) {
       }
       if (dloss < best) {
         best = dloss;
-        TextFileSaver saver("/tmp/textcat.model");
+        TextFileSaver saver("textcat.model");
         saver.save(model);
       }
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / (double)dtags) << ' ';

--- a/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
+++ b/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
   }
   // Output the model and parameter objects
   // to a cout.
-  TextFileSaver saver("/tmp/xor-batch-lookup.model");
+  TextFileSaver saver("xor-batch-lookup.model");
   saver.save(m);
 }
 

--- a/examples/cpp/xor-batch/train_xor-batch.cc
+++ b/examples/cpp/xor-batch/train_xor-batch.cc
@@ -65,6 +65,6 @@ int main(int argc, char** argv) {
 
   // Output the model and parameter objects
   // to a cout.
-  TextFileSaver saver("/tmp/xor-batch.model");
+  TextFileSaver saver("xor-batch.model");
   saver.save(m);
 }

--- a/examples/cpp/xor-multidevice/train_xor-multidevice.cc
+++ b/examples/cpp/xor-multidevice/train_xor-multidevice.cc
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
   }
 
   // Output the model and parameter objects to a file.
-  TextFileSaver saver("/tmp/xor.model");
+  TextFileSaver saver("xor.model");
   saver.save(m);
 }
 

--- a/examples/cpp/xor-xent/train_xor-xent.cc
+++ b/examples/cpp/xor-xent/train_xor-xent.cc
@@ -67,6 +67,6 @@ int main(int argc, char** argv) {
 
   // Output the model and parameter objects
   // to a file.
-  TextFileSaver saver("/tmp/xor-xent.model");
+  TextFileSaver saver("xor-xent.model");
   saver.save(m);
 }

--- a/examples/cpp/xor/train_xor.cc
+++ b/examples/cpp/xor/train_xor.cc
@@ -67,6 +67,6 @@ int main(int argc, char** argv) {
   }
 
   // Output the model and parameter objects to a file.
-  TextFileSaver saver("/tmp/xor.model");
+  TextFileSaver saver("xor.model");
   saver.save(m);
 }


### PR DESCRIPTION
Saving to /tmp/blah.model breaks on Windows. I'm happy to write code to find temp dir in a cross-platform manner, if anyone feels that it's important. The Python scripts save example models to the local dir, and that seems reasonable to me too, so I thought this is an easier fix.