### PR TITLE
Some partial supports for inplaced operations.

### DIFF
--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -169,7 +169,7 @@ void ComputationGraph::_revert(CGCheckpoint p) {
       Node* one = nodes[i];
       for(VariableIndex arg : one->args) {
         if(one->inplace_state == Node::INPLACE_TYPE::WRITE){
-          if(arg <= p.node_idx){
+          if(arg <= (unsigned)p.node_idx){
             DYNET_RUNTIME_ERR("Invalid revert for the node "<<arg<<" cannot be recovered from certain inplaced operation");
           }
           nodes[arg]->write_num -= 1;
@@ -377,7 +377,9 @@ void ComputationGraph::set_inplace_for_new_node(const VariableIndex& i) {
     }
     else if(node->inplace_state == Node::INPLACE_TYPE::WRITE){
       // currently only allow one layer of inplace for WRITE since letting it spreading out might cause certain problems
-      DYNET_ARG_CHECK((x0->write_num + x0->read_num == 0) && (!x0->inplaced()), "Failed input for WRITE inplaced-operation");
+      DYNET_ARG_CHECK((x0->write_num + x0->read_num == 0), "Failed input (used by others) for WRITE inplaced-operation");
+      DYNET_ARG_CHECK((!x0->inplaced()), "Failed input (already inplaced) for WRITE inplaced-operation");
+      DYNET_ARG_CHECK((x0->rewritable), "Failed input (not rewritable) for WRITE inplaced-operation");
     }
     else{
       DYNET_RUNTIME_ERR("Impossible inplace staus");

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -164,22 +164,22 @@ void ComputationGraph::_revert(CGCheckpoint p) {
   default_device->revert(p.device_mem_checkpoint);
   // clear all nodes at position >= p.node_idx
   if ((int)nodes.size() > p.node_idx) {
-		for(int i = p.node_idx; i < (int)nodes.size(); i++){
-			// revert some info
-			Node* one = nodes[i];
-			for(VariableIndex arg : one->args) {
-				if(one->inplace_state == Node::INPLACE_TYPE::WRITE){
-					if(arg <= p.node_idx){
-						DYNET_RUNTIME_ERR("Invalid revert for the node "<<arg<<" cannot be recovered from certain inplaced operation");
-					}
-					nodes[arg]->write_num -= 1;
-				}
-				else{
-					nodes[arg]->read_num -= 1;
-				}
-			}
-			delete one; // the deletion of nodes.
-		}
+    for(int i = p.node_idx; i < (int)nodes.size(); i++){
+      // revert some info
+      Node* one = nodes[i];
+      for(VariableIndex arg : one->args) {
+        if(one->inplace_state == Node::INPLACE_TYPE::WRITE){
+          if(arg <= p.node_idx){
+            DYNET_RUNTIME_ERR("Invalid revert for the node "<<arg<<" cannot be recovered from certain inplaced operation");
+          }
+          nodes[arg]->write_num -= 1;
+        }
+        else{
+          nodes[arg]->read_num -= 1;
+        }
+      }
+      delete one; // the deletion of nodes.
+    }
     nodes.resize(p.node_idx);
     ee->invalidate(p.node_idx - 1); // clear precomputed forward values
   }
@@ -365,36 +365,36 @@ VariableIndex ComputationGraph::add_const_lookup(LookupParameter p, const std::v
 
 // check for the inplace operations
 void ComputationGraph::set_inplace_for_new_node(const VariableIndex& i) {
-	Node* node = nodes[i];
-	// 1. check current node
-	if(node->inplaced()){
-		// currently, only unary operations support inplacing
-		DYNET_ARG_CHECK(node->args.size() == 1, "Failed input count check for inplaced-operation");
-		Node* x0 = nodes[node->args[0]];
-		// check for validity, currently somewhat strict, only allow multiple READ or one WRITE
-		if(node->inplace_state == Node::INPLACE_TYPE::READ){
-			DYNET_ARG_CHECK(x0->write_num == 0, "Failed input for READ inplaced-operation");
-		}
-		else if(node->inplace_state == Node::INPLACE_TYPE::WRITE){
-			// currently only allow one layer of inplace for WRITE since letting it spreading out might cause certain problems
-			DYNET_ARG_CHECK((x0->write_num + x0->read_num == 0) && (!x0->inplaced()), "Failed input for WRITE inplaced-operation");
-		}
-		else{
-			DYNET_RUNTIME_ERR("Impossible inplace staus");
-		}
-	}
-	// 2. check input arguments (make sure their value is preserved)
-	for(VariableIndex arg : node->args) {
-		Node* x = nodes[arg];
-		DYNET_ARG_CHECK(x->write_num == 0, "Failed input argument (already being inplaced)");
-	}
-	// 3. update info
-	for(VariableIndex arg : node->args) {
-		if(node->inplace_state == Node::INPLACE_TYPE::WRITE)
-			nodes[arg]->write_num += 1;
-		else
-			nodes[arg]->read_num += 1;
-	}
+  Node* node = nodes[i];
+  // 1. check current node
+  if(node->inplaced()){
+    // currently, only unary operations support inplacing
+    DYNET_ARG_CHECK(node->args.size() == 1, "Failed input count check for inplaced-operation");
+    Node* x0 = nodes[node->args[0]];
+    // check for validity, currently somewhat strict, only allow multiple READ or one WRITE
+    if(node->inplace_state == Node::INPLACE_TYPE::READ){
+      DYNET_ARG_CHECK(x0->write_num == 0, "Failed input for READ inplaced-operation");
+    }
+    else if(node->inplace_state == Node::INPLACE_TYPE::WRITE){
+      // currently only allow one layer of inplace for WRITE since letting it spreading out might cause certain problems
+      DYNET_ARG_CHECK((x0->write_num + x0->read_num == 0) && (!x0->inplaced()), "Failed input for WRITE inplaced-operation");
+    }
+    else{
+      DYNET_RUNTIME_ERR("Impossible inplace staus");
+    }
+  }
+  // 2. check input arguments (make sure their value is preserved)
+  for(VariableIndex arg : node->args) {
+    Node* x = nodes[arg];
+    DYNET_ARG_CHECK(x->write_num == 0, "Failed input argument (already being inplaced)");
+  }
+  // 3. update info
+  for(VariableIndex arg : node->args) {
+    if(node->inplace_state == Node::INPLACE_TYPE::WRITE)
+      nodes[arg]->write_num += 1;
+    else
+      nodes[arg]->read_num += 1;
+  }
 }
 
 // factory function should call this right after creating a new node object

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -736,13 +736,19 @@ struct Node {
   // for inplace operations
   enum class INPLACE_TYPE {NOPE, READ, WRITE};
   INPLACE_TYPE inplace_state{INPLACE_TYPE::NOPE}; /**< Type for the inplace operations: NOPE(non-inplace), READ(no changes to the memory), WRITE(unrecoverable changes possibly) */
-  int read_num{0};		/**< How many nodes have use this as inputs (NOPE+READ) */
-  int write_num{0};		/**< How many nodes have take this node's memory (WRITE) */
+  int read_num{0}; /**< How many nodes have use this as inputs (NOPE+READ) */
+  int write_num{0}; /**< How many nodes have take this node's memory (WRITE) */
+  bool rewritable{false}; /**< Whether this node can be rewritten by anothor inplaced Node (does not need its output when calculating gradients) */
 
   /**
    * \brief Whether this node is inplaced (borrowing other's memory)
    */
   inline bool inplaced() const { return inplace_state != INPLACE_TYPE::NOPE; }
+
+  /**
+  * \brief Force setting whether this Node can be rewrite (might be dangerous for some nodes which need its own values when calculating gradients)
+  */
+  inline void set_rewritable(bool v) { rewritable = v; }
 
  protected:
   Node() : args(), device(nullptr) {}

--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -52,9 +52,9 @@ const Tensor& SimpleExecutionEngine::get_value(VariableIndex i) {
   if (i >= num_nodes_evaluated) {
     incremental_forward(i);
   }
-	if(cg.nodes[i]->write_num > 0){
-		DYNET_RUNTIME_ERR("This operation's output has been written by an inplaced operation, thus no valid value");
-	}
+  if(cg.nodes[i]->write_num > 0){
+    DYNET_RUNTIME_ERR("This operation's output has been written by an inplaced operation, thus no valid value");
+  }
   return nfxs[i];
 }
 
@@ -63,9 +63,9 @@ const Tensor& SimpleExecutionEngine::get_gradient(VariableIndex i) {
   if (i >= backward_computed) {
     DYNET_RUNTIME_ERR("Requested gradient for node " << i << ", but backward pass was computed from node " << (backward_computed - 1));
   }
-	if(cg.nodes[i]->inplaced()){
-		DYNET_RUNTIME_ERR("This operation is an inplaced operation, thus no valid gradient");
-	}
+  if(cg.nodes[i]->inplaced()){
+    DYNET_RUNTIME_ERR("This operation is an inplaced operation, thus no valid gradient");
+  }
   return ndEdfs[i];
 }
 
@@ -108,10 +108,10 @@ const Tensor& SimpleExecutionEngine::incremental_forward(VariableIndex i) {
       nfxs[num_nodes_evaluated].device = node->device;
       nfxs[num_nodes_evaluated].mem_pool = DeviceMempool::FXS;
       // Get the memory (directly share pointer when inlined)
-			if(node->inplaced())
-				nfxs[num_nodes_evaluated].v = nfxs[node->args[0]].v;
-			else
-				nfxs[num_nodes_evaluated].v = static_cast<float*>(nfxs[num_nodes_evaluated].device->pools[(int)DeviceMempool::FXS]->allocate(node->dim.size() * sizeof(float)));
+      if(node->inplaced())
+        nfxs[num_nodes_evaluated].v = nfxs[node->args[0]].v;
+      else
+        nfxs[num_nodes_evaluated].v = static_cast<float*>(nfxs[num_nodes_evaluated].device->pools[(int)DeviceMempool::FXS]->allocate(node->dim.size() * sizeof(float)));
       if (nfxs[num_nodes_evaluated].v == nullptr)
         DYNET_RUNTIME_ERR("Ran out of memory when executing node " << num_nodes_evaluated);
       void* aux_mem = nullptr;
@@ -152,12 +152,12 @@ void SimpleExecutionEngine::backward(VariableIndex from_where, bool full) {
     ndEdfs[i].d = dim;
     ndEdfs[i].device = nfxs[i].device;
     ndEdfs[i].mem_pool = DeviceMempool::DEDFS;
-		// share pointers when inplacing
-		const Node* node = cg.nodes[i];
-		if(node->inplaced())
-			ndEdfs[i].v = ndEdfs[node->args[0]].v;
-		else
-			ndEdfs[i].v = static_cast<float*>(ndEdfs[i].device->pools[(int)DeviceMempool::DEDFS]->allocate(dim.size() * sizeof(float)));
+    // share pointers when inplacing
+    const Node* node = cg.nodes[i];
+    if(node->inplaced())
+      ndEdfs[i].v = ndEdfs[node->args[0]].v;
+    else
+      ndEdfs[i].v = static_cast<float*>(ndEdfs[i].device->pools[(int)DeviceMempool::DEDFS]->allocate(dim.size() * sizeof(float)));
     if (!ndEdfs[i].v)
       DYNET_RUNTIME_ERR("out of memory while attempting to allocate space for derivatives of node " << i);
   }
@@ -350,9 +350,9 @@ const Tensor& BatchedExecutionEngine::get_value(VariableIndex i) {
   if (i >= num_nodes_evaluated) {
     incremental_forward(i);
   }
-	if(cg.nodes[i]->write_num > 0){
-		DYNET_RUNTIME_ERR("This operation's output has been written by an inplaced operation, thus no valid value");
-	}
+  if(cg.nodes[i]->write_num > 0){
+    DYNET_RUNTIME_ERR("This operation's output has been written by an inplaced operation, thus no valid value");
+  }
   return get_nfx(i);
 }
 
@@ -361,9 +361,9 @@ const Tensor& BatchedExecutionEngine::get_gradient(VariableIndex i) {
   if (i >= backward_computed) {
     DYNET_RUNTIME_ERR("Requested gradient for node " << i << ", but backward pass was computed from node " << backward_computed);
   }
-	if(cg.nodes[i]->inplaced()){
-		DYNET_RUNTIME_ERR("This operation is an inplaced operation, thus no valid gradient");
-	}
+  if(cg.nodes[i]->inplaced()){
+    DYNET_RUNTIME_ERR("This operation is an inplaced operation, thus no valid gradient");
+  }
   return ndEdfs[i];
 }
 
@@ -642,10 +642,10 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(VariableInde
         nfx.device = node->device;
         nfx.mem_pool = DeviceMempool::FXS;
         // Allocate memory (just sharing pointers when inlined)
-				if(node->inplaced())
-					nfx.v = get_nfx(node->args[0]).v;
-				else
-					nfx.v = static_cast<float*>(node->device->pools[(int)DeviceMempool::FXS]->allocate(node2size[curr_node] * sizeof(float)));
+        if(node->inplaced())
+          nfx.v = get_nfx(node->args[0]).v;
+        else
+          nfx.v = static_cast<float*>(node->device->pools[(int)DeviceMempool::FXS]->allocate(node2size[curr_node] * sizeof(float)));
         if (nfx.v == nullptr)
           DYNET_RUNTIME_ERR("Ran out of memory when allocating for node " << curr_node);
         size_t aux_size = node->aux_storage_size();
@@ -812,7 +812,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward(VariableIndex i) {
     incremental_forward_no_update(i, autobatch_flag);
   }
 
-  num_nodes_evaluated = max(i + 1, num_nodes_evaluated);	
+  num_nodes_evaluated = max(i + 1, num_nodes_evaluated);  
   return get_nfx(i);
 }
 
@@ -855,12 +855,12 @@ void BatchedExecutionEngine::backward(VariableIndex from_where, bool full) {
     batched_ndEdfs[i].d = dim;
     batched_ndEdfs[i].device = cg.nodes[my_batch.ids[0]]->device;
     batched_ndEdfs[i].mem_pool = DeviceMempool::DEDFS;
-		// share pointers when inplacing
-		const Node* node = cg.nodes[my_batch.ids[0]];
-		if(node->inplaced())
-			batched_ndEdfs[i].v = ndEdfs[node->args[0]].v;
-		else
-			batched_ndEdfs[i].v = static_cast<float*>(batched_ndEdfs[i].device->pools[(int)DeviceMempool::DEDFS]->allocate(dim.size() * sizeof(float)));
+    // share pointers when inplacing
+    const Node* node = cg.nodes[my_batch.ids[0]];
+    if(node->inplaced())
+      batched_ndEdfs[i].v = ndEdfs[node->args[0]].v;
+    else
+      batched_ndEdfs[i].v = static_cast<float*>(batched_ndEdfs[i].device->pools[(int)DeviceMempool::DEDFS]->allocate(dim.size() * sizeof(float)));
     if (!batched_ndEdfs[i].v)
       DYNET_RUNTIME_ERR("out of memory while attempting to allocate space for derivatives of node " << i);
     // Assign the memory within the batch

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -78,14 +78,14 @@ Expression contract3d_1d(const Expression& x, const Expression& y, const Express
 Expression sqrt(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sqrt>({x.i})); }
 Expression abs(const Expression& x) { return Expression(x.pg, x.pg->add_function<Abs>({x.i})); }
 Expression erf(const Expression& x) { return Expression(x.pg, x.pg->add_function<Erf>({x.i})); }
-Expression tanh(const Expression& x) { return Expression(x.pg, x.pg->add_function<Tanh>({x.i})); }
+Expression tanh(const Expression& x, bool inplaced) { return Expression(x.pg, x.pg->add_function<Tanh>({x.i}, inplaced)); }
 Expression lgamma(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogGamma>({x.i})); }
 Expression log(const Expression& x) { return Expression(x.pg, x.pg->add_function<Log>({x.i})); }
 Expression exp(const Expression& x) { return Expression(x.pg, x.pg->add_function<Exp>({x.i})); }
 Expression square(const Expression& x) { return Expression(x.pg, x.pg->add_function<Square>({x.i})); }
 Expression cube(const Expression& x) { return Expression(x.pg, x.pg->add_function<Cube>({x.i})); }
-Expression logistic(const Expression& x) { return Expression(x.pg, x.pg->add_function<LogisticSigmoid>({x.i})); }
-Expression rectify(const Expression& x) { return Expression(x.pg, x.pg->add_function<Rectify>({x.i})); }
+Expression logistic(const Expression& x, bool inplaced) { return Expression(x.pg, x.pg->add_function<LogisticSigmoid>({x.i}, inplaced)); }
+Expression rectify(const Expression& x, bool inplaced) { return Expression(x.pg, x.pg->add_function<Rectify>({x.i}, inplaced)); }
 Expression elu(const Expression& x, float alpha) { return Expression(x.pg, x.pg->add_function<ExponentialLinearUnit>({x.i}, 1.0, alpha)); }
 Expression selu(const Expression& x) { return Expression(x.pg, x.pg->add_function<ExponentialLinearUnit>({x.i}, 1.0507009873554804934193349852946, 1.6732632423543772848170429916717)); }
 Expression hinge(const Expression& x, unsigned index, float m) { return Expression(x.pg, x.pg->add_function<Hinge>({x.i}, index, m)); }
@@ -102,17 +102,17 @@ Expression sparsemax(const Expression& x) { return Expression(x.pg, x.pg->add_fu
 Expression sparsemax_loss(const Expression& x, const vector<unsigned>& target_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, target_support)); }
 Expression sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, ptarget_support)); }
 Expression softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i})); }
-Expression softsign(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i})); }
+Expression softsign(const Expression& x, bool inplaced) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i}, inplaced)); }
 Expression pow(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Pow>({x.i, y.i})); }
 Expression min(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Min>({x.i, y.i})); }
 Expression max(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Max>({x.i, y.i})); }
 Expression noise(const Expression& x, real stddev) { return Expression(x.pg, x.pg->add_function<GaussianNoise>({x.i}, stddev)); }
-Expression dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<Dropout>({x.i}, p)); }
-Expression dropout_batch(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<DropoutBatch>({x.i}, p)); }
-Expression dropout_dim(const Expression& x, unsigned d, real p) { return Expression(x.pg, x.pg->add_function<DropoutDim>({x.i}, d, p)); }
-Expression block_dropout(const Expression& x, real p) { return Expression(x.pg, x.pg->add_function<BlockDropout>({x.i}, p)); }
+Expression dropout(const Expression& x, real p, bool inplaced) { return Expression(x.pg, x.pg->add_function<Dropout>({x.i}, p, inplaced)); }
+Expression dropout_batch(const Expression& x, real p, bool inplaced) { return Expression(x.pg, x.pg->add_function<DropoutBatch>({x.i}, p, inplaced)); }
+Expression dropout_dim(const Expression& x, unsigned d, real p, bool inplaced) { return Expression(x.pg, x.pg->add_function<DropoutDim>({x.i}, d, p, inplaced)); }
+Expression block_dropout(const Expression& x, real p, bool inplaced) { return Expression(x.pg, x.pg->add_function<BlockDropout>({x.i}, p, inplaced)); }
 
-Expression reshape(const Expression& x, const Dim& d) { return Expression(x.pg, x.pg->add_function<Reshape>({x.i}, d)); }
+Expression reshape(const Expression& x, const Dim& d, bool inplaced) { return Expression(x.pg, x.pg->add_function<Reshape>({x.i}, d, inplaced)); }
 Expression transpose(const Expression& x, const vector<unsigned>& dims) { return Expression(x.pg, x.pg->add_function<Transpose>({x.i}, dims)); }
 Expression select_rows(const Expression& x, const vector<unsigned>& rows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, rows)); }
 Expression select_rows(const Expression& x, const vector<unsigned>* prows) { return Expression(x.pg, x.pg->add_function<SelectRows>({x.i}, prows)); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -756,10 +756,11 @@ Expression erf(const Expression& x);
  * \details Elementwise calculation of the hyperbolic tangent
  *
  * \param x The input expression
+ * \param inplaced Whether doing inplace operation
  *
  * \return An expression where the ith element is equal to tanh(x_i)
  */
-Expression tanh(const Expression& x);
+Expression tanh(const Expression& x, bool inplaced=false);
 
 /**
  * \ingroup arithmeticoperations
@@ -822,10 +823,11 @@ Expression log(const Expression& x);
  * \details Calculate elementwise y_i = 1/(1+e^{-x_i})
  *
  * \param x The input expression
+ * \param inplaced Whether doing inplace operation
  *
  * \return An expression where the ith element is equal to y_i = 1/(1+e^{-x_i})
  */
-Expression logistic(const Expression& x);
+Expression logistic(const Expression& x, bool inplaced=false);
 
 /**
  * \ingroup arithmeticoperations
@@ -833,10 +835,11 @@ Expression logistic(const Expression& x);
  * \details Calculate elementwise the recitifer (ReLU) function y_i = max(x_i,0)
  *
  * \param x The input expression
+ * \param inplaced Whether doing inplace operation
  *
  * \return An expression where the ith element is equal to max(x_i,0)
  */
-Expression rectify(const Expression& x);
+Expression rectify(const Expression& x, bool inplaced = false);
 
 
 /**
@@ -893,10 +896,11 @@ Expression selu(const Expression& x);
  * \details Calculate elementwise the softsign function y_i = x_i/(1+|x_i|)
  *
  * \param x The input expression
+ * \param inplaced Whether doing inplace operation
  *
  * \return An expression where the ith element is equal to x_i/(1+|x_i|)
  */
-Expression softsign(const Expression& x);
+Expression softsign(const Expression& x, bool inplaced = false);
 
 /**
  * \ingroup arithmeticoperations
@@ -1457,10 +1461,11 @@ Expression flip_gradient(const Expression& x);
  *
  * \param x The input expression
  * \param d The new dimensions
+ * \param inplaced Whether doing inplace operation
  *
  * \return The reshaped expression
  */
-Expression reshape(const Expression& x, const Dim& d);
+Expression reshape(const Expression& x, const Dim& d, bool inplaced=false);
 
 /**
  * \ingroup flowoperations
@@ -1900,10 +1905,11 @@ Expression noise(const Expression& x, real stddev);
  *
  * \param x The input expression
  * \param p The dropout probability
+ * \param inplaced Whether doing inplace operation
  *
  * \return The dropped out expression
  */
-Expression dropout(const Expression& x, real p);
+Expression dropout(const Expression& x, real p, bool inplaced=false);
 
 /**
  * \ingroup noiseoperations
@@ -1915,10 +1921,11 @@ Expression dropout(const Expression& x, real p);
  * \param x The input expression
  * \param d The dimension along which to drop
  * \param p The dropout probability
+ * \param inplaced Whether doing inplace operation
  *
  * \return The dropped out expression
  */
-Expression dropout_dim(const Expression& x, unsigned d, real p);
+Expression dropout_dim(const Expression& x, unsigned d, real p, bool inplaced = false);
 
 /**
  * \ingroup noiseoperations
@@ -1927,10 +1934,11 @@ Expression dropout_dim(const Expression& x, unsigned d, real p);
  *
  * \param x The input expression
  * \param p The dropout probability
+ * \param inplaced Whether doing inplace operation
  *
  * \return The dropped out expression
  */
-Expression dropout_batch(const Expression& x, real p);
+Expression dropout_batch(const Expression& x, real p, bool inplaced = false);
 
 /**
  * \ingroup noiseoperations
@@ -1941,10 +1949,11 @@ Expression dropout_batch(const Expression& x, real p);
  *
  * \param x The input expression
  * \param p The block dropout probability
+ * \param inplaced Whether doing inplace operation
  *
  * \return The block dropout expression
  */
-Expression block_dropout(const Expression& x, real p);
+Expression block_dropout(const Expression& x, real p, bool inplaced = false);
 
 ////////////////////////////////////////////////
 // Convolution operations                     //

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -68,6 +68,8 @@ struct Expression {
     return (get_number_of_active_graphs() != 1 || graph_id != get_current_graph_id());
   }
 
+  inline void set_rewritable(bool v) { pg->nodes[i]->set_rewritable(v); }
+
   /**
    * \brief Get value of the expression
    * \details Throws a tuntime_error exception if no computation graph is available

--- a/dynet/nodes-activations.cc
+++ b/dynet/nodes-activations.cc
@@ -39,9 +39,9 @@ void Rectify::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   if(inplaced())
-		dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), FRectifyBackward());
+    dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), FRectifyBackward());
   else
-		dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), FRectifyBackward());
+    dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), FRectifyBackward());
 }
 DYNET_NODE_INST_DEV_IMPL(Rectify)
 
@@ -76,7 +76,7 @@ void LogisticSigmoid::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   if(inplaced())
-		dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), scalar_logistic_sigmoid_backward_op<float>());
+    dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), scalar_logistic_sigmoid_backward_op<float>());
   else
     dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), scalar_logistic_sigmoid_backward_op<float>());
 }
@@ -113,10 +113,10 @@ void SoftSign::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-	if(inplaced())
-		dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), FSoftSignBackward());
-	else
-		dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), FSoftSignBackward());
+  if(inplaced())
+    dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), FSoftSignBackward());
+  else
+    dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), FSoftSignBackward());
 }
 DYNET_NODE_INST_DEV_IMPL(SoftSign)
 

--- a/dynet/nodes-activations.cc
+++ b/dynet/nodes-activations.cc
@@ -38,7 +38,10 @@ void Rectify::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), FRectifyBackward());
+  if(inplaced())
+		dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), FRectifyBackward());
+  else
+		dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), FRectifyBackward());
 }
 DYNET_NODE_INST_DEV_IMPL(Rectify)
 
@@ -72,7 +75,10 @@ void LogisticSigmoid::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), scalar_logistic_sigmoid_backward_op<float>());
+  if(inplaced())
+		dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), scalar_logistic_sigmoid_backward_op<float>());
+  else
+    dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), scalar_logistic_sigmoid_backward_op<float>());
 }
 DYNET_NODE_INST_DEV_IMPL(LogisticSigmoid)
 
@@ -107,7 +113,10 @@ void SoftSign::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), FSoftSignBackward());
+	if(inplaced())
+		dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), FSoftSignBackward());
+	else
+		dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), FSoftSignBackward());
 }
 DYNET_NODE_INST_DEV_IMPL(SoftSign)
 

--- a/dynet/nodes-activations.h
+++ b/dynet/nodes-activations.h
@@ -8,27 +8,27 @@ namespace dynet {
 
 // y = max(0,x)
 struct Rectify : public Node {
-  explicit Rectify(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  explicit Rectify(const std::initializer_list<VariableIndex>& a, bool inplaced) : Node(a) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::rectify); return sm.get_idx(s); }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { if(inplaced()) return 0; Sig s(nt::rectify); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }  
   DYNET_NODE_DEFINE_DEV_IMPL()
 };
 
 // y = \sigma(x_1)
 struct LogisticSigmoid : public Node {
-  explicit LogisticSigmoid(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  explicit LogisticSigmoid(const std::initializer_list<VariableIndex>& a, bool inplaced): Node(a) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::logistic); return sm.get_idx(s); }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { if(inplaced()) return 0; Sig s(nt::logistic); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }  
   DYNET_NODE_DEFINE_DEV_IMPL()
 };
 
 // y = x / (1 + |x|)
 struct SoftSign : public Node {
-  explicit SoftSign(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  explicit SoftSign(const std::initializer_list<VariableIndex>& a, bool inplaced): Node(a) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::softsign); return sm.get_idx(s); }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { if(inplaced()) return 0; Sig s(nt::softsign); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }  
   DYNET_NODE_DEFINE_DEV_IMPL()
 };

--- a/dynet/nodes-dropout.cc
+++ b/dynet/nodes-dropout.cc
@@ -42,10 +42,10 @@ void Dropout::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   Tensor m(dim, (float*)aux_mem, fx.device, DeviceMempool::FXS);
-	if(inplaced())
-		dEdxi.tvec().device(*dev.edevice) = dEdf.tvec() * m.tvec();
-	else
-		dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * m.tvec();
+  if(inplaced())
+    dEdxi.tvec().device(*dev.edevice) = dEdf.tvec() * m.tvec();
+  else
+    dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * m.tvec();
 }
 DYNET_NODE_INST_DEV_IMPL(Dropout)
 
@@ -93,10 +93,10 @@ void DropoutDim::backward_dev_impl(const MyDevice & dev,
   mask_dim.d[dimension]=1;
   Tensor m(mask_dim, (float*)aux_mem, fx.device, DeviceMempool::FXS);
   Eigen::array<ptrdiff_t, 4> bcast = {1, 1, 1, 1}; bcast[dimension] = dEdf.d[dimension];
-	if(inplaced())
-		dEdxi.tb<3>().device(*dev.edevice) = dEdf.tb<3>() * m.tb<3>().broadcast(bcast);
-	else
-		dEdxi.tb<3>().device(*dev.edevice) += dEdf.tb<3>() * m.tb<3>().broadcast(bcast);
+  if(inplaced())
+    dEdxi.tb<3>().device(*dev.edevice) = dEdf.tb<3>() * m.tb<3>().broadcast(bcast);
+  else
+    dEdxi.tb<3>().device(*dev.edevice) += dEdf.tb<3>() * m.tb<3>().broadcast(bcast);
 }
 DYNET_NODE_INST_DEV_IMPL(DropoutDim)
 
@@ -140,10 +140,10 @@ void DropoutBatch::backward_dev_impl(const MyDevice & dev,
   Dim mask_dim({1},xs[0]->d.batch_elems());
   Tensor m(mask_dim, (float*)aux_mem, fx.device, DeviceMempool::FXS);
   Eigen::array<ptrdiff_t, 2> bcast = {xs[0]->d.batch_size(), 1};
-	if(inplaced())
-		dEdxi.tbvec().device(*dev.edevice) = dEdf.tbvec() * m.tbvec().broadcast(bcast);
-	else
-		dEdxi.tbvec().device(*dev.edevice) += dEdf.tbvec() * m.tbvec().broadcast(bcast);
+  if(inplaced())
+    dEdxi.tbvec().device(*dev.edevice) = dEdf.tbvec() * m.tbvec().broadcast(bcast);
+  else
+    dEdxi.tbvec().device(*dev.edevice) += dEdf.tbvec() * m.tbvec().broadcast(bcast);
 }
 DYNET_NODE_INST_DEV_IMPL(DropoutBatch)
 
@@ -189,10 +189,10 @@ void BlockDropout::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   float block_multiplier = *(static_cast<float*>(aux_mem));
-	if(inplaced())
-		dEdxi.tvec().device(*dev.edevice) = dEdf.tvec() * block_multiplier;
-	else
-		dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * block_multiplier;
+  if(inplaced())
+    dEdxi.tvec().device(*dev.edevice) = dEdf.tvec() * block_multiplier;
+  else
+    dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * block_multiplier;
 }
 DYNET_NODE_INST_DEV_IMPL(BlockDropout)
 

--- a/dynet/nodes-dropout.cc
+++ b/dynet/nodes-dropout.cc
@@ -42,7 +42,10 @@ void Dropout::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   Tensor m(dim, (float*)aux_mem, fx.device, DeviceMempool::FXS);
-  dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * m.tvec();
+	if(inplaced())
+		dEdxi.tvec().device(*dev.edevice) = dEdf.tvec() * m.tvec();
+	else
+		dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * m.tvec();
 }
 DYNET_NODE_INST_DEV_IMPL(Dropout)
 
@@ -90,7 +93,10 @@ void DropoutDim::backward_dev_impl(const MyDevice & dev,
   mask_dim.d[dimension]=1;
   Tensor m(mask_dim, (float*)aux_mem, fx.device, DeviceMempool::FXS);
   Eigen::array<ptrdiff_t, 4> bcast = {1, 1, 1, 1}; bcast[dimension] = dEdf.d[dimension];
-  dEdxi.tb<3>().device(*dev.edevice) += dEdf.tb<3>() * m.tb<3>().broadcast(bcast);
+	if(inplaced())
+		dEdxi.tb<3>().device(*dev.edevice) = dEdf.tb<3>() * m.tb<3>().broadcast(bcast);
+	else
+		dEdxi.tb<3>().device(*dev.edevice) += dEdf.tb<3>() * m.tb<3>().broadcast(bcast);
 }
 DYNET_NODE_INST_DEV_IMPL(DropoutDim)
 
@@ -134,7 +140,10 @@ void DropoutBatch::backward_dev_impl(const MyDevice & dev,
   Dim mask_dim({1},xs[0]->d.batch_elems());
   Tensor m(mask_dim, (float*)aux_mem, fx.device, DeviceMempool::FXS);
   Eigen::array<ptrdiff_t, 2> bcast = {xs[0]->d.batch_size(), 1};
-  dEdxi.tbvec().device(*dev.edevice) += dEdf.tbvec() * m.tbvec().broadcast(bcast);
+	if(inplaced())
+		dEdxi.tbvec().device(*dev.edevice) = dEdf.tbvec() * m.tbvec().broadcast(bcast);
+	else
+		dEdxi.tbvec().device(*dev.edevice) += dEdf.tbvec() * m.tbvec().broadcast(bcast);
 }
 DYNET_NODE_INST_DEV_IMPL(DropoutBatch)
 
@@ -180,7 +189,10 @@ void BlockDropout::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   float block_multiplier = *(static_cast<float*>(aux_mem));
-  dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * block_multiplier;
+	if(inplaced())
+		dEdxi.tvec().device(*dev.edevice) = dEdf.tvec() * block_multiplier;
+	else
+		dEdxi.tvec().device(*dev.edevice) += dEdf.tvec() * block_multiplier;
 }
 DYNET_NODE_INST_DEV_IMPL(BlockDropout)
 

--- a/dynet/nodes-dropout.h
+++ b/dynet/nodes-dropout.h
@@ -8,7 +8,7 @@ namespace dynet {
 
 // y = dropout(x,p) where p specifies the dropout probability
 struct Dropout : public Node {
-  explicit Dropout(const std::initializer_list<VariableIndex>& a, real p) : Node(a), p(p) {}
+  explicit Dropout(const std::initializer_list<VariableIndex>& a, real p, bool inplaced) : Node(a), p(p) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   DYNET_NODE_DEFINE_DEV_IMPL()
   size_t aux_storage_size() const override;
   virtual bool supports_multibatch() const override { return true; }
@@ -17,7 +17,7 @@ struct Dropout : public Node {
 
 // y = dropout(x,p) where p specifies the dropout probability
 struct DropoutDim : public Node {
-  explicit DropoutDim(const std::initializer_list<VariableIndex>& a, unsigned d,real p) : Node(a), dimension(d), p(p) {}
+  explicit DropoutDim(const std::initializer_list<VariableIndex>& a, unsigned d, real p, bool inplaced) : Node(a), dimension(d), p(p) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   DYNET_NODE_DEFINE_DEV_IMPL()
   size_t aux_storage_size() const override;
   virtual bool supports_multibatch() const override { return true; }
@@ -27,7 +27,7 @@ struct DropoutDim : public Node {
 
 // y = dropout(x,p) where p specifies the dropout probability
 struct DropoutBatch : public Node {
-  explicit DropoutBatch(const std::initializer_list<VariableIndex>& a, real p) : Node(a), p(p) {}
+  explicit DropoutBatch(const std::initializer_list<VariableIndex>& a, real p, bool inplaced) : Node(a), p(p) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   DYNET_NODE_DEFINE_DEV_IMPL()
   size_t aux_storage_size() const override;
   virtual bool supports_multibatch() const override { return true; }
@@ -36,7 +36,7 @@ struct DropoutBatch : public Node {
 
 // y = block_dropout(x,p) where p specifies the probability for dropping-out the entire block
 struct BlockDropout : public Node {
-  explicit BlockDropout(const std::initializer_list<VariableIndex>& a, real p) : Node(a), dropout_probability(p) {}
+  explicit BlockDropout(const std::initializer_list<VariableIndex>& a, real p, bool inplaced) : Node(a), dropout_probability(p) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   DYNET_NODE_DEFINE_DEV_IMPL()
   size_t aux_storage_size() const override;
   real dropout_probability;

--- a/dynet/nodes-flow.cc
+++ b/dynet/nodes-flow.cc
@@ -35,10 +35,10 @@ template<class MyDevice>
 void Reshape::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   // just point to the input memory and change dimensions
   // dimensions are handled by forward_dim
-	if(inplaced())
-		;		// pass, already sharing pointers
-	else
-		fx.tvec().device(*dev.edevice) = xs[0]->tvec();
+  if(inplaced())
+    ;    // pass, already sharing pointers
+  else
+    fx.tvec().device(*dev.edevice) = xs[0]->tvec();
 }
 
 template<class MyDevice>
@@ -49,10 +49,10 @@ void Reshape::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   const Tensor reshaped(dEdxi.d, dEdf.v, dEdxi.device, dEdf.mem_pool);
-	if(inplaced())
-		;		// pass, already accumulated into it
-	else
-		dEdxi.tvec().device(*dev.edevice) += reshaped.tvec();
+  if(inplaced())
+    ;    // pass, already accumulated into it
+  else
+    dEdxi.tvec().device(*dev.edevice) += reshaped.tvec();
 }
 DYNET_NODE_INST_DEV_IMPL(Reshape)
 
@@ -73,10 +73,10 @@ Dim Identity::dim_forward(const vector<Dim>& xs) const {
 
 template<class MyDevice>
 void Identity::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-	if(inplaced())
-		;		// pass, already sharing pointers
-	else
-		fx.tvec().device(*dev.edevice) = xs[0]->tvec();
+  if(inplaced())
+    ;    // pass, already sharing pointers
+  else
+    fx.tvec().device(*dev.edevice) = xs[0]->tvec();
 }
 
 template<class MyDevice>
@@ -86,10 +86,10 @@ void Identity::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-	if(inplaced())
-		;		// pass, already accumulated into it
-	else
-		dEdxi.tvec().device(*dev.edevice) += dEdf.tvec();
+  if(inplaced())
+    ;    // pass, already accumulated into it
+  else
+    dEdxi.tvec().device(*dev.edevice) += dEdf.tvec();
 }
 DYNET_NODE_INST_DEV_IMPL(Identity)
 

--- a/dynet/nodes-flow.cc
+++ b/dynet/nodes-flow.cc
@@ -35,7 +35,10 @@ template<class MyDevice>
 void Reshape::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   // just point to the input memory and change dimensions
   // dimensions are handled by forward_dim
-  fx.tvec().device(*dev.edevice) = xs[0]->tvec();
+	if(inplaced())
+		;		// pass, already sharing pointers
+	else
+		fx.tvec().device(*dev.edevice) = xs[0]->tvec();
 }
 
 template<class MyDevice>
@@ -46,7 +49,10 @@ void Reshape::backward_dev_impl(const MyDevice & dev,
                              unsigned i,
                              Tensor& dEdxi) const {
   const Tensor reshaped(dEdxi.d, dEdf.v, dEdxi.device, dEdf.mem_pool);
-  dEdxi.tvec().device(*dev.edevice) += reshaped.tvec();
+	if(inplaced())
+		;		// pass, already accumulated into it
+	else
+		dEdxi.tvec().device(*dev.edevice) += reshaped.tvec();
 }
 DYNET_NODE_INST_DEV_IMPL(Reshape)
 
@@ -67,7 +73,10 @@ Dim Identity::dim_forward(const vector<Dim>& xs) const {
 
 template<class MyDevice>
 void Identity::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
-  fx.tvec().device(*dev.edevice) = xs[0]->tvec();
+	if(inplaced())
+		;		// pass, already sharing pointers
+	else
+		fx.tvec().device(*dev.edevice) = xs[0]->tvec();
 }
 
 template<class MyDevice>
@@ -77,7 +86,10 @@ void Identity::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  dEdxi.tvec().device(*dev.edevice) += dEdf.tvec();
+	if(inplaced())
+		;		// pass, already accumulated into it
+	else
+		dEdxi.tvec().device(*dev.edevice) += dEdf.tvec();
 }
 DYNET_NODE_INST_DEV_IMPL(Identity)
 

--- a/dynet/nodes-flow.h
+++ b/dynet/nodes-flow.h
@@ -8,7 +8,7 @@ namespace dynet {
 
 // y = reshape(x_1, --> to)
 struct Reshape : public Node {
-  explicit Reshape(const std::initializer_list<VariableIndex>& a, const Dim& to) : Node(a), to(to) {}
+  explicit Reshape(const std::initializer_list<VariableIndex>& a, const Dim& to, bool inplaced) : Node(a), to(to) { if(inplaced) inplace_state = INPLACE_TYPE::READ; }
   DYNET_NODE_DEFINE_DEV_IMPL()
   virtual bool supports_multibatch() const override { return true; }
   Dim to;
@@ -16,9 +16,9 @@ struct Reshape : public Node {
 
 // y = x_1
 struct Identity : public Node {
-  explicit Identity(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  explicit Identity(const std::initializer_list<VariableIndex>& a, bool inplaced) : Node(a) { if(inplaced) inplace_state = INPLACE_TYPE::READ; }
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::identity); return sm.get_idx(s); }
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { if(inplaced()) return 0; Sig s(nt::identity); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }  
   DYNET_NODE_DEFINE_DEV_IMPL()
 };

--- a/dynet/nodes-trig.cc
+++ b/dynet/nodes-trig.cc
@@ -36,10 +36,10 @@ void Tanh::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-	if(inplaced())
-		dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), scalar_tanh_backward_op<float>());
-	else
-		dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), scalar_tanh_backward_op<float>());
+  if(inplaced())
+    dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), scalar_tanh_backward_op<float>());
+  else
+    dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), scalar_tanh_backward_op<float>());
 }
 DYNET_NODE_INST_DEV_IMPL(Tanh)
 

--- a/dynet/nodes-trig.cc
+++ b/dynet/nodes-trig.cc
@@ -36,7 +36,10 @@ void Tanh::backward_dev_impl(const MyDevice & dev,
                              const Tensor& dEdf,
                              unsigned i,
                              Tensor& dEdxi) const {
-  dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), scalar_tanh_backward_op<float>());
+	if(inplaced())
+		dEdxi.tvec().device(*dev.edevice) = fx.tvec().binaryExpr(dEdf.tvec(), scalar_tanh_backward_op<float>());
+	else
+		dEdxi.tvec().device(*dev.edevice) += fx.tvec().binaryExpr(dEdf.tvec(), scalar_tanh_backward_op<float>());
 }
 DYNET_NODE_INST_DEV_IMPL(Tanh)
 

--- a/dynet/nodes-trig.h
+++ b/dynet/nodes-trig.h
@@ -10,7 +10,7 @@ namespace dynet {
 struct Tanh : public Node {
   explicit Tanh(const std::initializer_list<VariableIndex>& a, bool inplaced): Node(a) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   virtual bool supports_multibatch() const override { return true; }
-	// if the operation is inplaced, let it non-autobatchable
+  // if the operation is inplaced, let it non-autobatchable
   virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { if(inplaced()) return 0; Sig s(nt::tanh); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }  
   DYNET_NODE_DEFINE_DEV_IMPL()

--- a/dynet/nodes-trig.h
+++ b/dynet/nodes-trig.h
@@ -8,9 +8,10 @@ namespace dynet {
 
 // y = tanh x_1
 struct Tanh : public Node {
-  explicit Tanh(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  explicit Tanh(const std::initializer_list<VariableIndex>& a, bool inplaced): Node(a) { if(inplaced) inplace_state = INPLACE_TYPE::WRITE; }
   virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { Sig s(nt::tanh); return sm.get_idx(s); }
+	// if the operation is inplaced, let it non-autobatchable
+  virtual int autobatch_sig(const ComputationGraph &cg, SigMap &sm) const override { if(inplaced()) return 0; Sig s(nt::tanh); return sm.get_idx(s); }
   virtual std::vector<int> autobatch_concat(const ComputationGraph & cg) const override { return std::vector<int>(1, 1); }  
   DYNET_NODE_DEFINE_DEV_IMPL()
 };

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -233,6 +233,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
         CDim dim() except +
         bool is_stale()
         const CTensor& gradient() except +
+        void set_rewritable(bool v) except +
     #CExpression c_input "dynet::input" (CComputationGraph& g, float s)   #
     CExpression c_input "dynet::input" (CComputationGraph& g, float *ps) except + #
     CExpression c_input "dynet::input" (CComputationGraph& g, CDim& d, vector[float]* pdata) except +

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -275,7 +275,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_cmult "dynet::cmult" (CExpression& x, CExpression& y) except + #
     CExpression c_colwise_add "dynet::colwise_add" (CExpression& x, CExpression& bias) except + #
 
-    CExpression c_tanh "dynet::tanh" (CExpression& x) except + #
+    CExpression c_tanh "dynet::tanh" (CExpression& x, bool inplaced) except + #
     CExpression c_exp "dynet::exp" (CExpression& x) except + #
     CExpression c_square "dynet::square" (CExpression& x) except + #
     CExpression c_sqrt "dynet::sqrt" (CExpression& x) except + #
@@ -284,8 +284,8 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_cube "dynet::cube" (CExpression& x) except + #
     CExpression c_log "dynet::log" (CExpression& x) except + #
     CExpression c_lgamma "dynet::lgamma" (CExpression& x) except + #
-    CExpression c_logistic "dynet::logistic" (CExpression& x) except + #
-    CExpression c_rectify "dynet::rectify" (CExpression& x) except + #
+    CExpression c_logistic "dynet::logistic" (CExpression& x, bool inplaced) except + #
+    CExpression c_rectify "dynet::rectify" (CExpression& x, bool inplaced) except + #
     CExpression c_hinge "dynet::hinge" (CExpression& x, unsigned index, float m) except + #
     CExpression c_hinge "dynet::hinge" (CExpression& x, vector[unsigned] vs, float m) except + #
     CExpression c_hinge_dim "dynet::hinge_dim" (CExpression& x, vector[unsigned] index, unsigned d, float m) except + #
@@ -294,17 +294,17 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_log_softmax "dynet::log_softmax" (CExpression& x, vector[unsigned]& restriction) except + #?
     CExpression c_softmax "dynet::softmax" (CExpression& x) except + #
     CExpression c_sparsemax "dynet::sparsemax" (CExpression& x) except + #
-    CExpression c_softsign "dynet::softsign" (CExpression& x) except + #
+    CExpression c_softsign "dynet::softsign" (CExpression& x, bool inplaced) except + #
     CExpression c_pow "dynet::pow" (CExpression& x, CExpression& y) except + #
     CExpression c_bmin "dynet::min" (CExpression& x, CExpression& y) except + #
     CExpression c_bmax "dynet::max" (CExpression& x, CExpression& y) except + #
     CExpression c_noise "dynet::noise" (CExpression& x, float stddev) except + #
-    CExpression c_dropout "dynet::dropout" (CExpression& x, float p) except + #
-    CExpression c_dropout_batch "dynet::dropout_batch" (CExpression& x, float p) except + #
-    CExpression c_dropout_dim "dynet::dropout_dim" (CExpression& x, unsigned d, float p) except + #
-    CExpression c_block_dropout "dynet::block_dropout" (CExpression& x, float p) except + #
+    CExpression c_dropout "dynet::dropout" (CExpression& x, float p, bool inplaced) except + #
+    CExpression c_dropout_batch "dynet::dropout_batch" (CExpression& x, float p, bool inplaced) except + #
+    CExpression c_dropout_dim "dynet::dropout_dim" (CExpression& x, unsigned d, float p, bool inplaced) except + #
+    CExpression c_block_dropout "dynet::block_dropout" (CExpression& x, float p, bool inplaced) except + #
 
-    CExpression c_reshape "dynet::reshape" (CExpression& x, CDim& d) except + #?
+    CExpression c_reshape "dynet::reshape" (CExpression& x, CDim& d, bool inplaced) except + #?
     CExpression c_transpose "dynet::transpose" (CExpression& x, vector[unsigned]& dims) except + #
 
     CExpression c_affine_transform "dynet::affine_transform" (const vector[CExpression]& xs) except +

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -2586,18 +2586,19 @@ cpdef Expression maxpooling2d(Expression x, vector[unsigned] ksize, vector[unsig
     return Expression.from_cexpr(x.cg_version, c_maxpooling2d(x.c(), ksize, stride, is_valid))
 
 # unary-exp
-cpdef Expression tanh(Expression x): 
+cpdef Expression tanh(Expression x, bool inplaced=False): 
     """Hyperbolic tangent
     
     Elementwise calculation of the hyperbolic tangent
     
     Args:
         x (dynet.Expression): Input expression
+		inplaced (bool): whether this is an inplaced operation
     
     Returns:
         dynet.Expression: :math:`\\tanh(x)`
     """
-    return Expression.from_cexpr(x.cg_version, c_tanh(x.c()))
+    return Expression.from_cexpr(x.cg_version, c_tanh(x.c(), inplaced))
 cpdef Expression exp(Expression x): 
     """Natural exponent
     
@@ -2696,31 +2697,33 @@ cpdef Expression lgamma(Expression x):
         dynet.Expression: :math:`y_i = \ln(\Gamma(x_i))`
     """
     return Expression.from_cexpr(x.cg_version, c_lgamma(x.c()))
-cpdef Expression logistic(Expression x): 
+cpdef Expression logistic(Expression x, bool inplaced=False): 
     """Logistic sigmoid function
     
     Calculate elementwise :math:`y_i = \\frac{1}{1+e^{-x_i}}`
     
     Args:
         x (dynet.Expression): Input expression
+		inplaced (bool): whether this is an inplaced operation
     
     Returns:
         dynet.Expression: :math:`y_i = \\frac{1}{1+e^{-x_i}}`
     """
-    return Expression.from_cexpr(x.cg_version, c_logistic(x.c()))
+    return Expression.from_cexpr(x.cg_version, c_logistic(x.c(), inplaced))
 
-cpdef Expression rectify(Expression x): 
+cpdef Expression rectify(Expression x, bool inplaced=False): 
     """Rectifier (or ReLU, Rectified Linear Unit)
     
     Calculate elementwise recitifer (ReLU) function :math:`y_i = \max(x_i,0)`
 
     Args:
         x (dynet.Expression): Input expression
+		inplaced (bool): whether this is an inplaced operation
     
     Returns:
         dynet.Expression: :math:`y_i = \max(x_i,0)`
     """
-    return Expression.from_cexpr(x.cg_version, c_rectify(x.c()))
+    return Expression.from_cexpr(x.cg_version, c_rectify(x.c(), inplaced))
 
 cpdef Expression elu(Expression x, float alpha=1.0): 
     """Exponential Linear Unit (ELU)
@@ -2816,18 +2819,19 @@ cpdef Expression sparsemax(Expression x):
         dynet.Expression: The sparsemax of the scores
     """
     return Expression.from_cexpr(x.cg_version, c_sparsemax(x.c()))
-cpdef Expression softsign(Expression x):
+cpdef Expression softsign(Expression x, inplaced=False):
     """Softsign function
 
     Calculate elementwise the softsign function :math:`y_i = \\frac{x_i}{1+\\vert x_i\\vert}`
 
     Args:
         x (dynet.Expression): Input expression
+		inplaced (bool): whether this is an inplaced operation
     
     Returns:
         dynet.Expression: :math:`y_i = \\frac{x_i}{1+\\vert x_i\\vert}`
     """
-    return Expression.from_cexpr(x.cg_version, c_softsign(x.c()))
+    return Expression.from_cexpr(x.cg_version, c_softsign(x.c(), inplaced))
 cpdef Expression pow(Expression x, Expression y):
     """Power function
     
@@ -3382,7 +3386,7 @@ cpdef Expression noise(Expression x, float stddev):
     """
     return Expression.from_cexpr(x.cg_version, c_noise(x.c(), stddev))
 
-cpdef Expression dropout(Expression x, float p):
+cpdef Expression dropout(Expression x, float p, bool inplaced=False):
     """Dropout
     
     With a fixed probability, drop out (set to zero) nodes in the input expression, and **scale** the remaining nodes by 1/p. Note that there are `two kinds of dropout <http://cs231n.github.io/neural-networks-2/#reg>`_: 
@@ -3395,14 +3399,15 @@ cpdef Expression dropout(Expression x, float p):
     Args:
         x (dynet.Expression): Input expression
         p (number): The dropout probability
+		inplaced (bool): whether this is an inplaced operation
     
     Returns:
         dynet.Expression: The dropped out expression :math:`y=\\frac{1}{1-\\texttt{p}}x\circ z, z\sim\\text{Bernoulli}(1-\\texttt{p})`
     """
-    return Expression.from_cexpr(x.cg_version, c_dropout(x.c(), p))
+    return Expression.from_cexpr(x.cg_version, c_dropout(x.c(), p, inplaced))
 
     
-cpdef Expression dropout_batch(Expression x, float p):
+cpdef Expression dropout_batch(Expression x, float p, bool inplaced=False):
     """Dropout entire elements of a minibatch
     
     Identical to the dropout operation except entire batch elements are dropped
@@ -3410,13 +3415,14 @@ cpdef Expression dropout_batch(Expression x, float p):
     Args:
         x (dynet.Expression): Input expression
         p (number): The dropout probability
+		inplaced (bool): whether this is an inplaced operation
     
     Returns:
         dynet.Expression: The dropped expression
     """
-    return Expression.from_cexpr(x.cg_version, c_dropout_batch(x.c(), p))
+    return Expression.from_cexpr(x.cg_version, c_dropout_batch(x.c(), p, inplaced))
 
-cpdef Expression dropout_dim(Expression x, unsigned d, float p):
+cpdef Expression dropout_dim(Expression x, unsigned d, float p, bool inplaced=False):
     """Dropout along one dimension
     
     Identical to the dropout operation except the dropout mask is the same across one dimension. Use this if you want to drop columns or lines in a matrix for example 
@@ -3427,13 +3433,14 @@ cpdef Expression dropout_dim(Expression x, unsigned d, float p):
         x (dynet.Expression): Input expression
         d (int): Dimension along which to drop
         p (number): The dropout probability
+		inplaced (bool): whether this is an inplaced operation
     
     Returns:
         dynet.Expression: The dropped expression
     """
-    return Expression.from_cexpr(x.cg_version, c_dropout_dim(x.c(), d, p))
+    return Expression.from_cexpr(x.cg_version, c_dropout_dim(x.c(), d, p, inplaced))
 
-cpdef Expression block_dropout(Expression x, float p):
+cpdef Expression block_dropout(Expression x, float p, bool inplaced=False):
     """Block dropout
     
     Identical to the dropout operation, but either drops out *all* or *no* values in the expression, as opposed to making a decision about each value individually.
@@ -3441,13 +3448,14 @@ cpdef Expression block_dropout(Expression x, float p):
     Args:
         x (dynet.Expression): Input expression
         p (number): The dropout probability
+		inplaced (bool): whether this is an inplaced operation
     
     Returns:
         dynet.Expression: The block dropout expression
     """
-    return Expression.from_cexpr(x.cg_version, c_block_dropout(x.c(), p))
+    return Expression.from_cexpr(x.cg_version, c_block_dropout(x.c(), p, inplaced))
 #expr-dim
-cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1):
+cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1, bool inplaced=False):
     """Reshape to another size
     
     This node reshapes a tensor to another size, without changing the underlying layout of the data. The layout of the data in DyNet is column-major, so if we have a 3x4 matrix :
@@ -3474,6 +3482,7 @@ cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1):
     Args:
         x (dynet.Expression): Input expression
         d (tuple): New dimension
+		inplaced (bool): whether this is an inplaced operation
     
     Keyword Arguments:
         batch_size (int): New batch size (default: (1))
@@ -3481,7 +3490,7 @@ cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1):
     Returns:
         dynet.Expression: The reshaped expression
     """
-    return Expression.from_cexpr(x.cg_version, c_reshape(x.c(),Dim(d, batch_size)))
+    return Expression.from_cexpr(x.cg_version, c_reshape(x.c(),Dim(d, batch_size),inplaced))
 
 cpdef Expression max_dim(Expression x, unsigned d=0):
     """Max out through a dimension

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1672,6 +1672,17 @@ cdef class Expression: #{{{
         if self.cg_version != _cg._cg_version: raise RuntimeError("Stale Expression (created before renewing the Computation Graph).")
         self.cgp().backward(self.vindex, full)
 
+    cpdef set_rewritable(self, bool value):
+        """Setting whether this expression(Node)'s memory could be rewritten by others (for inplaced operations)
+        
+        This action could be dangerous for nodes which need its original value when calculating gradients !!
+        
+        Args:
+            value (bool): Whether this could be rewritable.
+        
+        """
+        self.c().set_rewritable(value)
+
     def __add__(self, other):
         if isinstance(self, Expression) and isinstance(other, Expression):
             return _add(self,other)

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -650,6 +650,7 @@ BOOST_AUTO_TEST_CASE( tanh_gradient ) {
 BOOST_AUTO_TEST_CASE(tanh_inplace_gradient) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
+  x1.set_rewritable(true);
   Expression y = tanh(x1, true);
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
@@ -713,6 +714,7 @@ BOOST_AUTO_TEST_CASE( logistic_gradient ) {
 BOOST_AUTO_TEST_CASE(logistic_inplace_gradient) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
+  x1.set_rewritable(true);
   Expression y = logistic(x1, true);
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
@@ -731,6 +733,7 @@ BOOST_AUTO_TEST_CASE( rectify_gradient ) {
 BOOST_AUTO_TEST_CASE(rectify_inplace_gradient) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
+  x1.set_rewritable(true);
   Expression y = rectify(x1, true);
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
@@ -919,6 +922,7 @@ BOOST_AUTO_TEST_CASE( softsign_gradient ) {
 BOOST_AUTO_TEST_CASE(softsign_inplace_gradient) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
+  x1.set_rewritable(true);
   Expression y = softsign(x1, true);
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
@@ -977,6 +981,7 @@ BOOST_AUTO_TEST_CASE( dropout_forward ) {
 BOOST_AUTO_TEST_CASE(dropout_inplace_forward) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
+  x1.set_rewritable(true);
   Expression y = dropout(x1, 0.5, true);
   Expression z = sum_elems(y);
   cg.forward(z);
@@ -993,6 +998,7 @@ BOOST_AUTO_TEST_CASE( dropout_batch_forward ) {
 BOOST_AUTO_TEST_CASE(dropout_batch_inplace_forward) {
   dynet::ComputationGraph cg;
   Expression x = input(cg, Dim({3}, 2), batch_vals);
+  x.set_rewritable(true);
   Expression y = dropout_batch(x, 0.5, true);
   Expression z = sum_elems(y);
   cg.forward(z);
@@ -1012,6 +1018,7 @@ BOOST_AUTO_TEST_CASE(dropout_dim_inplace_forward) {
   for(unsigned d = 0; d < 3; d++) {
     dynet::ComputationGraph cg;
     Expression x = parameter(cg, param_cube1);
+    x.set_rewritable(true);
     Expression y = dropout_dim(x, d, 0.5, true);
     Expression z = sum_elems(y);
     cg.forward(z);
@@ -1034,6 +1041,7 @@ BOOST_AUTO_TEST_CASE( reshape_gradient ) {
 BOOST_AUTO_TEST_CASE(reshape_inplace_gradient) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
+  x1.set_rewritable(true);
   Expression y = reshape(x1, {1, 3}, true);
   Expression z = sum_elems(y);
   BOOST_CHECK(check_grad(mod, z, 0));
@@ -1056,6 +1064,7 @@ BOOST_AUTO_TEST_CASE(reshape_inplace_batch_gradient) {
   Expression x1 = parameter(cg, param1);
   Expression x2 = input(cg, Dim({3}, 2), batch_vals);
   Expression y1 = x1 * transpose(x2);
+  y1.set_rewritable(true);
   Expression y2 = reshape(y1, Dim({3, 3}, 2), true);
   Expression z = sum_batches(sum_elems(y2));
   BOOST_CHECK(check_grad(mod, z, 0));

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -646,6 +646,15 @@ BOOST_AUTO_TEST_CASE( tanh_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression tanh(const Expression& x, bool inplaced=true);
+BOOST_AUTO_TEST_CASE(tanh_inplace_gradient) {
+	dynet::ComputationGraph cg;
+	Expression x1 = parameter(cg, param1);
+	Expression y = tanh(x1, true);
+	Expression z = sum_elems(y);
+	BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 // Expression exp(const Expression& x);
 BOOST_AUTO_TEST_CASE( exp_gradient ) {
   dynet::ComputationGraph cg;
@@ -700,6 +709,15 @@ BOOST_AUTO_TEST_CASE( logistic_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression logistic(const Expression& x, bool inplaced=true);
+BOOST_AUTO_TEST_CASE(logistic_inplace_gradient) {
+	dynet::ComputationGraph cg;
+	Expression x1 = parameter(cg, param1);
+	Expression y = logistic(x1, true);
+	Expression z = sum_elems(y);
+	BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 // Expression rectify(const Expression& x);
 BOOST_AUTO_TEST_CASE( rectify_gradient ) {
   dynet::ComputationGraph cg;
@@ -709,6 +727,14 @@ BOOST_AUTO_TEST_CASE( rectify_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression rectify(const Expression& x, bool inplaced=true);
+BOOST_AUTO_TEST_CASE(rectify_inplace_gradient) {
+	dynet::ComputationGraph cg;
+	Expression x1 = parameter(cg, param1);
+	Expression y = rectify(x1, true);
+	Expression z = sum_elems(y);
+	BOOST_CHECK(check_grad(mod, z, 0));
+}
 
 // Expression elu(const Expression& x);
 BOOST_AUTO_TEST_CASE( elu_gradient ) {
@@ -889,6 +915,15 @@ BOOST_AUTO_TEST_CASE( softsign_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression softsign(const Expression& x, bool inplaced=true);
+BOOST_AUTO_TEST_CASE(softsign_inplace_gradient) {
+	dynet::ComputationGraph cg;
+	Expression x1 = parameter(cg, param1);
+	Expression y = softsign(x1, true);
+	Expression z = sum_elems(y);
+	BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 // Expression pow(const Expression& x, const Expression& y);
 BOOST_AUTO_TEST_CASE( pow_gradient ) {
   dynet::ComputationGraph cg;
@@ -939,6 +974,14 @@ BOOST_AUTO_TEST_CASE( dropout_forward ) {
   cg.forward(z);
 }
 
+BOOST_AUTO_TEST_CASE(dropout_inplace_forward) {
+	dynet::ComputationGraph cg;
+	Expression x1 = parameter(cg, param1);
+	Expression y = dropout(x1, 0.5, true);
+	Expression z = sum_elems(y);
+	cg.forward(z);
+}
+
 BOOST_AUTO_TEST_CASE( dropout_batch_forward ) {
   dynet::ComputationGraph cg;
   Expression x = input(cg, Dim({3}, 2), batch_vals);
@@ -947,6 +990,13 @@ BOOST_AUTO_TEST_CASE( dropout_batch_forward ) {
   cg.forward(z);
 }
 
+BOOST_AUTO_TEST_CASE(dropout_batch_inplace_forward) {
+	dynet::ComputationGraph cg;
+	Expression x = input(cg, Dim({3}, 2), batch_vals);
+	Expression y = dropout_batch(x, 0.5, true);
+	Expression z = sum_elems(y);
+	cg.forward(z);
+}
 
 BOOST_AUTO_TEST_CASE( dropout_dim_forward ) {
   for (unsigned d = 0; d < 3; d++) {
@@ -956,6 +1006,16 @@ BOOST_AUTO_TEST_CASE( dropout_dim_forward ) {
     Expression z = sum_elems(y);
     cg.forward(z);
   }
+}
+
+BOOST_AUTO_TEST_CASE(dropout_dim_inplace_forward) {
+	for(unsigned d = 0; d < 3; d++) {
+		dynet::ComputationGraph cg;
+		Expression x = parameter(cg, param_cube1);
+		Expression y = dropout_dim(x, d, 0.5, true);
+		Expression z = sum_elems(y);
+		cg.forward(z);
+	}
 }
 
 // TODO: Dropout scales the gradients at training time, so they don't match.
@@ -970,6 +1030,15 @@ BOOST_AUTO_TEST_CASE( reshape_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression reshape(const Expression& x, const Dim& d, bool inplaced=true);
+BOOST_AUTO_TEST_CASE(reshape_inplace_gradient) {
+	dynet::ComputationGraph cg;
+	Expression x1 = parameter(cg, param1);
+	Expression y = reshape(x1, {1, 3}, true);
+	Expression z = sum_elems(y);
+	BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 // Expression reshape(const Expression& x, const Dim& d);
 BOOST_AUTO_TEST_CASE( reshape_batch_gradient ) {
   dynet::ComputationGraph cg;
@@ -979,6 +1048,17 @@ BOOST_AUTO_TEST_CASE( reshape_batch_gradient ) {
   Expression y2 = reshape(y1, Dim({3, 3}, 2));
   Expression z = sum_batches(sum_elems(y2));
   BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression reshape(const Expression& x, const Dim& d, bool inplaced=true);
+BOOST_AUTO_TEST_CASE(reshape_inplace_batch_gradient) {
+	dynet::ComputationGraph cg;
+	Expression x1 = parameter(cg, param1);
+	Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+	Expression y1 = x1 * transpose(x2);
+	Expression y2 = reshape(y1, Dim({3, 3}, 2), true);
+	Expression z = sum_batches(sum_elems(y2));
+	BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression transpose(const Expression& x);

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -648,11 +648,11 @@ BOOST_AUTO_TEST_CASE( tanh_gradient ) {
 
 // Expression tanh(const Expression& x, bool inplaced=true);
 BOOST_AUTO_TEST_CASE(tanh_inplace_gradient) {
-	dynet::ComputationGraph cg;
-	Expression x1 = parameter(cg, param1);
-	Expression y = tanh(x1, true);
-	Expression z = sum_elems(y);
-	BOOST_CHECK(check_grad(mod, z, 0));
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression y = tanh(x1, true);
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression exp(const Expression& x);
@@ -711,11 +711,11 @@ BOOST_AUTO_TEST_CASE( logistic_gradient ) {
 
 // Expression logistic(const Expression& x, bool inplaced=true);
 BOOST_AUTO_TEST_CASE(logistic_inplace_gradient) {
-	dynet::ComputationGraph cg;
-	Expression x1 = parameter(cg, param1);
-	Expression y = logistic(x1, true);
-	Expression z = sum_elems(y);
-	BOOST_CHECK(check_grad(mod, z, 0));
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression y = logistic(x1, true);
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression rectify(const Expression& x);
@@ -729,11 +729,11 @@ BOOST_AUTO_TEST_CASE( rectify_gradient ) {
 
 // Expression rectify(const Expression& x, bool inplaced=true);
 BOOST_AUTO_TEST_CASE(rectify_inplace_gradient) {
-	dynet::ComputationGraph cg;
-	Expression x1 = parameter(cg, param1);
-	Expression y = rectify(x1, true);
-	Expression z = sum_elems(y);
-	BOOST_CHECK(check_grad(mod, z, 0));
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression y = rectify(x1, true);
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression elu(const Expression& x);
@@ -917,11 +917,11 @@ BOOST_AUTO_TEST_CASE( softsign_gradient ) {
 
 // Expression softsign(const Expression& x, bool inplaced=true);
 BOOST_AUTO_TEST_CASE(softsign_inplace_gradient) {
-	dynet::ComputationGraph cg;
-	Expression x1 = parameter(cg, param1);
-	Expression y = softsign(x1, true);
-	Expression z = sum_elems(y);
-	BOOST_CHECK(check_grad(mod, z, 0));
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression y = softsign(x1, true);
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression pow(const Expression& x, const Expression& y);
@@ -975,11 +975,11 @@ BOOST_AUTO_TEST_CASE( dropout_forward ) {
 }
 
 BOOST_AUTO_TEST_CASE(dropout_inplace_forward) {
-	dynet::ComputationGraph cg;
-	Expression x1 = parameter(cg, param1);
-	Expression y = dropout(x1, 0.5, true);
-	Expression z = sum_elems(y);
-	cg.forward(z);
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression y = dropout(x1, 0.5, true);
+  Expression z = sum_elems(y);
+  cg.forward(z);
 }
 
 BOOST_AUTO_TEST_CASE( dropout_batch_forward ) {
@@ -991,11 +991,11 @@ BOOST_AUTO_TEST_CASE( dropout_batch_forward ) {
 }
 
 BOOST_AUTO_TEST_CASE(dropout_batch_inplace_forward) {
-	dynet::ComputationGraph cg;
-	Expression x = input(cg, Dim({3}, 2), batch_vals);
-	Expression y = dropout_batch(x, 0.5, true);
-	Expression z = sum_elems(y);
-	cg.forward(z);
+  dynet::ComputationGraph cg;
+  Expression x = input(cg, Dim({3}, 2), batch_vals);
+  Expression y = dropout_batch(x, 0.5, true);
+  Expression z = sum_elems(y);
+  cg.forward(z);
 }
 
 BOOST_AUTO_TEST_CASE( dropout_dim_forward ) {
@@ -1009,13 +1009,13 @@ BOOST_AUTO_TEST_CASE( dropout_dim_forward ) {
 }
 
 BOOST_AUTO_TEST_CASE(dropout_dim_inplace_forward) {
-	for(unsigned d = 0; d < 3; d++) {
-		dynet::ComputationGraph cg;
-		Expression x = parameter(cg, param_cube1);
-		Expression y = dropout_dim(x, d, 0.5, true);
-		Expression z = sum_elems(y);
-		cg.forward(z);
-	}
+  for(unsigned d = 0; d < 3; d++) {
+    dynet::ComputationGraph cg;
+    Expression x = parameter(cg, param_cube1);
+    Expression y = dropout_dim(x, d, 0.5, true);
+    Expression z = sum_elems(y);
+    cg.forward(z);
+  }
 }
 
 // TODO: Dropout scales the gradients at training time, so they don't match.
@@ -1032,11 +1032,11 @@ BOOST_AUTO_TEST_CASE( reshape_gradient ) {
 
 // Expression reshape(const Expression& x, const Dim& d, bool inplaced=true);
 BOOST_AUTO_TEST_CASE(reshape_inplace_gradient) {
-	dynet::ComputationGraph cg;
-	Expression x1 = parameter(cg, param1);
-	Expression y = reshape(x1, {1, 3}, true);
-	Expression z = sum_elems(y);
-	BOOST_CHECK(check_grad(mod, z, 0));
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression y = reshape(x1, {1, 3}, true);
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression reshape(const Expression& x, const Dim& d);
@@ -1052,13 +1052,13 @@ BOOST_AUTO_TEST_CASE( reshape_batch_gradient ) {
 
 // Expression reshape(const Expression& x, const Dim& d, bool inplaced=true);
 BOOST_AUTO_TEST_CASE(reshape_inplace_batch_gradient) {
-	dynet::ComputationGraph cg;
-	Expression x1 = parameter(cg, param1);
-	Expression x2 = input(cg, Dim({3}, 2), batch_vals);
-	Expression y1 = x1 * transpose(x2);
-	Expression y2 = reshape(y1, Dim({3, 3}, 2), true);
-	Expression z = sum_batches(sum_elems(y2));
-	BOOST_CHECK(check_grad(mod, z, 0));
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression y1 = x1 * transpose(x2);
+  Expression y2 = reshape(y1, Dim({3, 3}, 2), true);
+  Expression z = sum_batches(sum_elems(y2));
+  BOOST_CHECK(check_grad(mod, z, 0));
 }
 
 // Expression transpose(const Expression& x);


### PR DESCRIPTION
This PR adds certain partial enhancements for in-place operations (concerning issue [#774](https://github.com/clab/dynet/issues/774)) to save some memories.

About the changes:

0. For usage, call the enhanced expressions with an additional parameter `inplaced` set to `true`, those added parameters are set to `false` by default, thus no conflicts with previous codes. 
1. For inplace operations, the `Node` does not hold its own memory, it borrows the forward-value/backward-gradient memories of its args and the corresponding operations are done in-place. Two kinds of inplace nodes are considered: READ(no re-writing the forward-value) and WRITE(scrambling the original value, but don't need the original value for gradient calculations, for eg., tanh). `Reshape` is an example of the former while `Tanh` is an example of the latter.
2. The borrowing is simply implemented by sharing (float*) pointers in Tensor::v, and if the node is `inplaced`, no new memory will be allocated for them and its arg's value pointer will be directly utilized. The forward process is not changed since Eigen seems to be able to handle the situation of alias, while for the backward, all `+=` are changed to `=`. (This breaks the convention of using `+=` for backward, but is the most convenient way of sharing gradient memories, thus some constrains are placed, the main of which is that the borrowed node could only be used by this borrowing inplaced node.)
3. Currently only support certain unary operations: Reshape, Identity (READ); Rectify, LogisticSigmoid, SoftSign, Tanh, Dropout* (WRITE).

Constrains:
1. Only support certain unary operations as described above.
2. For simplicity, break the convention of using `+=` for backward, thus adding somewhat strict rules for the inplaced nodes and the nodes whose memories are borrowed. Briefly, WRITE-inplaced Nodes cannot borrow memories of the nodes whose output have been used (read) by other nodes or another WRITE-inplaced Node (nested WRITE-nodes might bring certain problems); READ-inplaced and plain Nodes cannot rely on nodes whose memories have been borrowed by WRITE-inplaced Nodes. See function `ComputationGraph::set_inplace_for_new_node`.
3. Forbid `revert`/`get_value` when we need to restore some scrambled values.
4. For simplicity, disable the supports of auto-batch for all inplaced nodes, since we cannot guarantee they are in contagious memories.
5. Currently no supports for `NoBackprop` and `FlipGradient`, whose gradients need special manipulations and thus are not that easy to be correctly shared.

Example (in python):

    import dynet as dy
    import numpy as np
    import random
    N = 100
    Ns = 10
    m = dy.Model()
    ini = [random.random() for _ in range(N)]
    w1 = m.add_parameters((N,), dy.NumpyInitializer(np.array(ini)))
    w2 = m.add_parameters((N,), dy.NumpyInitializer(np.array(ini)))
    tr = dy.SimpleSGDTrainer(m)
    assert all(w1.as_array() == w2.as_array())
    for inplaced in [True, False]:
        wp = dy.parameter(w1 if inplaced else w2)
        x1 = dy.inputVector(ini)
        x2 = dy.reshape(x1, (Ns, Ns), inplaced)
        wp2 = dy.reshape(wp, (Ns, Ns), inplaced)
        y1 = wp2 * x2
        y2 = dy.reshape(y1, (N,), inplaced)
        z1 = y2 + wp
        z2 = dy.tanh(z1, inplaced)
        loss = dy.sum_elems(z2)
        loss.backward()
        tr.update()
    assert all(w1.as_array() == w2.as_array())

Here the two iter should have the same effect with only the differences of calling `reshape` and `tanh` with different `inplaced` values.

I'm not sure whether this implement for inplaced operations is fine, or there are hidden problems with this. From the user's perspective, the only changes are the additional parameters of `inplaced` for certain operations. Since dynet is dynamic calculation graph, and users can always add later operations depending on previous values, it can be hard to automatically optimize with in-place operations. Thus to use inplace, maybe the users could only manually specify that like this?
