### PR TITLE
Remove deprecated Trainer::update_epoch

### DIFF
--- a/examples/cpp/embed-cl/train_embed-cl.cc
+++ b/examples/cpp/embed-cl/train_embed-cl.cc
@@ -145,7 +145,6 @@ int main(int argc, char** argv) {
   unsigned si = training.size();
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   // int report = 0;
   // unsigned dev_every_i_reports = 10;
   unsigned lines = 0;
@@ -156,7 +155,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         random_shuffle(order.begin(), order.end());
       }

--- a/examples/cpp/embed-cl/train_embed-cl.cc
+++ b/examples/cpp/embed-cl/train_embed-cl.cc
@@ -156,7 +156,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         random_shuffle(order.begin(), order.end());
       }

--- a/examples/cpp/encdec/train_encdec.cc
+++ b/examples/cpp/encdec/train_encdec.cc
@@ -159,12 +159,9 @@ int main(int argc, char** argv) {
   vector<unsigned> order(num_batches);
   for (unsigned i = 0; i < num_batches; ++i) order[i] = i;
 
-  bool first = true;
   int epoch = 0;
   // Run for the given number of epochs (or indefinitely if params.NUM_EPOCHS is negative)
   while (epoch < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
-    // Update the optimizer
-    if (first) { first = false; }
     // Reshuffle the dataset
     cerr << "**SHUFFLE\n";
     random_shuffle(order.begin(), order.end());

--- a/examples/cpp/encdec/train_encdec.cc
+++ b/examples/cpp/encdec/train_encdec.cc
@@ -164,7 +164,7 @@ int main(int argc, char** argv) {
   // Run for the given number of epochs (or indefinitely if params.NUM_EPOCHS is negative)
   while (epoch < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
     // Update the optimizer
-    if (first) { first = false; } else { adam->update_epoch(); }
+    if (first) { first = false; }
     // Reshuffle the dataset
     cerr << "**SHUFFLE\n";
     random_shuffle(order.begin(), order.end());

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -253,7 +253,6 @@ int main(int argc, char** argv) {
   unsigned si = training.size();
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   int report = 0;
   unsigned lines = 0;
   TextFileSaver saver("imdb.model");
@@ -265,7 +264,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/mlc/train_mlc.cc
+++ b/examples/cpp/mlc/train_mlc.cc
@@ -134,7 +134,6 @@ int main(int argc, char** argv) {
 
   unsigned report_every_i = 50;
   unsigned si = train.size();
-  bool first = true;
   vector<unsigned> order(train.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
   double ti = 0;
@@ -145,7 +144,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == train.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/mlc/train_mlc.cc
+++ b/examples/cpp/mlc/train_mlc.cc
@@ -145,7 +145,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == train.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd.update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/mnist/train_mnist.cc
+++ b/examples/cpp/mnist/train_mnist.cc
@@ -80,15 +80,12 @@ int main(int argc, char** argv) {
   vector<unsigned> order(num_batches);
   for (unsigned i = 0; i < num_batches; ++i) order[i] = i;
 
-  bool first = true;
   unsigned epoch = 0;
   vector<Expression> cur_batch;
   vector<unsigned> cur_labels;
 
   // Run for the given number of epochs (or indefinitely if params.NUM_EPOCHS is negative)
   while (epoch < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
-    // Update the optimizer
-    if (first) { first = false; }
     // Reshuffle the dataset
     cerr << "**SHUFFLE\n";
     random_shuffle(order.begin(), order.end());

--- a/examples/cpp/mnist/train_mnist.cc
+++ b/examples/cpp/mnist/train_mnist.cc
@@ -88,7 +88,7 @@ int main(int argc, char** argv) {
   // Run for the given number of epochs (or indefinitely if params.NUM_EPOCHS is negative)
   while (epoch < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
     // Update the optimizer
-    if (first) { first = false; } else { adam.update_epoch(); }
+    if (first) { first = false; }
     // Reshuffle the dataset
     cerr << "**SHUFFLE\n";
     random_shuffle(order.begin(), order.end());

--- a/examples/cpp/poisson-regression/train_poisson-regression.cc
+++ b/examples/cpp/poisson-regression/train_poisson-regression.cc
@@ -149,7 +149,6 @@ int main(int argc, char** argv) {
   unsigned si = training.size();
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   int report = 0;
   unsigned lines = 0;
   while(1) {
@@ -159,7 +158,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/poisson-regression/train_poisson-regression.cc
+++ b/examples/cpp/poisson-regression/train_poisson-regression.cc
@@ -159,7 +159,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
+++ b/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
@@ -206,7 +206,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
+++ b/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
@@ -196,7 +196,6 @@ int main(int argc, char** argv) {
   unsigned si = training.size();
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   int report = 0;
   unsigned lines = 0;
   while(1) {
@@ -206,7 +205,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
+++ b/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
@@ -160,7 +160,7 @@ int main(int argc, char** argv) {
   // Run for the given number of epochs (or indefinitely if params.NUM_EPOCHS is negative)
   while (epoch < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
     // Update the optimizer
-    if (first) { first = false; } else { adam->update_epoch(); }
+    if (first) { first = false; }
     // Reshuffle the dataset
     cerr << "**SHUFFLE\n";
     random_shuffle(order.begin(), order.end());

--- a/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
+++ b/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
@@ -155,12 +155,9 @@ int main(int argc, char** argv) {
   vector<unsigned> order(num_batches);
   for (unsigned i = 0; i < num_batches; ++i) order[i] = i;
 
-  bool first = true;
   unsigned epoch = 0;
   // Run for the given number of epochs (or indefinitely if params.NUM_EPOCHS is negative)
   while (epoch < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
-    // Update the optimizer
-    if (first) { first = false; }
     // Reshuffle the dataset
     cerr << "**SHUFFLE\n";
     random_shuffle(order.begin(), order.end());

--- a/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
+++ b/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
@@ -158,7 +158,6 @@ int main(int argc, char** argv) {
   unsigned si = training.size();
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   int report = 0;
   unsigned lines = 0;
   while(1) {
@@ -169,7 +168,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
+++ b/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
@@ -169,7 +169,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
+++ b/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
@@ -209,7 +209,6 @@ int main(int argc, char** argv) {
   vector<unsigned> order((training.size() + BATCH_SIZE - 1) / BATCH_SIZE);
   unsigned si = order.size();
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i * BATCH_SIZE;
-  bool first = true;
   int report = 0;
   unsigned lines = 0;
   while (1) {
@@ -219,7 +218,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i, ++si) {
       if (si == order.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
+++ b/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
@@ -219,7 +219,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i, ++si) {
       if (si == order.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
+++ b/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
@@ -191,7 +191,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
+++ b/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
@@ -178,7 +178,6 @@ int main(int argc, char** argv) {
   unsigned si = training.size();
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   int report = 0;
   unsigned lines = 0;
   vector<unsigned> rows;
@@ -191,7 +190,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -265,7 +265,7 @@ int main(int argc, char** argv) {
       for (unsigned i = 0; i < report_every_i; ++i) {
         if (si == training.size()) {
           si = 0;
-          if (first) { first = false; } else { sgd->update_epoch(); }
+          if (first) { first = false; }
           cerr << "**SHUFFLE\n";
           completed_epoch++;
           if (eta_decay_onset_epoch && completed_epoch >= (int)eta_decay_onset_epoch)

--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -253,7 +253,6 @@ int main(int argc, char** argv) {
     if (report_every_i > si) report_every_i = si;
     vector<unsigned> order(training.size());
     for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-    bool first = true;
     int report = 0;
     double lines = 0;
     int completed_epoch = -1;
@@ -265,7 +264,6 @@ int main(int argc, char** argv) {
       for (unsigned i = 0; i < report_every_i; ++i) {
         if (si == training.size()) {
           si = 0;
-          if (first) { first = false; }
           cerr << "**SHUFFLE\n";
           completed_epoch++;
           if (eta_decay_onset_epoch && completed_epoch >= (int)eta_decay_onset_epoch)

--- a/examples/cpp/segrnn-sup/train_segrnn-sup.cc
+++ b/examples/cpp/segrnn-sup/train_segrnn-sup.cc
@@ -1094,7 +1094,6 @@ int main(int argc, char** argv) {
     unsigned si = training.size();
     vector<unsigned> order(training.size());
     for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-    bool first = true;
     int report = 0;
     unsigned lines = 0;
     while(1) {
@@ -1105,7 +1104,6 @@ int main(int argc, char** argv) {
       for (unsigned i = 0; i < report_every_i; ++i) {
         if (si == training.size()) {
           si = 0;
-          if (first) { first = false; }
           cerr << "**SHUFFLE\n";
           shuffle(order.begin(), order.end(), *rndeng);
         }

--- a/examples/cpp/segrnn-sup/train_segrnn-sup.cc
+++ b/examples/cpp/segrnn-sup/train_segrnn-sup.cc
@@ -1105,7 +1105,7 @@ int main(int argc, char** argv) {
       for (unsigned i = 0; i < report_every_i; ++i) {
         if (si == training.size()) {
           si = 0;
-          if (first) { first = false; } else { sgd->update_epoch(); }
+          if (first) { first = false; }
           cerr << "**SHUFFLE\n";
           shuffle(order.begin(), order.end(), *rndeng);
         }

--- a/examples/cpp/skiprnnlm/train_skiprnnlm.cc
+++ b/examples/cpp/skiprnnlm/train_skiprnnlm.cc
@@ -143,7 +143,6 @@ int main(int argc, char** argv) {
     unsigned si = training.size();
     vector<unsigned> order(training.size());
     for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-    bool first = true;
     int report = 0;
     unsigned lines = 0;
     while(1) {
@@ -153,7 +152,6 @@ int main(int argc, char** argv) {
         for (unsigned i = 0; i < report_every_i; ++i) {
             if (si == training.size()) {
                 si = 0;
-                if (first) { first = false; }
                 LOG(INFO) << "**SHUFFLE\n";
                 shuffle(order.begin(), order.end(), *rndeng);
             }

--- a/examples/cpp/skiprnnlm/train_skiprnnlm.cc
+++ b/examples/cpp/skiprnnlm/train_skiprnnlm.cc
@@ -153,7 +153,7 @@ int main(int argc, char** argv) {
         for (unsigned i = 0; i < report_every_i; ++i) {
             if (si == training.size()) {
                 si = 0;
-                if (first) { first = false; } else { sgd->update_epoch(); }
+                if (first) { first = false; }
                 LOG(INFO) << "**SHUFFLE\n";
                 shuffle(order.begin(), order.end(), *rndeng);
             }

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -215,7 +215,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -204,7 +204,6 @@ int main(int argc, char** argv) {
   unsigned si = training.size();
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   int report = 0;
   unsigned lines = 0;
   while(1) {
@@ -215,7 +214,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -251,7 +251,6 @@ int main(int argc, char** argv) {
   unsigned si = training.size();
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   int report = 0;
   unsigned lines = 0;
   while(1) {
@@ -262,7 +261,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -262,7 +262,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/tok-embed/train_tok-embed.cc
+++ b/examples/cpp/tok-embed/train_tok-embed.cc
@@ -274,7 +274,7 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; } else { sgd->update_epoch(); }
+        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/tok-embed/train_tok-embed.cc
+++ b/examples/cpp/tok-embed/train_tok-embed.cc
@@ -261,7 +261,6 @@ int main(int argc, char** argv) {
   cerr << "Parameters allocated.\n";
   vector<unsigned> order(training.size());
   for (unsigned i = 0; i < order.size(); ++i) order[i] = i;
-  bool first = true;
   // int report = 0;
   unsigned lines = 0;
   unsigned report_every_i = 50;
@@ -274,7 +273,6 @@ int main(int argc, char** argv) {
     for (unsigned i = 0; i < report_every_i; ++i) {
       if (si == training.size()) {
         si = 0;
-        if (first) { first = false; }
         cerr << "**SHUFFLE\n";
         shuffle(order.begin(), order.end(), *rndeng);
       }

--- a/examples/cpp/xor-xent/train_xor-xent.cc
+++ b/examples/cpp/xor-xent/train_xor-xent.cc
@@ -60,7 +60,6 @@ int main(int argc, char** argv) {
       cg.backward(loss_expr);
       sgd.update();
     }
-    sgd.update_epoch();
     loss /= 4;
     cerr << "E = " << loss << endl;
   }


### PR DESCRIPTION
This PR removes the deprecated method call used in the examples.
The method was deprecated in #695.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/852)
<!-- Reviewable:end -->
