### PR TITLE
Use std::unique_ptr.

### DIFF
--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -107,9 +107,9 @@ void Node::autobatch_reshape_concatonly(const ComputationGraph & cg,
 
 ComputationGraph::ComputationGraph() {
   if(autobatch_flag) {
-    ee = new BatchedExecutionEngine(*this);
+    ee.reset(new BatchedExecutionEngine(*this));
   } else {
-    ee = new SimpleExecutionEngine(*this);
+    ee.reset(new SimpleExecutionEngine(*this));
   }
   if (n_hgs > 0) {
     cerr << "Memory allocator assumes only a single ComputationGraph at a time.\n";
@@ -124,9 +124,9 @@ ComputationGraph::ComputationGraph() {
 
 ComputationGraph::ComputationGraph(bool batched) {
   if(batched) {
-    ee = new BatchedExecutionEngine(*this);
+    ee.reset(new BatchedExecutionEngine(*this));
   } else {
-    ee = new SimpleExecutionEngine(*this);
+    ee.reset(new SimpleExecutionEngine(*this));
   }
   if (n_hgs > 0) {
     cerr << "Memory allocator assumes only a single ComputationGraph at a time.\n";
@@ -141,7 +141,6 @@ ComputationGraph::ComputationGraph(bool batched) {
 
 ComputationGraph::~ComputationGraph() {
   this->clear();
-  delete ee;
   --n_hgs;
 }
 

--- a/dynet/dynet.h
+++ b/dynet/dynet.h
@@ -8,6 +8,7 @@
 
 #include <initializer_list>
 #include <iostream>
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -478,7 +479,7 @@ struct ComputationGraph {
                                                // that can be updated (subset of
                                                // nodes)
 
-  ExecutionEngine* ee;  // handles the execution
+  std::unique_ptr<ExecutionEngine> ee;  // handles the execution
 
  private:
   unsigned graph_id;

--- a/dynet/io.cc
+++ b/dynet/io.cc
@@ -66,10 +66,7 @@ TextFileSaver::TextFileSaver(const std::string & filename, bool append) :
   datastream << std::scientific << std::showpos;
 }
 
-TextFileSaver::~TextFileSaver() {
-  delete p_datastream;
-  p_datastream = nullptr;
-}
+TextFileSaver::~TextFileSaver() {}
 
 void TextFileSaver::save(const ParameterCollection & model,
                          const std::string & key) {

--- a/dynet/io.h
+++ b/dynet/io.h
@@ -1,6 +1,7 @@
 #ifndef DYNET_IO_H_
 #define DYNET_IO_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 #include <sstream>
@@ -152,7 +153,7 @@ protected:
   void save(const ParameterStorage & param, const std::string & key = "");
   void save(const LookupParameterStorage & param, const std::string & key = "");
 
-  std::ostream* p_datastream;
+  std::unique_ptr<std::ostream> p_datastream;
   std::ostream& datastream;
 
 }; // class TextFileSaver

--- a/examples/cpp/embed-cl/train_embed-cl.cc
+++ b/examples/cpp/embed-cl/train_embed-cl.cc
@@ -135,11 +135,11 @@ int main(int argc, char** argv) {
   }
 
   bool use_momentum = false;
-  Trainer* sgd = nullptr;
+  std::unique_ptr<Trainer> sgd;
   if (use_momentum)
-    sgd = new MomentumSGDTrainer(model);
+    sgd.reset(new MomentumSGDTrainer(model));
   else
-    sgd = new SimpleSGDTrainer(model);
+    sgd.reset(new SimpleSGDTrainer(model));
 
   unsigned report_every_i = 100;
   unsigned si = training.size();
@@ -213,6 +213,4 @@ int main(int argc, char** argv) {
     }
 #endif
   }
-  delete sgd;
 }
-

--- a/examples/cpp/encdec/train_encdec.cc
+++ b/examples/cpp/encdec/train_encdec.cc
@@ -127,8 +127,7 @@ int main(int argc, char** argv) {
   // Initialize model and trainer ------------------------------------------------------------------
   ParameterCollection model;
   // Use Adam optimizer
-  Trainer* adam = nullptr;
-  adam = new AdamTrainer(model, 0.001, 0.9, 0.999, 1e-8);
+  std::unique_ptr<Trainer> adam(new AdamTrainer(model, 0.001, 0.9, 0.999, 1e-8));
   adam->clip_threshold *= params.BATCH_SIZE;
 
   // Create model
@@ -172,7 +171,7 @@ int main(int argc, char** argv) {
     double loss = 0;
     unsigned chars = 0;
     // Start timer
-    Timer* iteration = new Timer("completed in");
+    std::unique_ptr<Timer> iteration(new Timer("completed in"));
 
     for (si = 0; si < num_batches; ++si) {
       // build graph for this instance
@@ -196,8 +195,7 @@ int main(int argc, char** argv) {
         adam->status();
         cerr << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
         // Reinitialize timer
-        delete iteration;
-        iteration = new Timer("completed in");
+        iteration.reset(new Timer("completed in"));
         // Reinitialize loss
         loss = 0;
         chars = 0;
@@ -233,8 +231,7 @@ int main(int argc, char** argv) {
            << "] E = " << (dloss / dchars)
            << " ppl=" << exp(dloss / dchars) << ' ';
       // Reinitialize timer
-      delete iteration;
-      iteration = new Timer("completed in");
+      iteration.reset(new Timer("completed in"));
     }
 
 
@@ -268,6 +265,4 @@ int main(int argc, char** argv) {
     // Increment epoch
     ++epoch;
   }
-  // Free memory
-  delete adam;
 }

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -238,8 +238,7 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  Trainer* sgd = nullptr;
-  sgd = new AdamTrainer(model);
+  std::unique_ptr<Trainer> sgd(new AdamTrainer(model));
 
   DocumentModel engine(model);
 
@@ -309,5 +308,4 @@ int main(int argc, char** argv) {
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / (double)dtags) << ' ';
     }
   }
-  delete sgd;
 }

--- a/examples/cpp/mnist/train_mnist.cc
+++ b/examples/cpp/mnist/train_mnist.cc
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
     double num_samples = 0;
 
     // Start timer
-    Timer* iteration = new Timer("completed in");
+    std::unique_ptr<Timer> iteration(new Timer("completed in"));
 
     // Activate dropout
     nn.enable_dropout();
@@ -133,8 +133,7 @@ int main(int argc, char** argv) {
         adam.status();
         cerr << " E = " << (loss / num_samples) << ' ';
         // Reinitialize timer
-        delete iteration;
-        iteration = new Timer("completed in");
+        iteration.reset(new Timer("completed in"));
         // Reinitialize loss
         loss = 0;
         num_samples = 0;
@@ -168,8 +167,7 @@ int main(int argc, char** argv) {
       cerr << "\n***DEV [epoch=" << (epoch)
            << "] E = " << (dpos / (double) mnist_dev.size()) << ' ';
       // Reinitialize timer
-      delete iteration;
-      iteration = new Timer("completed in");
+      iteration.reset(new Timer("completed in"));
     }
 
     // Increment epoch

--- a/examples/cpp/poisson-regression/train_poisson-regression.cc
+++ b/examples/cpp/poisson-regression/train_poisson-regression.cc
@@ -135,8 +135,7 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  Trainer* sgd = nullptr;
-  sgd = new SimpleSGDTrainer(model);
+  std::unique_ptr<Trainer> sgd(new SimpleSGDTrainer(model));
 
   RNNLengthPredictor<LSTMBuilder> lm(model);
   if (argc == 4) {
@@ -197,6 +196,4 @@ int main(int argc, char** argv) {
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
     }
   }
-  delete sgd;
 }
-

--- a/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
+++ b/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
@@ -176,12 +176,12 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  Trainer* sgd = nullptr;
+  std::unique_ptr<Trainer> sgd;
   // bool use_momentum = false;
   // if (use_momentum)
   //   sgd = new MomentumSGDTrainer(model);
   // else
-  sgd = new SimpleSGDTrainer(model);
+  sgd.reset(new SimpleSGDTrainer(model));
 
   RNNLanguageModel<GRUBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
@@ -245,6 +245,4 @@ int main(int argc, char** argv) {
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
     }
   }
-  delete sgd;
 }
-

--- a/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
+++ b/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
@@ -122,7 +122,7 @@ int main(int argc, char** argv) {
   // Initialize model and trainer ------------------------------------------------------------------
   ParameterCollection model;
   // Use Adam optimizer
-  Trainer* adam = new AdamTrainer(model, 0.001, 0.9, 0.999, 1e-8);
+  std::unique_ptr<Trainer> adam(new AdamTrainer(model, 0.001, 0.9, 0.999, 1e-8));
   adam->clip_threshold *= params.BATCH_SIZE;
 
   // Create model
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
     double loss = 0;
     unsigned tokens = 0;
     // Start timer
-    Timer* iteration = new Timer("completed in");
+    std::unique_ptr<Timer> iteration(new Timer("completed in"));
 
     for (si = 0; si < num_batches; ++si) {
       // build graph for this instance
@@ -190,8 +190,7 @@ int main(int argc, char** argv) {
         adam->status();
         cerr << " E = " << (loss / tokens) << " ppl=" << exp(loss / tokens) << ' ';
         // Reinitialize timer
-        delete iteration;
-        iteration = new Timer("completed in");
+        iteration.reset(new Timer("completed in"));
         // Reinitialize loss
         loss = 0;
         tokens = 0;
@@ -225,8 +224,7 @@ int main(int argc, char** argv) {
            << "] E = " << (dloss / dtokens)
            << " ppl=" << exp(dloss / dtokens) << ' ';
       // Reinitialize timer
-      delete iteration;
-      iteration = new Timer("completed in");
+      iteration.reset(new Timer("completed in"));
     }
 
     // Sample some examples because it's cool (also helps debugging)
@@ -237,5 +235,4 @@ int main(int argc, char** argv) {
     // Increment epoch
     ++epoch;
   }
-  delete adam;
 }

--- a/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
+++ b/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
@@ -139,12 +139,12 @@ int main(int argc, char** argv) {
   cerr << "Parameters will be written to: " << fname << endl;
   double best = 9e+99;
 
-  Trainer* sgd = nullptr;
+  std::unique_ptr<Trainer> sgd;
   // bool use_momentum = false;
   // if (use_momentum)
   //   sgd = new MomentumSGDTrainer(model);
   // else
-  sgd = new SimpleSGDTrainer(model);
+  sgd.reset(new SimpleSGDTrainer(model));
 
   RNNLanguageModel<LSTMBuilder> lm(model, cfsm);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model, cfsm);
@@ -211,6 +211,4 @@ int main(int argc, char** argv) {
     }
 #endif
   }
-  delete sgd;
 }
-

--- a/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
+++ b/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
@@ -194,8 +194,7 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  Trainer* sgd = nullptr;
-  sgd = new SimpleSGDTrainer(model);
+  std::unique_ptr<Trainer> sgd(new SimpleSGDTrainer(model));
   sgd->clip_threshold *= BATCH_SIZE;
 
   RNNLanguageModel<LSTMBuilder> lm(model);
@@ -254,5 +253,4 @@ int main(int argc, char** argv) {
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
     }
   }
-  delete sgd;
 }

--- a/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
+++ b/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
@@ -161,11 +161,11 @@ int main(int argc, char** argv) {
 
   ParameterCollection model;
   bool use_momentum = false;
-  Trainer* sgd = nullptr;
+  std::unique_ptr<Trainer> sgd;
   //if (use_momentum)
   //else
   //sgd = new SimpleSGDTrainer(model);
-  sgd = new MomentumSGDTrainer(model);
+  sgd.reset(new MomentumSGDTrainer(model));
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
   if (argc == 4) {
@@ -244,6 +244,4 @@ int main(int argc, char** argv) {
     }
 #endif
   }
-  delete sgd;
 }
-

--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -201,7 +201,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  Trainer* sgd = new SimpleSGDTrainer(model);
+  std::unique_ptr<Trainer> sgd(new SimpleSGDTrainer(model));
   sgd->learning_rate = params.eta0;
   RNNLanguageModel<LSTMBuilder> lm(model);
 
@@ -369,6 +369,4 @@ int main(int argc, char** argv) {
       cout << endl;
     }
   }
-
-  delete sgd;
 }

--- a/examples/cpp/segrnn-sup/train_segrnn-sup.cc
+++ b/examples/cpp/segrnn-sup/train_segrnn-sup.cc
@@ -1074,7 +1074,7 @@ int main(int argc, char** argv) {
 
     ParameterCollection model;
     // auto sgd = new SimpleSGDTrainer(model);
-    std::uniqu_ptr<Trainer> sgd(new AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8));
+    std::unique_ptr<Trainer> sgd(new AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8));
     int max_seg_len = DATA_MAX_SEG_LEN + 1;
     if(vm.count("train_max_seg_len")){
       max_seg_len = vm["train_max_seg_len"].as<int>();

--- a/examples/cpp/segrnn-sup/train_segrnn-sup.cc
+++ b/examples/cpp/segrnn-sup/train_segrnn-sup.cc
@@ -1074,7 +1074,7 @@ int main(int argc, char** argv) {
 
     ParameterCollection model;
     // auto sgd = new SimpleSGDTrainer(model);
-    auto sgd = new AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8);
+    std::uniqu_ptr<Trainer> sgd(new AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8));
     int max_seg_len = DATA_MAX_SEG_LEN + 1;
     if(vm.count("train_max_seg_len")){
       max_seg_len = vm["train_max_seg_len"].as<int>();
@@ -1156,7 +1156,6 @@ int main(int argc, char** argv) {
         }
       }
     }
-    delete sgd;
   }else if(vm["test"].as<bool>()){
     use_pretrained_embeding = false;
     use_dropout = false;

--- a/examples/cpp/skiprnnlm/train_skiprnnlm.cc
+++ b/examples/cpp/skiprnnlm/train_skiprnnlm.cc
@@ -126,16 +126,16 @@ int main(int argc, char** argv) {
 
     ParameterCollection model;
     bool use_momentum = false;
-    Trainer* sgd = nullptr;
+    std::unique_ptr<Trainer> sgd;
     if (use_momentum)
-        sgd = new MomentumSGDTrainer(model);
+        sgd.reset(new MomentumSGDTrainer(model));
     else
-        sgd = new SimpleSGDTrainer(model);
+        sgd.reset(new SimpleSGDTrainer(model));
 
     RNNSkipLM lm(model);
     if (argc == 4) {
         TextfileLoader loader(argv[3]);
-        loader.populate(model);'
+        loader.populate(model);
     }
 
     unsigned report_every_i = 50;
@@ -197,7 +197,6 @@ int main(int argc, char** argv) {
             LOG(INFO) << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dchars) << " ppl=" << exp(dloss / dchars) << ' ';
         }
     }
-    delete sgd;
 }
 
 void read_documents(const std::string &filename, Corpus &corpus) {

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -186,11 +186,11 @@ int main(int argc, char** argv) {
 
   ParameterCollection model;
   bool use_momentum = true;
-  Trainer* sgd = nullptr;
+  std::unique_ptr<Trainer> sgd;
   if (use_momentum)
-    sgd = new MomentumSGDTrainer(model);
+    sgd.reset(new MomentumSGDTrainer(model));
   else
-    sgd = new SimpleSGDTrainer(model);
+    sgd.reset(new SimpleSGDTrainer(model));
 
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
@@ -258,5 +258,4 @@ int main(int argc, char** argv) {
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / dtags) << ' ';
     }
   }
-  delete sgd;
 }

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -233,9 +233,8 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  Trainer* sgd = nullptr;
   //sgd = new MomentumSGDTrainer(model);
-  sgd = new AdagradTrainer(model);
+  std::unique_ptr<Trainer> sgd(new AdagradTrainer(model));
   //sgd = new SimpleSGDTrainer(model);
 
   //NeuralBagOfWords nbow(model);
@@ -315,6 +314,4 @@ int main(int argc, char** argv) {
       cerr << "\n***DEV [epoch=" << (lines / (double)training.size()) << "] E = " << (dloss / dtags) << " ppl=" << exp(dloss / dtags) << " acc=" << (dcorr / (double)dtags) << ' ';
     }
   }
-  delete sgd;
 }
-

--- a/examples/cpp/tok-embed/train_tok-embed.cc
+++ b/examples/cpp/tok-embed/train_tok-embed.cc
@@ -223,8 +223,7 @@ int main(int argc, char** argv) {
     return 1;
   }
   ParameterCollection model;
-  Trainer* sgd = nullptr;
-  sgd = new SimpleSGDTrainer(model);
+  std::unique_ptr<Trainer> sgd(new SimpleSGDTrainer(model));
   vector<pair<string,vector<unsigned>>> training;
   kSOW = d.convert("<w>");
   kEOW = d.convert("</w>");
@@ -294,6 +293,4 @@ int main(int argc, char** argv) {
     sgd->status();
     cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / ttags) << ") ";
   }
-  delete sgd;
 }
-


### PR DESCRIPTION
This PR takes advantage of std::unique_ptr added in C++11.  Given that
dynet uses C++11, we can take advantage of the feature for RAII if
applicable.

For the code of dynet library, it would be helpful to clarify the
ownership of objects. In particular, it is useful for debugging or avoiding memory
related bugs such as memory leaks, use-after-free.

For the code in examples, we can remove the code to manually delete
objects allocated by new, using std::unique_ptr.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/853)
<!-- Reviewable:end -->
