### PR TITLE
Reduce global non-POD objects by adding DeviceManager class

### DIFF
--- a/dynet/cuda.cc
+++ b/dynet/cuda.cc
@@ -80,7 +80,6 @@ vector<Device*> initialize_gpu(DynetParams& params) {
   for (int i = 0; i < params.requested_gpus; ++i) {
     cerr << ' ' << gpus[i];
     Device* d = new Device_GPU(gpudevices.size(), params.mem_descriptor, gpus[i]);
-    dynet::devices_map[d->name] = d;
     gpudevices.push_back(d);
   }
   cerr << endl;

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -134,12 +134,35 @@ Device_CPU::Device_CPU(int my_id, const DeviceMempoolSizes & mbs, bool shared) :
 
 Device_CPU::~Device_CPU() {}
 
-Device* get_global_device(const std::string & name) {
-  auto it = dynet::devices_map.find(name);
-  if (it == dynet::devices_map.end()) {
+
+DeviceManager::DeviceManager() {}
+
+DeviceManager::~DeviceManager() {
+  // TODO: Devices cannot be deleted at the moment because the destructor
+  // is protected
+  // for(Device* device : devices) delete device;
+  devices.clear();
+}
+
+void DeviceManager::add(Device* d) {
+    devices.push_back(d);
+    devices_map[d->name] = d;
+}
+
+Device* DeviceManager::get_global_device(const std::string & name) {
+  auto it = devices_map.find(name);
+  if (it == devices_map.end()) {
     throw std::runtime_error("Invalid device name: " + name);
   }
   return it->second;
+}
+
+DeviceManager* get_device_manager() {
+  // In C++11, initialization of function local static objects is
+  // thread safe.
+  // See https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use
+  static auto device_manager = new DeviceManager;
+  return device_manager;
 }
 
 } // namespace dynet

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -138,6 +138,10 @@ Device_CPU::~Device_CPU() {}
 DeviceManager::DeviceManager() {}
 
 DeviceManager::~DeviceManager() {
+  clear();
+}
+
+void DeviceManager::clear() {
   // TODO: Devices cannot be deleted at the moment because the destructor
   // is protected
   // for(Device* device : devices) delete device;

--- a/dynet/devices.h
+++ b/dynet/devices.h
@@ -89,7 +89,7 @@ class DeviceManager final {
 
   size_t num_devices() const { return devices.size(); }
 
-  std::vector<Device*>& get_devices() { return devices; }
+  const std::vector<Device*>& get_devices() const { return devices; }
 
   Device* get_global_device(const std::string & name);
 

--- a/dynet/devices.h
+++ b/dynet/devices.h
@@ -83,6 +83,8 @@ class DeviceManager final {
   DeviceManager();
   ~DeviceManager();
 
+  void clear();
+
   void add(Device* d);
 
   Device* get(size_t i) { return devices[i]; }

--- a/dynet/devices.h
+++ b/dynet/devices.h
@@ -1,6 +1,7 @@
 #ifndef DYNET_DEVICES_H
 #define DYNET_DEVICES_H
 
+#include <unordered_map>
 #include <string>
 #include <exception>
 #include "dynet/aligned-mem-pool.h"
@@ -77,7 +78,31 @@ class Device_CPU : public Device {
   MemAllocator* shmem;
 };
 
-Device* get_global_device(const std::string & name);
+class DeviceManager final {
+ public:
+  DeviceManager();
+  ~DeviceManager();
+
+  void add(Device* d);
+
+  Device* get(size_t i) { return devices[i]; }
+
+  size_t num_devices() const { return devices.size(); }
+
+  std::vector<Device*>& get_devices() { return devices; }
+
+  Device* get_global_device(const std::string & name);
+
+  // no copying allowed
+  DeviceManager(const DeviceManager &) = delete;
+  void operator=(const DeviceManager &) = delete;
+
+ private:
+  std::vector<Device*> devices;
+  std::unordered_map<std::string, Device*> devices_map;
+};
+
+DeviceManager* get_device_manager();
 
 } // namespace dynet
 

--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -139,7 +139,7 @@ void SimpleExecutionEngine::backward(VariableIndex from_where, bool full) {
 
   const unsigned num_nodes = from_where+1;
   ndEdfs.resize(num_nodes);
-  vector<Device*> &devices = device_manager->get_devices();
+  const vector<Device*> &devices = device_manager->get_devices();
   for(Device* device : devices)
     device->pools[(int)DeviceMempool::DEDFS]->free();
   for (unsigned i = 0; i < num_nodes; ++i) {

--- a/dynet/exec.h
+++ b/dynet/exec.h
@@ -5,6 +5,8 @@
 
 namespace dynet {
 
+class DeviceManager;
+
 class ExecutionEngine {
  public:
   virtual ~ExecutionEngine();
@@ -20,7 +22,8 @@ class ExecutionEngine {
   virtual void backward(bool full = false) = 0;
   virtual void backward(VariableIndex i, bool full = false) = 0;
  protected:
-  explicit ExecutionEngine(const ComputationGraph& cg) : cg(cg), backward_computed(0) {}
+  explicit ExecutionEngine(const ComputationGraph& cg);
+  DeviceManager* const device_manager;
   const ComputationGraph& cg;
   VariableIndex backward_computed;
 };

--- a/dynet/globals.cc
+++ b/dynet/globals.cc
@@ -5,8 +5,6 @@
 namespace dynet {
 
 std::mt19937* rndeng = nullptr;
-std::vector<Device*> devices;
-std::unordered_map<std::string, Device*> devices_map;
 Device* default_device = nullptr;
 float weight_decay_lambda;
 int autobatch_flag; 

--- a/dynet/globals.h
+++ b/dynet/globals.h
@@ -2,9 +2,6 @@
 #define DYNET_GLOBALS_H
 
 #include <random>
-#include <vector>
-#include <string>
-#include <unordered_map>
 
 namespace dynet {
 
@@ -12,8 +9,6 @@ class Device;
 class NamedTimer;
 
 extern std::mt19937* rndeng;
-extern std::vector<Device*> devices;
-extern std::unordered_map<std::string, Device*> devices_map;
 extern Device* default_device;
 extern NamedTimer timer; // debug timing in executors.
 

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -235,6 +235,7 @@ void initialize(int& argc, char**& argv, bool shared_parameters) {
 
 void cleanup() {
   delete rndeng;
+  get_device_manager()->clear();
   default_device = nullptr;
 }
 

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -210,14 +210,9 @@ void initialize(DynetParams& params) {
   // Allocate memory
   cerr << "[dynet] allocating memory: " << params.mem_descriptor << "MB\n";
   int default_index = 0;
-  if (gpudevices.size() > 0) {
-    Device *d = new Device_CPU(device_manager->num_devices(), params.mem_descriptor, params.shared_parameters);
-    device_manager->add(d);
-  } else {
-    Device *d = new Device_CPU(device_manager->num_devices(), params.mem_descriptor,
-                               params.shared_parameters);
-    device_manager->add(d);
-  }
+
+  Device *d = new Device_CPU(device_manager->num_devices(), params.mem_descriptor, params.shared_parameters);
+  device_manager->add(d);
   default_device = device_manager->get(default_index);
 
   // TODO these should be accessed through the relevant device and removed here

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -242,14 +242,15 @@ float LookupParameter::current_weight_decay() const {
   return get_storage().owner->get_weight_decay().current_weight_decay();
 }
 
-ParameterCollectionStorage::ParameterCollectionStorage() : gradient_norm_scratch(nullptr) {
+ParameterCollectionStorage::ParameterCollectionStorage()
+    : gradient_norm_scratch(nullptr), device_manager(get_device_manager()) {
   weight_decay.set_lambda(weight_decay_lambda);
 }
 
 ParameterCollectionStorage::~ParameterCollectionStorage() {
   for (auto p : all_params) delete p;
   if (gradient_norm_scratch)
-    dynet::get_global_device("CPU")->mem->free(gradient_norm_scratch);
+    device_manager->get_global_device("CPU")->mem->free(gradient_norm_scratch);
 }
 
 void ParameterCollectionStorage::project_weights(float radius) {
@@ -817,7 +818,7 @@ template float ParameterCollectionStorage::gradient_l2_norm_dev<Device_GPU>(Devi
 extern template float ParameterCollectionStorage::gradient_l2_norm_dev<Device_GPU>(Device_GPU & dev) const;
 template float ParameterCollectionStorage::gradient_l2_norm_dev<Device_CPU>(Device_CPU & dev) const;
 float ParameterCollectionStorage::gradient_l2_norm() const {
-  if (default_device->type == DeviceType::CPU || default_device->type == DeviceType::GPU) { return gradient_l2_norm_dev(*(Device_CPU*)dynet::get_global_device("CPU")); }
+  if (default_device->type == DeviceType::CPU || default_device->type == DeviceType::GPU) { return gradient_l2_norm_dev(*(Device_CPU*)device_manager->get_global_device("CPU")); }
   else { throw std::runtime_error("Bad device type"); }
 }
 float ParameterCollection::gradient_l2_norm() const {
@@ -826,7 +827,7 @@ float ParameterCollection::gradient_l2_norm() const {
 #else
 template float ParameterCollectionStorage::gradient_l2_norm_dev<Device_CPU>(Device_CPU & dev) const;
 float ParameterCollectionStorage::gradient_l2_norm() const {
-  if (default_device->type == DeviceType::CPU) { return gradient_l2_norm_dev(*(Device_CPU*)dynet::get_global_device("CPU")); }
+  if (default_device->type == DeviceType::CPU) { return gradient_l2_norm_dev(*(Device_CPU*)device_manager->get_global_device("CPU")); }
   else { throw std::runtime_error("Bad device type"); }
 }
 float ParameterCollection::gradient_l2_norm() const {

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -27,6 +27,7 @@ namespace dynet {
 // * LookupParameters represents a table of vectors that are used to embed a
 //   set of discrete objects. These are sparsely updated.
 
+class DeviceManager;
 class ParameterCollection;
 struct ParameterInit;
 
@@ -454,6 +455,9 @@ struct ParameterCollectionStorage {
 
   mutable float* gradient_norm_scratch;
   L2WeightDecay weight_decay;
+
+ private:
+  DeviceManager* const device_manager;
 };
 
 // this is a collection of parameters

--- a/examples/cpp/xor-multidevice/train_xor-multidevice.cc
+++ b/examples/cpp/xor-multidevice/train_xor-multidevice.cc
@@ -18,8 +18,8 @@ int main(int argc, char** argv) {
   SimpleSGDTrainer sgd(m);
 
   // Get two devices, the CPU device and GPU device
-  Device* cpu_device = get_global_device("CPU");
-  Device* gpu_device = get_global_device("GPU:0");
+  Device* cpu_device = get_device_manager()->get_global_device("CPU");
+  Device* gpu_device = get_device_manager()->get_global_device("GPU:0");
 
   const unsigned HIDDEN_SIZE = 8;
   Parameter p_W = m.add_parameters({HIDDEN_SIZE, 2}, gpu_device);


### PR DESCRIPTION
This attempts to remove global non-POD objects (devices, devices_map) by
adding DeviceManager class. Using global non-POD objects can trigger nasty bugs.
In general, it is very hard to reproduce and debug. I think it is a good practice to reduce the use of non-POD objects in global scope.

The idea is simple. 
- Move devices and devices_map move to private members of DeviceManager class. The class provides the access to the variables. 
- get_device_manager is used to get the unique manager object
- Initialization of the manager object is done when get_device_manager is called for the first time (this initialization is thread safe since C++11)

I'm not sure the destructor of Device class is declared as protected instead of public.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/857)
<!-- Reviewable:end -->
