### PR TITLE
Use ParameterCollection instead of deprecated Model class

### DIFF
--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -154,7 +154,7 @@ int main(int argc, char** argv) {
   SAMPLE = params.sample;
   if (params.dropout_rate)
     DROPOUT = params.dropout_rate;
-  Model model;
+  ParameterCollection model;
   if (params.clusters_file != "")
     cfsm = new ClassFactoredSoftmaxBuilder(HIDDEN_DIM, params.clusters_file, d, model);
   else if (params.paths_file != "")


### PR DESCRIPTION
This PR removes the use of deprecated Model class in the example of RNN LM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/858)
<!-- Reviewable:end -->
