### PR TITLE
Compare the return value of mmap with MAP_FAILED

### DIFF
--- a/dynet/mem.cc
+++ b/dynet/mem.cc
@@ -48,7 +48,7 @@ void* SharedAllocator::malloc(size_t n) {
   throw dynet::out_of_memory("Shared memory allocation failed");
 #else
   void* ptr = mmap(NULL, n, PROT_READ|PROT_WRITE, MAP_ANON|MAP_SHARED, -1, 0);
-  if (!ptr) {
+  if (ptr == MAP_FAILED) {
     cerr << "Shared memory allocation failed n=" << n << endl;
     throw dynet::out_of_memory("Shared memory allocation failed");
   }


### PR DESCRIPTION
On errors, mmap returns MAP_FAILED as documented in `man mmap`.
We should check whether the return address is MAP_FAILED, instead of NULL.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/859)
<!-- Reviewable:end -->
