### PR TITLE
examples/cpp: Use appropriate naming based on the type of training algorithms

### DIFF
--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -238,7 +238,7 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  std::unique_ptr<Trainer> sgd(new AdamTrainer(model));
+  std::unique_ptr<Trainer> adam(new AdamTrainer(model));
 
   DocumentModel engine(model);
 
@@ -279,11 +279,11 @@ int main(int argc, char** argv) {
       Expression loss_expr = engine.objective(cg, inst, logits);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update();
+      adam->update();
       ++lines;
       ++ttags;
     }
-    sgd->status();
+    adam->status();
     cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / (double)ttags) << ") ";
     model.project_weights();
 

--- a/examples/cpp/segrnn-sup/train_segrnn-sup.cc
+++ b/examples/cpp/segrnn-sup/train_segrnn-sup.cc
@@ -1074,7 +1074,7 @@ int main(int argc, char** argv) {
 
     ParameterCollection model;
     // auto sgd = new SimpleSGDTrainer(model);
-    std::unique_ptr<Trainer> sgd(new AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8));
+    std::unique_ptr<Trainer> adam(new AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8));
     int max_seg_len = DATA_MAX_SEG_LEN + 1;
     if(vm.count("train_max_seg_len")){
       max_seg_len = vm["train_max_seg_len"].as<int>();
@@ -1136,11 +1136,11 @@ int main(int argc, char** argv) {
           ttags += sent.second.size();
           loss += as_scalar(cg.forward(loss_expr));
           cg.backward(loss_expr);
-          sgd->update(1.0);
+          adam->update(1.0);
         }
         ++lines;
       }
-      sgd->status();
+      adam->status();
       cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / ttags) << ") ";
       report++;
       if (report % dev_every_i_reports == 0) {

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -234,7 +234,7 @@ int main(int argc, char** argv) {
 
   ParameterCollection model;
   //sgd = new MomentumSGDTrainer(model);
-  std::unique_ptr<Trainer> sgd(new AdagradTrainer(model));
+  std::unique_ptr<Trainer> adagrad(new AdagradTrainer(model));
   //sgd = new SimpleSGDTrainer(model);
 
   //NeuralBagOfWords nbow(model);
@@ -276,11 +276,11 @@ int main(int argc, char** argv) {
       Expression loss_expr = HingeLoss(y_pred, y);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update(2.0);
+      adagrad->update(2.0);
       ++lines;
       ++ttags;
     }
-    sgd->status();
+    adagrad->status();
     cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / (double)ttags) << ") ";
     model.project_weights();
 


### PR DESCRIPTION
This PR fixes the names of the variables used in C++ examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/864)
<!-- Reviewable:end -->
