### PR TITLE
Use consistently 'trainer' as the variable name of Trainer objects

### DIFF
--- a/doc/source/cpp_basic_tutorial.rst
+++ b/doc/source/cpp_basic_tutorial.rst
@@ -11,7 +11,7 @@ Create a parameter collection, and an SGD trainer to update its parameters.
 .. code:: cpp
 
     ParameterCollection pc;
-    SimpleSGDTrainer sgd(pc);
+    SimpleSGDTrainer trainer(pc);
 
 Create a "computation graph," which will define the flow of information.
 
@@ -71,11 +71,11 @@ Now, we perform a parameter update for a single example. Set the input/output to
 
     cg.backward(l);
 
-``sgd.update`` updates parameters of the parameter collection that was passed to its constructor. Here 1.0 is the scaling factor that allows us to control the size of the update.
+``trainer.update`` updates parameters of the parameter collection that was passed to its constructor. Here 1.0 is the scaling factor that allows us to control the size of the update.
 
 .. code:: cpp
 
-    sgd.update(1.0);
+    trainer.update(1.0);
 
 Note that this very simple example that doesn't cover things like memory
 initialization, reading/writing parameter collections, recurrent/LSTM networks, or

--- a/examples/cpp/embed-cl/train_embed-cl.cc
+++ b/examples/cpp/embed-cl/train_embed-cl.cc
@@ -135,11 +135,11 @@ int main(int argc, char** argv) {
   }
 
   bool use_momentum = false;
-  std::unique_ptr<Trainer> sgd;
+  std::unique_ptr<Trainer> trainer;
   if (use_momentum)
-    sgd.reset(new MomentumSGDTrainer(model));
+    trainer.reset(new MomentumSGDTrainer(model));
   else
-    sgd.reset(new SimpleSGDTrainer(model));
+    trainer.reset(new SimpleSGDTrainer(model));
 
   unsigned report_every_i = 100;
   unsigned si = training.size();
@@ -180,11 +180,11 @@ int main(int argc, char** argv) {
       if (iloss > 0) {
         loss += iloss;
         cg.backward(l);
-        sgd->update();
+        trainer->update();
       }
       ++lines;
     }
-    sgd->status();
+    trainer->status();
     cerr << " E = " << (loss) << " ppl=" << exp(loss / chars) << ' ';
 
 #if 0

--- a/examples/cpp/encdec/train_encdec.cc
+++ b/examples/cpp/encdec/train_encdec.cc
@@ -127,8 +127,8 @@ int main(int argc, char** argv) {
   // Initialize model and trainer ------------------------------------------------------------------
   ParameterCollection model;
   // Use Adam optimizer
-  std::unique_ptr<Trainer> adam(new AdamTrainer(model, 0.001, 0.9, 0.999, 1e-8));
-  adam->clip_threshold *= params.BATCH_SIZE;
+  std::unique_ptr<Trainer> trainer(new AdamTrainer(model, 0.001, 0.9, 0.999, 1e-8));
+  trainer->clip_threshold *= params.BATCH_SIZE;
 
   // Create model
   EncoderDecoder<LSTMBuilder> lm(model,
@@ -185,11 +185,11 @@ int main(int argc, char** argv) {
       // Compute gradient with backward pass
       cg.backward(loss_expr);
       // Update parameters
-      adam->update();
+      trainer->update();
       // Print progress every tenth of the dataset
       if ((si + 1) % (num_batches / 10) == 0 || si == num_batches - 1) {
         // Print informations
-        adam->status();
+        trainer->status();
         cerr << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
         // Reinitialize timer
         iteration.reset(new Timer("completed in"));

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -238,7 +238,7 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  std::unique_ptr<Trainer> adam(new AdamTrainer(model));
+  std::unique_ptr<Trainer> trainer(new AdamTrainer(model));
 
   DocumentModel engine(model);
 
@@ -279,11 +279,11 @@ int main(int argc, char** argv) {
       Expression loss_expr = engine.objective(cg, inst, logits);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      adam->update();
+      trainer->update();
       ++lines;
       ++ttags;
     }
-    adam->status();
+    trainer->status();
     cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / (double)ttags) << ") ";
     model.project_weights();
 

--- a/examples/cpp/mlc/train_mlc.cc
+++ b/examples/cpp/mlc/train_mlc.cc
@@ -128,9 +128,9 @@ int main(int argc, char** argv) {
   ParameterCollection m;
   MLCBuilder mlc(m, max_xi, max_yi);
 
-  //AdadeltaTrainer sgd(m);
-  SimpleSGDTrainer sgd(m);
-  sgd.learning_rate = 0.001;
+  //AdadeltaTrainer trainer(m);
+  SimpleSGDTrainer trainer(m);
+  trainer.learning_rate = 0.001;
 
   unsigned report_every_i = 50;
   unsigned si = train.size();
@@ -168,7 +168,7 @@ int main(int argc, char** argv) {
       Expression loss_expr = sparsemax_loss(u, &xy.labels);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd.update();
+      trainer.update();
     }
     cerr << "[epoch=" << (ti / train.size()) << "] E=" << (loss / instances) << ' ';
   }

--- a/examples/cpp/mnist/train_mnist.cc
+++ b/examples/cpp/mnist/train_mnist.cc
@@ -51,8 +51,8 @@ int main(int argc, char** argv) {
 
   ParameterCollection model;
   // Use Adam optimizer
-  AdamTrainer adam(model);
-  adam.clip_threshold *= params.BATCH_SIZE;
+  AdamTrainer trainer(model);
+  trainer.clip_threshold *= params.BATCH_SIZE;
 
   // Create model
   MLP nn(model, vector<Layer>({
@@ -123,11 +123,11 @@ int main(int argc, char** argv) {
       // Compute gradient with backward pass
       cg.backward(loss_expr);
       // Update parameters
-      adam.update();
+      trainer.update();
       // Print progress every tenth of the dataset
       if ((si + 1) % (num_batches / 10) == 0 || si == num_batches - 1) {
         // Print informations
-        adam.status();
+        trainer.status();
         cerr << " E = " << (loss / num_samples) << ' ';
         // Reinitialize timer
         iteration.reset(new Timer("completed in"));

--- a/examples/cpp/nlm/train_nlm.cc
+++ b/examples/cpp/nlm/train_nlm.cc
@@ -21,7 +21,7 @@ int main(int argc, char** argv) {
 
   // parameters
   ParameterCollection model;
-  SimpleSGDTrainer sgd(model);
+  SimpleSGDTrainer trainer(model);
   LookupParameter p_c = model.add_lookup_parameters(VOCAB_SIZE, {DIM});
 
   ComputationGraph cg;
@@ -75,7 +75,7 @@ int main(int argc, char** argv) {
       loss += as_scalar(cg.forward(nerr));
       cg.backward(nerr);
       ++n;
-      sgd.update();
+      trainer.update();
       if (n == 2500) break;
     }
     loss /= n;

--- a/examples/cpp/poisson-regression/train_poisson-regression.cc
+++ b/examples/cpp/poisson-regression/train_poisson-regression.cc
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  std::unique_ptr<Trainer> sgd(new SimpleSGDTrainer(model));
+  std::unique_ptr<Trainer> trainer(new SimpleSGDTrainer(model));
 
   RNNLengthPredictor<LSTMBuilder> lm(model);
   if (argc == 4) {
@@ -168,11 +168,11 @@ int main(int argc, char** argv) {
       Expression loss_expr = lm.BuildLMGraph(sent.first, sent.second, cg);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update();
+      trainer->update();
       ++lines;
       ++chars;
     }
-    sgd->status();
+    trainer->status();
     cerr << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
 
     // show score on dev data?

--- a/examples/cpp/read-write/train_read-write.cc
+++ b/examples/cpp/read-write/train_read-write.cc
@@ -45,7 +45,7 @@ public:
     a = parameter(cg, pa);
   }
 
-  float Train(const vector<dynet::real>& input, dynet::real gold_output, SimpleSGDTrainer& sgd) {
+  float Train(const vector<dynet::real>& input, dynet::real gold_output, SimpleSGDTrainer& trainer) {
     ComputationGraph cg;
     NewGraph(cg);
 
@@ -58,7 +58,7 @@ public:
 
     float return_loss = as_scalar(cg.forward(loss));
     cg.backward(loss);
-    sgd.update();
+    trainer.update();
     return return_loss;
   }
 
@@ -89,7 +89,7 @@ int main(int argc, char** argv) {
   const unsigned HIDDEN = 8;
   const unsigned ITERATIONS = 20;
   ParameterCollection m;
-  SimpleSGDTrainer sgd(m);
+  SimpleSGDTrainer trainer(m);
   XORModel model(HIDDEN, m);
 
   vector<dynet::real> x_values(2);  // set x_values to change the inputs
@@ -104,7 +104,7 @@ int main(int argc, char** argv) {
       x_values[0] = x1 ? 1 : -1;
       x_values[1] = x2 ? 1 : -1;
       y_value = (x1 != x2) ? 1 : -1;
-      loss += model.Train(x_values, y_value, sgd);
+      loss += model.Train(x_values, y_value, trainer);
     }
     loss /= 4;
     cerr << "E = " << loss << endl;

--- a/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
+++ b/examples/cpp/rnnlm-aevb/train_rnnlm-aevb.cc
@@ -176,12 +176,12 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  std::unique_ptr<Trainer> sgd;
+  std::unique_ptr<Trainer> trainer;
   // bool use_momentum = false;
   // if (use_momentum)
-  //   sgd = new MomentumSGDTrainer(model);
+  //   trainer = new MomentumSGDTrainer(model);
   // else
-  sgd.reset(new SimpleSGDTrainer(model));
+  trainer.reset(new SimpleSGDTrainer(model));
 
   RNNLanguageModel<GRUBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
@@ -217,10 +217,10 @@ int main(int argc, char** argv) {
       Expression loss_expr = lm.BuildLMGraph(sent, cg);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update();
+      trainer->update();
       ++lines;
     }
-    sgd->status();
+    trainer->status();
     cerr << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
 
     // show score on dev data?

--- a/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
+++ b/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
@@ -122,8 +122,8 @@ int main(int argc, char** argv) {
   // Initialize model and trainer ------------------------------------------------------------------
   ParameterCollection model;
   // Use Adam optimizer
-  std::unique_ptr<Trainer> adam(new AdamTrainer(model, 0.001, 0.9, 0.999, 1e-8));
-  adam->clip_threshold *= params.BATCH_SIZE;
+  std::unique_ptr<Trainer> trainer(new AdamTrainer(model, 0.001, 0.9, 0.999, 1e-8));
+  trainer->clip_threshold *= params.BATCH_SIZE;
 
   // Create model
   RNNBatchLanguageModel<LSTMBuilder> lm(model,
@@ -180,11 +180,11 @@ int main(int argc, char** argv) {
       // Compute gradient with backward pass
       cg.backward(loss_expr);
       // Update parameters
-      adam->update();
+      trainer->update();
       // Print progress every tenth of the dataset
       if ((si + 1) % (num_batches / 10) == 0 || si == num_batches - 1) {
         // Print informations
-        adam->status();
+        trainer->status();
         cerr << " E = " << (loss / tokens) << " ppl=" << exp(loss / tokens) << ' ';
         // Reinitialize timer
         iteration.reset(new Timer("completed in"));

--- a/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
+++ b/examples/cpp/rnnlm-cfsm/train_rnnlm-cfsm.cc
@@ -139,12 +139,12 @@ int main(int argc, char** argv) {
   cerr << "Parameters will be written to: " << fname << endl;
   double best = 9e+99;
 
-  std::unique_ptr<Trainer> sgd;
+  std::unique_ptr<Trainer> trainer;
   // bool use_momentum = false;
   // if (use_momentum)
-  //   sgd = new MomentumSGDTrainer(model);
+  //   trainer = new MomentumSGDTrainer(model);
   // else
-  sgd.reset(new SimpleSGDTrainer(model));
+  trainer.reset(new SimpleSGDTrainer(model));
 
   RNNLanguageModel<LSTMBuilder> lm(model, cfsm);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model, cfsm);
@@ -180,10 +180,10 @@ int main(int argc, char** argv) {
       Expression loss_expr = lm.BuildLMGraph(sent, cg);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update();
+      trainer->update();
       ++lines;
     }
-    sgd->status();
+    trainer->status();
     cerr << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
     lm.RandomSample();
 

--- a/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
+++ b/examples/cpp/rnnlm-final-batch/train_rnnlm-final-batch.cc
@@ -194,8 +194,8 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  std::unique_ptr<Trainer> sgd(new SimpleSGDTrainer(model));
-  sgd->clip_threshold *= BATCH_SIZE;
+  std::unique_ptr<Trainer> trainer(new SimpleSGDTrainer(model));
+  trainer->clip_threshold *= BATCH_SIZE;
 
   RNNLanguageModel<LSTMBuilder> lm(model);
   if (argc == 4) {
@@ -226,10 +226,10 @@ int main(int argc, char** argv) {
       Expression loss_expr = lm.BuildLMGraphs(training, order[si], bsize, chars, cg);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update();
+      trainer->update();
       lines += bsize;
     }
-    sgd->status();
+    trainer->status();
     cerr << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
     lm.RandomSample();
 

--- a/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
+++ b/examples/cpp/rnnlm-givenbag/rnnlm-givenbag.cc
@@ -161,11 +161,11 @@ int main(int argc, char** argv) {
 
   ParameterCollection model;
   bool use_momentum = false;
-  std::unique_ptr<Trainer> sgd;
+  std::unique_ptr<Trainer> trainer;
   //if (use_momentum)
   //else
-  //sgd = new SimpleSGDTrainer(model);
-  sgd.reset(new MomentumSGDTrainer(model));
+  //trainer = new SimpleSGDTrainer(model);
+  trainer.reset(new MomentumSGDTrainer(model));
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
   if (argc == 4) {
@@ -213,11 +213,11 @@ int main(int argc, char** argv) {
       Expression loss_expr = lm.BuildLMGraph(rmsent, cg, &rows);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update();
+      trainer->update();
       for (auto w : sent) { w2sl[w] = 0; }
       ++lines;
     }
-    sgd->status();
+    trainer->status();
     cerr << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
 #if 0
     lm.RandomSample();

--- a/examples/cpp/rnnlm-mp/train_rnnlm-mp.cc
+++ b/examples/cpp/rnnlm-mp/train_rnnlm-mp.cc
@@ -74,12 +74,12 @@ int main(int argc, char** argv) {
   dynet::initialize(argc, argv, true);
 
   ParameterCollection model;
-  SimpleSGDTrainer sgd(model, 0.2);
-  //AdagradTrainer sgd(model, 0.0);
-  //AdamTrainer sgd(model, 0.0);
+  SimpleSGDTrainer trainer(model, 0.2);
+  //AdagradTrainer trainer(model, 0.0);
+  //AdamTrainer trainer(model, 0.0);
 
   RNNLanguageModel<LSTMBuilder> rnnlm(model);
 
   Learner<LSTMBuilder, Datum> learner(rnnlm, data.size());
-  run_multi_process<Datum>(num_children, &learner, &sgd, data, dev_data, num_iterations, dev_frequency, report_frequency);
+  run_multi_process<Datum>(num_children, &learner, &trainer, data, dev_data, num_iterations, dev_frequency, report_frequency);
 }

--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -201,8 +201,8 @@ int main(int argc, char** argv) {
     }
   }
 
-  std::unique_ptr<Trainer> sgd(new SimpleSGDTrainer(model));
-  sgd->learning_rate = params.eta0;
+  std::unique_ptr<Trainer> trainer(new SimpleSGDTrainer(model));
+  trainer->learning_rate = params.eta0;
   RNNLanguageModel<LSTMBuilder> lm(model);
 
   bool has_model_to_load = params.model_file != "";
@@ -267,7 +267,7 @@ int main(int argc, char** argv) {
           cerr << "**SHUFFLE\n";
           completed_epoch++;
           if (eta_decay_onset_epoch && completed_epoch >= (int)eta_decay_onset_epoch)
-            sgd->learning_rate *= eta_decay_rate;
+            trainer->learning_rate *= eta_decay_rate;
           shuffle(order.begin(), order.end(), *rndeng);
         }
 
@@ -279,11 +279,11 @@ int main(int argc, char** argv) {
         Expression loss_expr = lm.BuildLMGraph(sent, cg, DROPOUT > 0.f);
         loss += as_scalar(cg.forward(loss_expr));
         cg.backward(loss_expr);
-        sgd->update();
+        trainer->update();
         ++lines;
       }
       report++;
-      cerr << '#' << report << " [epoch=" << (lines / training.size()) << " lr=" << sgd->learning_rate << "] E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
+      cerr << '#' << report << " [epoch=" << (lines / training.size()) << " lr=" << trainer->learning_rate << "] E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
 
       // show score on dev data?
       if (report % dev_every_i_reports == 0) {

--- a/examples/cpp/segrnn-sup/train_segrnn-sup.cc
+++ b/examples/cpp/segrnn-sup/train_segrnn-sup.cc
@@ -1073,8 +1073,8 @@ int main(int argc, char** argv) {
     }
 
     ParameterCollection model;
-    // auto sgd = new SimpleSGDTrainer(model);
-    std::unique_ptr<Trainer> adam(new AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8));
+    // auto trainer = new SimpleSGDTrainer(model);
+    std::unique_ptr<Trainer> trainer(new AdamTrainer(model, 0.0005, 0.01, 0.9999, 1e-8));
     int max_seg_len = DATA_MAX_SEG_LEN + 1;
     if(vm.count("train_max_seg_len")){
       max_seg_len = vm["train_max_seg_len"].as<int>();
@@ -1136,11 +1136,11 @@ int main(int argc, char** argv) {
           ttags += sent.second.size();
           loss += as_scalar(cg.forward(loss_expr));
           cg.backward(loss_expr);
-          adam->update(1.0);
+          trainer->update(1.0);
         }
         ++lines;
       }
-      adam->status();
+      trainer->status();
       cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / ttags) << ") ";
       report++;
       if (report % dev_every_i_reports == 0) {

--- a/examples/cpp/skiprnnlm/train_skiprnnlm.cc
+++ b/examples/cpp/skiprnnlm/train_skiprnnlm.cc
@@ -126,11 +126,11 @@ int main(int argc, char** argv) {
 
     ParameterCollection model;
     bool use_momentum = false;
-    std::unique_ptr<Trainer> sgd;
+    std::unique_ptr<Trainer> trainer;
     if (use_momentum)
-        sgd.reset(new MomentumSGDTrainer(model));
+        trainer.reset(new MomentumSGDTrainer(model));
     else
-        sgd.reset(new SimpleSGDTrainer(model));
+        trainer.reset(new SimpleSGDTrainer(model));
 
     RNNSkipLM lm(model);
     if (argc == 4) {
@@ -166,10 +166,10 @@ int main(int argc, char** argv) {
             Expression loss_expr = lm.BuildLMGraph(doc, cg);
             loss += as_scalar(cg.forward(loss_expr));
             cg.backward(loss_expr);
-            sgd->update();
+            trainer->update();
             ++lines;
         }
-        sgd->status();
+        trainer->status();
         // FIXME: is chars incorrect?
         LOG(INFO) << " E = " << (loss / chars) << " ppl=" << exp(loss / chars) << ' ';
         //lm.RandomSample(); // why???

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -186,11 +186,11 @@ int main(int argc, char** argv) {
 
   ParameterCollection model;
   bool use_momentum = true;
-  std::unique_ptr<Trainer> sgd;
+  std::unique_ptr<Trainer> trainer;
   if (use_momentum)
-    sgd.reset(new MomentumSGDTrainer(model));
+    trainer.reset(new MomentumSGDTrainer(model));
   else
-    sgd.reset(new SimpleSGDTrainer(model));
+    trainer.reset(new SimpleSGDTrainer(model));
 
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
@@ -227,10 +227,10 @@ int main(int argc, char** argv) {
       // Run forward pass, backpropagate, and do an update
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update();
+      trainer->update();
       ++lines;
     }
-    sgd->status();
+    trainer->status();
     cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / ttags) << ") ";
 
     // show score on dev data?

--- a/examples/cpp/textcat/train_textcat.cc
+++ b/examples/cpp/textcat/train_textcat.cc
@@ -233,9 +233,9 @@ int main(int argc, char** argv) {
   double best = 9e+99;
 
   ParameterCollection model;
-  //sgd = new MomentumSGDTrainer(model);
-  std::unique_ptr<Trainer> adagrad(new AdagradTrainer(model));
-  //sgd = new SimpleSGDTrainer(model);
+  //trainer = new MomentumSGDTrainer(model);
+  std::unique_ptr<Trainer> trainer(new AdagradTrainer(model));
+  //trainer = new SimpleSGDTrainer(model);
 
   //NeuralBagOfWords nbow(model);
   ConvNet nbow(model);
@@ -276,11 +276,11 @@ int main(int argc, char** argv) {
       Expression loss_expr = HingeLoss(y_pred, y);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      adagrad->update(2.0);
+      trainer->update(2.0);
       ++lines;
       ++ttags;
     }
-    adagrad->status();
+    trainer->status();
     cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / (double)ttags) << ") ";
     model.project_weights();
 

--- a/examples/cpp/tok-embed/train_tok-embed.cc
+++ b/examples/cpp/tok-embed/train_tok-embed.cc
@@ -223,7 +223,7 @@ int main(int argc, char** argv) {
     return 1;
   }
   ParameterCollection model;
-  std::unique_ptr<Trainer> sgd(new SimpleSGDTrainer(model));
+  std::unique_ptr<Trainer> trainer(new SimpleSGDTrainer(model));
   vector<pair<string,vector<unsigned>>> training;
   kSOW = d.convert("<w>");
   kEOW = d.convert("</w>");
@@ -285,10 +285,10 @@ int main(int argc, char** argv) {
       ttags += 1;
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd->update();
+      trainer->update();
       ++lines;
     }
-    sgd->status();
+    trainer->status();
     cerr << " E = " << (loss / ttags) << " ppl=" << exp(loss / ttags) << " (acc=" << (correct / ttags) << ") ";
   }
 }

--- a/examples/cpp/xor-autobatch/train_xor-autobatch.cc
+++ b/examples/cpp/xor-autobatch/train_xor-autobatch.cc
@@ -17,8 +17,8 @@ int main(int argc, char** argv) {
   // parameters
   const unsigned ITERATIONS = 30;
   ParameterCollection m;
-  SimpleSGDTrainer sgd(m);
-  //MomentumSGDTrainer sgd(m);
+  SimpleSGDTrainer trainer(m);
+  //MomentumSGDTrainer trainer(m);
 
   Parameter p_W, p_b, p_V, p_a;
   const unsigned HIDDEN_SIZE = 3;
@@ -69,7 +69,7 @@ int main(int argc, char** argv) {
     // Calculate the loss. Batching will automatically be done here.
     float loss = as_scalar(cg.forward(loss_expr)) / 4;
     cg.backward(loss_expr);
-    sgd.update();
+    trainer.update();
 
     cerr << "E = " << loss << endl;
   }

--- a/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
+++ b/examples/cpp/xor-batch-lookup/train_xor-batch-lookup.cc
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
   const unsigned HIDDEN_SIZE = 8;
   const unsigned ITERATIONS = 200;
   ParameterCollection m;
-  SimpleSGDTrainer sgd(m);
+  SimpleSGDTrainer trainer(m);
 
   ComputationGraph cg;
   Parameter p_W, p_b, p_V, p_a;
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
   for (unsigned iter = 0; iter < ITERATIONS; ++iter) {
     vector<float> losses = as_vector(cg.forward(sum_loss));
     cg.backward(sum_loss);
-    sgd.update();
+    trainer.update();
     float loss = 0;
     for(auto l : losses)
       loss += l;

--- a/examples/cpp/xor-batch/train_xor-batch.cc
+++ b/examples/cpp/xor-batch/train_xor-batch.cc
@@ -18,7 +18,7 @@ int main(int argc, char** argv) {
   const unsigned HIDDEN_SIZE = 8;
   const unsigned ITERATIONS = 200;
   ParameterCollection m;
-  SimpleSGDTrainer sgd(m);
+  SimpleSGDTrainer trainer(m);
 
   ComputationGraph cg;
   Parameter p_W, p_b, p_V, p_a;
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
   for (unsigned iter = 0; iter < ITERATIONS; ++iter) {
     float my_loss = as_scalar(cg.forward(sum_loss)) / 4;
     cg.backward(sum_loss);
-    sgd.update();
+    trainer.update();
     cerr << "E = " << my_loss << endl;
   }
 

--- a/examples/cpp/xor-multidevice/train_xor-multidevice.cc
+++ b/examples/cpp/xor-multidevice/train_xor-multidevice.cc
@@ -15,7 +15,7 @@ int main(int argc, char** argv) {
 
   // ParameterCollection (all the model parameters).
   ParameterCollection m;
-  SimpleSGDTrainer sgd(m);
+  SimpleSGDTrainer trainer(m);
 
   // Get two devices, the CPU device and GPU device
   Device* cpu_device = get_global_device("CPU");
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
 
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd.update();
+      trainer.update();
 
     }
     loss /= 4;

--- a/examples/cpp/xor-xent/train_xor-xent.cc
+++ b/examples/cpp/xor-xent/train_xor-xent.cc
@@ -16,8 +16,8 @@ int main(int argc, char** argv) {
   // parameters
   const unsigned HIDDEN_SIZE = 8;
   ParameterCollection m;
-  SimpleSGDTrainer sgd(m);
-  //MomentumSGDTrainer sgd(m);
+  SimpleSGDTrainer trainer(m);
+  //MomentumSGDTrainer trainer(m);
 
   ComputationGraph cg;
 
@@ -58,7 +58,7 @@ int main(int argc, char** argv) {
       y_value = (x1 != x2) ? 1 : 0;
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd.update();
+      trainer.update();
     }
     loss /= 4;
     cerr << "E = " << loss << endl;

--- a/examples/cpp/xor/train_xor.cc
+++ b/examples/cpp/xor/train_xor.cc
@@ -16,7 +16,7 @@ int main(int argc, char** argv) {
 
   // ParameterCollection (all the model parameters).
   ParameterCollection m;
-  SimpleSGDTrainer sgd(m);
+  SimpleSGDTrainer trainer(m);
 
   const unsigned HIDDEN_SIZE = 8;
   Parameter p_W = m.add_parameters({HIDDEN_SIZE, 2});
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
       y_value = (x1 != x2) ? 1 : -1;
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
-      sgd.update();
+      trainer.update();
     }
     loss /= 4;
     cerr << "E = " << loss << endl;

--- a/examples/python/bilstmtagger.py
+++ b/examples/python/bilstmtagger.py
@@ -48,7 +48,7 @@ nwords = vw.size()
 ntags  = vt.size()
 
 model = Model()
-sgd = SimpleSGDTrainer(model)
+trainer = SimpleSGDTrainer(model)
 
 E = model.add_lookup_parameters((nwords, 128))
 p_t1  = model.add_lookup_parameters((ntags, 30))
@@ -119,7 +119,7 @@ for ITER in range(50):
     random.shuffle(train)
     for i,s in enumerate(train,1):
         if i % 5000 == 0:
-            sgd.status()
+            trainer.status()
             print(loss / tagged)
             loss = 0
             tagged = 0
@@ -139,6 +139,6 @@ for ITER in range(50):
         loss += sum_errs.scalar_value()
         tagged += len(ps)
         sum_errs.backward()
-        sgd.update()
+        trainer.update()
 
 

--- a/examples/python/crayonusage/rnnlm-batch.py
+++ b/examples/python/crayonusage/rnnlm-batch.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
     VOCAB_SIZE = vocab.size()
 
     model = dy.ParameterCollection()
-    sgd = SimpleSGDTrainer(model)
+    trainer = SimpleSGDTrainer(model)
 
     #lm = RNNLanguageModel(model, LAYERS, INPUT_DIM, HIDDEN_DIM, VOCAB_SIZE, builder=SimpleRNNBuilder)
     lm = RNNLanguageModel(model, LAYERS, INPUT_DIM, HIDDEN_DIM, VOCAB_SIZE, builder=LSTMBuilder)
@@ -135,7 +135,7 @@ if __name__ == '__main__':
         for sid in train_order: 
             i += 1
             #if i % int(50) == 0:
-            sgd.status()
+            trainer.status()
             if chars > 0: print(loss / chars,)
             for _ in range(1):
                 samp = lm.sample(first=vocab.w2i["<s>"],stop=vocab.w2i["\n"])
@@ -150,15 +150,15 @@ if __name__ == '__main__':
             myexp.add_scalar_value("lossevolution", loss)
             chars += mb_chars
             errs.backward()
-            sgd.update()
+            trainer.update()
                 
 
             #print "TM:",(time.time() - _start)/chars
         print("ITER",ITER,loss)
         #print(loss / chars,)
         #print "TM:",(time.time() - _start)/len(train)
-        sgd.status()
-        sgd.update_epoch(1.0)
+        trainer.status()
+        trainer.update_epoch(1.0)
 
     # To save the experiment
     filename = myexp.to_zip()

--- a/examples/python/rnnlm-batch.py
+++ b/examples/python/rnnlm-batch.py
@@ -105,7 +105,7 @@ if __name__ == '__main__':
     VOCAB_SIZE = vocab.size()
 
     model = Model()
-    sgd = SimpleSGDTrainer(model)
+    trainer = SimpleSGDTrainer(model)
 
     #lm = RNNLanguageModel(model, LAYERS, INPUT_DIM, HIDDEN_DIM, VOCAB_SIZE, builder=SimpleRNNBuilder)
     lm = RNNLanguageModel(model, LAYERS, INPUT_DIM, HIDDEN_DIM, VOCAB_SIZE, builder=LSTMBuilder)
@@ -124,7 +124,7 @@ if __name__ == '__main__':
         for sid in train_order: 
             i += 1
             #if i % int(50) == 0:
-            sgd.status()
+            trainer.status()
             if chars > 0: print(loss / chars,)
             for _ in range(1):
                 samp = lm.sample(first=vocab.w2i["<s>"],stop=vocab.w2i["\n"])
@@ -137,12 +137,12 @@ if __name__ == '__main__':
             loss += errs.scalar_value()
             chars += mb_chars
             errs.backward()
-            sgd.update()
+            trainer.update()
                 
 
             #print "TM:",(time.time() - _start)/chars
         print("ITER",ITER,loss)
         #print(loss / chars,)
         #print "TM:",(time.time() - _start)/len(train)
-        sgd.status()
-        sgd.update_epoch(1.0)
+        trainer.status()
+        trainer.update_epoch(1.0)

--- a/examples/python/rnnlm.py
+++ b/examples/python/rnnlm.py
@@ -98,7 +98,7 @@ if __name__ == '__main__':
     VOCAB_SIZE = vocab.size()
 
     model = Model()
-    sgd = SimpleSGDTrainer(model, learning_rate=1.0)
+    trainer = SimpleSGDTrainer(model, learning_rate=1.0)
 
     #lm = RNNLanguageModel(model, LAYERS, INPUT_DIM, HIDDEN_DIM, VOCAB_SIZE, builder=SimpleRNNBuilder)
     lm = RNNLanguageModel(model, LAYERS, INPUT_DIM, HIDDEN_DIM, VOCAB_SIZE, builder=LSTMBuilder)
@@ -111,7 +111,7 @@ if __name__ == '__main__':
         for i,sent in enumerate(train):
             _start = time.time()
             if i % 50 == 0:
-                sgd.status()
+                trainer.status()
                 if chars > 0: print(loss / chars,)
                 for _ in range(1):
                     samp = lm.sample(first=vocab.w2i["<s>"],stop=vocab.w2i["\n"])
@@ -124,10 +124,10 @@ if __name__ == '__main__':
             errs = lm.build_lm_graph(isent)
             loss += errs.scalar_value()
             errs.backward()
-            sgd.update()
+            trainer.update()
             #print "TM:",(time.time() - _start)/len(sent)
         print("ITER {}, loss={}".format(ITER, loss))
-        sgd.status()
+        trainer.status()
 
     lm.save_to_disk("RNNLanguageModel.model")
 

--- a/examples/python/rnnlm_transduce.py
+++ b/examples/python/rnnlm_transduce.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     VOCAB_SIZE = vocab.size()
 
     model = Model()
-    sgd = SimpleSGDTrainer(model)
+    trainer = SimpleSGDTrainer(model)
 
     #lm = RNNLanguageModel(model, LAYERS, INPUT_DIM, HIDDEN_DIM, VOCAB_SIZE, builder=SimpleRNNBuilder)
     lm = RNNLanguageModel(model, LAYERS, INPUT_DIM, HIDDEN_DIM, VOCAB_SIZE, builder=LSTMBuilder)
@@ -92,7 +92,7 @@ if __name__ == '__main__':
         for i,sent in enumerate(train):
             _start = time.time()
             if i % 50 == 0:
-                sgd.status()
+                trainer.status()
                 if chars > 0: print(loss / chars,)
                 for _ in range(1):
                     samp = lm.sample(first=vocab.w2i["<s>"],stop=vocab.w2i["\n"])
@@ -105,8 +105,8 @@ if __name__ == '__main__':
             errs = lm.BuildLMGraph(isent)
             loss += errs.scalar_value()
             errs.backward()
-            sgd.update(1.0)
+            trainer.update(1.0)
             #print "TM:",(time.time() - _start)/len(sent)
         print("ITER",ITER,loss)
-        sgd.status()
-        sgd.update_epoch(1.0)
+        trainer.status()
+        trainer.update_epoch(1.0)

--- a/examples/python/viz_birnn.py
+++ b/examples/python/viz_birnn.py
@@ -9,7 +9,7 @@ num_words = len(w2i)
 num_tags = len(t2i)
 
 model = Model()
-sgd = SimpleSGDTrainer(model)
+trainer = SimpleSGDTrainer(model)
 
 WEMB_DIM = 128
 RNN_HIDDEN_DIM = 64

--- a/examples/python/xor.py
+++ b/examples/python/xor.py
@@ -8,7 +8,7 @@ HIDDEN_SIZE = 8
 ITERATIONS = 2000
 
 m = dy.Model()
-sgd = dy.SimpleSGDTrainer(m)
+trainer = dy.SimpleSGDTrainer(m)
 
 pW = m.add_parameters((HIDDEN_SIZE, 2))
 pb = m.add_parameters(HIDDEN_SIZE)
@@ -47,7 +47,7 @@ for iter in range(ITERATIONS):
         y.set(T if x1 != x2 else F)
         mloss += loss.scalar_value()
         loss.backward()
-        sgd.update()
+        trainer.update()
     mloss /= 4.
     print("loss: %0.9f" % mloss)
 


### PR DESCRIPTION
As per the discussion at #864, it might be better to use `trainer` consistently rather than individual name based on the type of training algorithms such as `sgd`, `adam` or `adagrad`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/866)
<!-- Reviewable:end -->
