### PR TITLE
examples/python: Do not pass arguments to trainer.update()

### DIFF
--- a/doc/source/cpp_basic_tutorial.rst
+++ b/doc/source/cpp_basic_tutorial.rst
@@ -75,7 +75,7 @@ Now, we perform a parameter update for a single example. Set the input/output to
 
 .. code:: cpp
 
-    trainer.update(1.0);
+    trainer.update();
 
 Note that this very simple example that doesn't cover things like memory
 initialization, reading/writing parameter collections, recurrent/LSTM networks, or

--- a/examples/python/rnnlm_transduce.py
+++ b/examples/python/rnnlm_transduce.py
@@ -105,7 +105,7 @@ if __name__ == '__main__':
             errs = lm.BuildLMGraph(isent)
             loss += errs.scalar_value()
             errs.backward()
-            trainer.update(1.0)
+            trainer.update()
             #print "TM:",(time.time() - _start)/len(sent)
         print("ITER",ITER,loss)
         trainer.status()


### PR DESCRIPTION
This fixes runtime errors when running `examples/python/rnnlm_transduce.py`.
Trainer.update method takes no arguments, but 1 argument is passed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/873)
<!-- Reviewable:end -->
