### PR TITLE
examples/python: Remove deprecated update_epoch()

### DIFF
--- a/examples/python/crayonusage/rnnlm-batch.py
+++ b/examples/python/crayonusage/rnnlm-batch.py
@@ -157,7 +157,6 @@ if __name__ == '__main__':
         #print(loss / chars,)
         #print "TM:",(time.time() - _start)/len(train)
         trainer.status()
-        trainer.update_epoch(1.0)
 
     # To save the experiment
     filename = myexp.to_zip()

--- a/examples/python/rnnlm-batch.py
+++ b/examples/python/rnnlm-batch.py
@@ -145,4 +145,3 @@ if __name__ == '__main__':
         #print(loss / chars,)
         #print "TM:",(time.time() - _start)/len(train)
         trainer.status()
-        trainer.update_epoch(1.0)

--- a/examples/python/rnnlm_transduce.py
+++ b/examples/python/rnnlm_transduce.py
@@ -109,4 +109,3 @@ if __name__ == '__main__':
             #print "TM:",(time.time() - _start)/len(sent)
         print("ITER",ITER,loss)
         trainer.status()
-        trainer.update_epoch(1.0)


### PR DESCRIPTION
This removes Trainer.update_epoch() marked as deprecated in the examples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/878)
<!-- Reviewable:end -->
