### PR TITLE
Optionally enable Debug build, ASan enabled or TSan enabled binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,10 @@ function(find_mkl)
   endif()
 endfunction()
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE "Release")
+endif()
+
 ######## Cross-compiler, cross-platform options
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DEIGEN_FAST_MATH")
 if (MKL OR MKL_ROOT)
@@ -84,7 +88,9 @@ endif()
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W1 /MP")   # -Wall produces 20k warnings. Enable parallel compilation
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -funroll-loops -fno-finite-math-only -Wall -Wno-missing-braces -std=c++11 -Ofast -g -march=native")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fno-finite-math-only -Wall -Wno-missing-braces -std=c++11 -g")
+  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-omit-frame-pointer")
+  set(CMAKE_CXX_FLAGS_RELEASE "-funroll-loops -Ofast -march=native")
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -96,7 +96,7 @@ Build with TSan
 
 Linux/macOS only.
 
-If you're on macOS or Linux, we can build DyNet with
+If you're on Linux or macOS, you can build DyNet with
 `ThreadSanitizer <https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual>`__
 (aka TSan). TSan is a data race error detector for C/C++. It finds data races at runtime
 just like ASan. Please see the `official wiki <https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual>`__

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -39,6 +39,84 @@ In Python, these values can be set by using optional arguments to the ``renew_cg
     dy.renew_cg(immediate_compute = True, check_validity = True)
 
 
+Debug Builds
+------------
+
+By default, DyNet is built with all optimization enabled.
+You can build DyNet without optimizations by adding
+``-DCMAKE_BUILD_TYPE=Debug`` to the cmake command
+
+::
+
+    cd dynet
+    mkdir build
+    cd build
+    cmake .. -DCMAKE_BUILD_TYPE=Debug
+    make -j8 # replace 8 properly
+
+
+Note: pass other cmake options based on your environment.
+
+
+Debugging Crashes
+-----------------
+
+Build with ASan
+~~~~~~~~~~~~~~~
+
+If you're on Linux or macOS, you can build DyNet with
+`AddressSanitizer <https://github.com/google/sanitizers/wiki/AddressSanitizer>`__
+(aka ASan). ASan is a memory error detector for C/C++. It's useful for debugging
+bugs or crashes caused by memory errors such as use-after-free, heap buffer overflow,
+stack buffer overflow. By running ASan-enabled tests or programs, ASan finds memory
+errors at runtime. To enable ASan, add ``-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address"``
+to the cmake command:
+
+
+::
+
+    cd dynet
+    mkdir build-asan
+    cd build-asan
+    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address"
+    make -j8
+
+
+Please see the `official wiki <https://github.com/google/sanitizers/wiki/AddressSanitizer>`__
+for the details.
+
+CAUTION: Please do not install ASan enabled libraries or programs
+under root partition. You might have a bad time.
+
+Debugging Threading Issues
+--------------------------
+
+Build with TSan
+~~~~~~~~~~~~~~~
+
+Linux/macOS only.
+
+If you're on macOS or Linux, we can build DyNet with
+`ThreadSanitizer <https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual>`__
+(aka TSan). TSan is a data race error detector for C/C++. It finds data races at runtime
+just like ASan. Please see the `official wiki <https://github.com/google/sanitizers/wiki/ThreadSanitizerCppManual>`__
+for more details.
+
+By running TSan-enabled tests or programs, TSan finds data races at runtime.
+To enable TSan, add ``-DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address"``
+to the cmake command:
+
+::
+
+    cd dynet
+    mkdir build-tsan
+    cd build-tsan
+    cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address"
+
+
+CAUTION: Please do not install TSan enabled libraries or programs
+under root partition. You might have a bad time.
+
 .. _debugging-asking:
 
 Asking Questions/Reporting Bugs


### PR DESCRIPTION
Currently, DyNet is built with all optimizations enabled by default.
Optionally allowing debug builds would be useful for debugging crashes
or data races, enabling AddressSanitizer (aka ASan) or ThreadSanitizer
(aka TSan).

With this change, developers can tell cmake to create Debug build,
by specifying `-DCMAKE_BUILD_TYPE=Debug` without editing CMakeLists.txt.
If `-DCMAKE_BUILD_TYPE` is not specified, Release build is built as
before.
So, this change requires no burden for standard users.

Typical workflow to create Debug builds, ASan enabled binaries, or
TSan enabled binaries would be like:

$ mkdir Debug
$ cd Debug
$ cmake .. -DCMAKE_BUILD_TYPE=Debug -G Ninja
$ ninja

ASan enabled binaries
$ mkdir Debug-asan
$ cd Debug-asan
$ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=address" -G Ninja
$ ninja

TSan enabled binaries
$ mkdir Debug-tsan
$ cd Debug-tsan
$ cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-fsanitize=thread" -G Ninja
$ ninja

Note: I'm using ninja as a build system. This applies to other build
systems such as make.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/880)
<!-- Reviewable:end -->
