### PR TITLE
Fix -Wsign-compare warnings

### DIFF
--- a/dynet/nodes-lstm.cc
+++ b/dynet/nodes-lstm.cc
@@ -31,7 +31,7 @@ namespace dynet {
     unsigned input_dim=xs[num_inputs+1][1];
     unsigned batch_size=xs[0].bd;
     unsigned inputs_dim_sum=0;
-    for(int i=0; i<num_inputs; i++){
+    for(unsigned i=0; i<num_inputs; i++){
         DYNET_ARG_CHECK(xs[i].ndims() == 1, "VanillaLSTMGates: x_t[" << i << "] expected to be a vector");
         DYNET_ARG_CHECK(xs[i].bd == batch_size, "VanillaLSTMGates: x_t has inconsistent batch size");
         inputs_dim_sum += xs[i][0];
@@ -62,7 +62,7 @@ namespace dynet {
     unsigned num_inputs = dropout?args.size()-6:args.size()-4;
     // Assume parameter vectors must be same
     if(dim.bd == 1) {
-      for(int i=0; i<num_inputs; i++)
+      for(unsigned i=0; i<num_inputs; i++)
         s.add_dim(cg.nodes[args[i]]->dim);
       // TODO: correct? parameter vectors would be args[num_inputs+1] .. args[num_inputs+3]
       // s.add_dim(cg.nodes[args[num_inputs]]->dim); // not necessary, as will be the same
@@ -132,7 +132,7 @@ namespace dynet {
       tmp.v = static_cast<float*>(scratch_allocator->allocate(tmp.d.size() * sizeof(float)));
       Eigen::DSizes<ptrdiff_t, 2> indices_tmp(0, 0);
       Eigen::DSizes<ptrdiff_t, 2> sizes_tmp(0, static_cast<ptrdiff_t>(fx.d.bd));
-      for(int i=0; i<num_inputs; i++){
+      for(unsigned i=0; i<num_inputs; i++){
         sizes_tmp[0] = xs[i]->d[0];
         tmp.tbvec().slice(indices_tmp, sizes_tmp).device(*dev.edevice) = xs[i]->tbvec();
         indices_tmp[0] += xs[i]->d[0];
@@ -337,7 +337,7 @@ namespace dynet {
         Wx_slice.v = Wx->v;
       } else {
         unsigned offset=0;
-        for(int j=0; j<i; j++) offset += xs[j]->d[0];
+        for(unsigned j=0; j<i; j++) offset += xs[j]->d[0];
         Eigen::DSizes<ptrdiff_t, 3> indices_Wx(0, offset, 0);
         Eigen::DSizes<ptrdiff_t, 3> sizes_Wx(hidden_dim*4, xs[i]->d[0], 1);
         Wx_slice.v = static_cast<float*>(scratch_allocator->allocate(Wx_slice.d.size() * sizeof(float)));
@@ -372,7 +372,7 @@ namespace dynet {
           dropout_mask.v = mask_x.v;
         } else {
           unsigned offset=0;
-          for(int j=0; j<i; j++) offset += xs[j]->d[0];
+          for(unsigned j=0; j<i; j++) offset += xs[j]->d[0];
           Eigen::DSizes<ptrdiff_t, 2> indices_dropout(offset, 0);
           Eigen::DSizes<ptrdiff_t, 2> sizes_dropout(xs[i]->d[0], mask_x.d.bd);
           dropout_mask.v = static_cast<float*>(scratch_allocator->allocate(dropout_mask.d.size() * sizeof(float)));
@@ -439,7 +439,7 @@ namespace dynet {
         tmp.v = static_cast<float*>(scratch_allocator->allocate(tmp.d.size() * sizeof(float)));
         Eigen::DSizes<ptrdiff_t, 2> indices_tmp(0, 0);
         Eigen::DSizes<ptrdiff_t, 2> sizes_tmp(0, static_cast<ptrdiff_t>(fx.d.bd));
-        for(int i=0; i<num_inputs; i++){
+        for(unsigned i=0; i<num_inputs; i++){
           sizes_tmp[0] = xs[i]->d[0];
           tmp.tbvec().slice(indices_tmp, sizes_tmp).device(*dev.edevice) = xs[i]->tbvec();
           indices_tmp[0] += xs[i]->d[0];

--- a/examples/cpp/encdec/encdec.h
+++ b/examples/cpp/encdec/encdec.h
@@ -145,7 +145,7 @@ public:
             // Fill x_t with the characters at step t in the batch
             for (unsigned i = 0; i < bsize; ++i) {
                 x_t[i] = isents[id + i][t];
-                if (x_t[i] != *isents[id].rbegin()) chars++; // if x_t is non-EOS, count a char
+                if (x_t[i] != static_cast<unsigned>(*isents[id].rbegin())) chars++; // if x_t is non-EOS, count a char
             }
             // Get embedding
             Expression i_x_t = lookup(cg, p_ec, x_t);
@@ -161,7 +161,7 @@ public:
             rev_enc_builder.start_new_sequence();
             // Fill x_t with the characters at step t in the batch (in reverse order)
             for (int t = islen - 1; t >= 0; --t) {
-                for (int i = 0; i < bsize; ++i) {
+                for (unsigned i = 0; i < bsize; ++i) {
                     x_t[i] = isents[id + i][t];
                 }
                 // Get embedding (could be mutualized with fwd_enc_builder)
@@ -362,7 +362,7 @@ private:
         float p = (float)rand() / (float) RAND_MAX;
         float cumul = 0.f;
         int idx = 0;
-        while (idx < v.size() && p > cumul) {
+        while (idx < static_cast<int>(v.size()) && p > cumul) {
             cumul += v[idx];
             idx += 1;
         }

--- a/examples/cpp/imdb/train_imdb.cc
+++ b/examples/cpp/imdb/train_imdb.cc
@@ -275,7 +275,7 @@ int main(int argc, char** argv) {
       Expression logits = engine.classify(cg, inst);
       std::vector<float> pred = dynet::as_vector(cg.get_value(logits));
       unsigned y_pred = std::max_element(pred.begin(), pred.end()) - pred.begin();
-      if (y_pred == inst.second) { correct ++; }
+      if (y_pred == static_cast<unsigned>(inst.second)) { correct ++; }
       Expression loss_expr = engine.objective(cg, inst, logits);
       loss += as_scalar(cg.forward(loss_expr));
       cg.backward(loss_expr);
@@ -296,7 +296,7 @@ int main(int argc, char** argv) {
       for (auto& inst : dev) {
         ComputationGraph cg;
         unsigned y_pred = engine.predict(cg, inst);
-        if (y_pred == inst.second) dcorr++;
+        if (y_pred == static_cast<unsigned>(inst.second)) dcorr++;
         dtags++;
       }
       if (dloss < best) {

--- a/examples/cpp/mnist/train_mnist.cc
+++ b/examples/cpp/mnist/train_mnist.cc
@@ -85,7 +85,7 @@ int main(int argc, char** argv) {
   vector<unsigned> cur_labels;
 
   // Run for the given number of epochs (or indefinitely if params.NUM_EPOCHS is negative)
-  while (epoch < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
+  while (static_cast<int>(epoch) < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
     // Reshuffle the dataset
     cerr << "**SHUFFLE\n";
     random_shuffle(order.begin(), order.end());

--- a/examples/cpp/rnnlm-batch/rnnlm-batch.h
+++ b/examples/cpp/rnnlm-batch/rnnlm-batch.h
@@ -131,7 +131,7 @@ public:
       for (unsigned i = 0; i < bsize; ++i) {
         next_arr[i] = sents[id + i][t];
         // count non-EOS tokens
-        if (next_arr[i] != *sents[id].rbegin()) tokens++;
+        if (next_arr[i] != static_cast<unsigned>(*sents[id].rbegin())) tokens++;
       }
       // Embed the current tokens
       Expression i_x_t = lookup(cg, p_c, last_arr);
@@ -202,7 +202,7 @@ public:
         if (w == dist.size()) w = kEOS;
       }
 
-      if (w == kEOS) {
+      if (static_cast<int>(w) == kEOS) {
         // If the sampled token is an EOS, reinitialize network and start generating a new sample
         rnn.start_new_sequence();
         cerr << endl;

--- a/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
+++ b/examples/cpp/rnnlm-batch/train_rnnlm-batch.cc
@@ -157,7 +157,7 @@ int main(int argc, char** argv) {
 
   unsigned epoch = 0;
   // Run for the given number of epochs (or indefinitely if params.NUM_EPOCHS is negative)
-  while (epoch < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
+  while (static_cast<int>(epoch) < params.NUM_EPOCHS || params.NUM_EPOCHS < 0) {
     // Reshuffle the dataset
     cerr << "**SHUFFLE\n";
     random_shuffle(order.begin(), order.end());

--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -103,11 +103,11 @@ struct RNNLanguageModel {
         auto dist = as_vector(cg.incremental_forward(dist_expr));
         double p = rand01();
         cur = 0;
-        for (; cur < dist.size(); ++cur) {
+        for (; static_cast<unsigned>(cur) < dist.size(); ++cur) {
           p -= dist[cur];
           if (p < 0.0) { break; }
         }
-        if (cur == dist.size()) cur = kEOS;
+        if (static_cast<unsigned>(cur) == dist.size()) cur = kEOS;
       }
       if (cur == kEOS) break;
       ++len;

--- a/examples/cpp/tag-bilstm/train_tag-bilstm.cc
+++ b/examples/cpp/tag-bilstm/train_tag-bilstm.cc
@@ -101,7 +101,7 @@ struct RNNLanguageModel {
           // Find best tag according to the distribution
           double best = -9e99;
           int besti = -1;
-          for (int i = 0; i < dist.size(); ++i) {
+          for (int i = 0; i < static_cast<int>(dist.size()); ++i) {
             if (dist[i] > best) { best = dist[i]; besti = i; }
           }
           if (tags[t] == besti) (*cor)++;

--- a/tests/test-rnn.cc
+++ b/tests/test-rnn.cc
@@ -481,10 +481,10 @@ BOOST_AUTO_TEST_CASE( lstm_node_multi_input_fwd ) {
   for (unsigned i = 0; i < 3; i++) {
     Expression gates_t = dynet::vanilla_lstm_gates_concat({x1, x3}, h_tm1, Wx, Wh, b, 0.0f);
     Expression gates_t_2 = dynet::vanilla_lstm_gates_concat({x}, h_tm1, Wx, Wh, b, 0.0f);
-    for(int b=0; b<batch_size; b++){
-      for(int u=0; u<4*hidden_dim; u++){
-        BOOST_CHECK_CLOSE(as_vector(pick_batch_elem(gates_t, (unsigned)b).value())[u],
-        as_vector(pick_batch_elem(gates_t_2, (unsigned)b).value())[u],
+    for(unsigned b=0; b<batch_size; b++){
+      for(unsigned u=0; u<4*hidden_dim; u++){
+        BOOST_CHECK_CLOSE(as_vector(pick_batch_elem(gates_t, b).value())[u],
+        as_vector(pick_batch_elem(gates_t_2, b).value())[u],
         0.001);
       }
     }
@@ -553,10 +553,10 @@ BOOST_AUTO_TEST_CASE( lstm_node_dropout_multi_input_fwd ) {
   for (unsigned i = 0; i < 3; i++) {
     Expression gates_t = dynet::vanilla_lstm_gates_dropout_concat({x1, x3}, h_tm1, Wx, Wh, b, mask_x, mask_h, 0.0f);
     Expression gates_t_2 = dynet::vanilla_lstm_gates_dropout(x, h_tm1, Wx, Wh, b, mask_x, mask_h, 0.0f);
-    for(int b=0; b<batch_size; b++){
-      for(int u=0; u<4*hidden_dim; u++){
-        BOOST_CHECK_CLOSE(as_vector(pick_batch_elem(gates_t, (unsigned)b).value())[u],
-        as_vector(pick_batch_elem(gates_t_2, (unsigned)b).value())[u],
+    for(unsigned b=0; b<batch_size; b++){
+      for(unsigned u=0; u<4*hidden_dim; u++){
+        BOOST_CHECK_CLOSE(as_vector(pick_batch_elem(gates_t, b).value())[u],
+        as_vector(pick_batch_elem(gates_t_2, b).value())[u],
         0.001);
       }
     }


### PR DESCRIPTION
Currently, we see lots of warnings when building with `-DBACKEND=cuda`.
This attempts to fix -Wsign-compare warnings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/883)
<!-- Reviewable:end -->
