### PR TITLE
Fix -Wshorten-64-to-32 warnings

### DIFF
--- a/dynet/dim.h
+++ b/dynet/dim.h
@@ -77,7 +77,7 @@ struct Dim {
         x.size() <= DYNET_MAX_TENSOR_DIM,
         "Out of bounds exception in Dim::Dim() with vector of size "
         << x.size());
-    for (auto v : x) d[nd++] = v;
+    for (auto v : x) d[nd++] = static_cast<unsigned int>(v);
   }
   /**
      * \brief Initialize from a vector of dimensions and a batch size
@@ -90,7 +90,7 @@ struct Dim {
         x.size() <= DYNET_MAX_TENSOR_DIM,
         "Out of bounds exception in Dim::Dim() with vector of size "
         << x.size());
-    for (auto v : x) d[nd++] = v;
+    for (auto v : x) d[nd++] = static_cast<unsigned int>(v);
   }
   /**
    * \brief Total size of a batch

--- a/dynet/rnn.h
+++ b/dynet/rnn.h
@@ -85,7 +85,7 @@ struct RNNBuilder {
   Expression set_h(const RNNPointer& prev, const std::vector<Expression>& h_new = {}) {
     sm.transition(RNNOp::add_input);
     head.push_back(prev);
-    cur = head.size() - 1;
+    cur = static_cast<int>(head.size()) - 1;
     return set_h_impl(prev, h_new);
   }
 
@@ -105,7 +105,7 @@ struct RNNBuilder {
   Expression set_s(const RNNPointer& prev, const std::vector<Expression>& s_new = {}) {
     sm.transition(RNNOp::add_input);
     head.push_back(prev);
-    cur = head.size() - 1;
+    cur = static_cast<int>(head.size()) - 1;
     return set_s_impl(prev, s_new);
   }
 
@@ -121,7 +121,7 @@ struct RNNBuilder {
     sm.transition(RNNOp::add_input);
     head.push_back(cur);
     int rcp = cur;
-    cur = head.size() - 1;
+    cur = static_cast<int>(head.size()) - 1;
     return add_input_impl(rcp, x);
   }
 
@@ -140,7 +140,7 @@ struct RNNBuilder {
   Expression add_input(const RNNPointer& prev, const Expression& x) {
     sm.transition(RNNOp::add_input);
     head.push_back(prev);
-    cur = head.size() - 1;
+    cur = static_cast<int>(head.size()) - 1;
     return add_input_impl(prev, x);
   }
 


### PR DESCRIPTION
This fixes warnings in `rnn.h` and `dim.h`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/886)
<!-- Reviewable:end -->
