### PR TITLE
Suppress warnings in compiling Cython generated file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ if ENV.get("MSVC") == "1":
     append_cmake_lib_list(LIBRARIES, ENV.get("CUDA_RT_FILES"))
     append_cmake_list(LIBRARY_DIRS, ENV.get("CUDA_RT_DIRS"))
 else:
-    COMPILER_ARGS[:] = ["-std=c++11"]
+    COMPILER_ARGS[:] = ["-std=c++11", "-Wno-shorten-64-to-32", "-Wno-unused-function"]
     RUNTIME_LIB_DIRS.extend([DYNET_LIB_DIR, LIBS_INSTALL_DIR])
     # in some OSX systems, the following extra flags are needed:
     if platform.system() == "Darwin":


### PR DESCRIPTION
This attempts to suppress warnings by disabling in compiling Cythoned files.
It seems like Cython doesn't provide the interface to control the code generation
to avoid warnings like `-Wunused-function` or `-Wshorten-64-to-32`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/887)
<!-- Reviewable:end -->
