### PR TITLE
More fine grained access to numpy LookupParams

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -830,7 +830,7 @@ cdef class LookupParameters: # {{{
         """
         cdef vector[CTensor] vals
         vals = self.thisptr.get_storage().values
-        return np.vstack([c_tensor_as_np(vals[row]).reshape(1,-1,order='F') for row in rows])
+        return np.stack([c_tensor_as_np(vals[row]) for row in rows])
 
     cpdef as_array(self):
         """Return as a numpy array.
@@ -842,7 +842,7 @@ cdef class LookupParameters: # {{{
         """
         cdef vector[CTensor] vals
         vals = self.thisptr.get_storage().values
-        return np.vstack([c_tensor_as_np(t).reshape(1,-1,order='F') for t in vals])
+        return np.stack([c_tensor_as_np(t) for t in vals])
 
     cpdef grad_as_array(self):
         """Return gradients as a numpy array.
@@ -854,7 +854,7 @@ cdef class LookupParameters: # {{{
         """
         cdef vector[CTensor] grads
         grads = self.thisptr.get_storage().grads
-        return np.vstack([c_tensor_as_np(t).reshape(1,-1,order='F') for t in grads])
+        return np.stack([c_tensor_as_np(t) for t in grads])
 
     cpdef row_grad_as_array(self, row):
         """Return row gradient as a numpy array.
@@ -882,7 +882,7 @@ cdef class LookupParameters: # {{{
         """
         cdef vector[CTensor] vals
         vals = self.thisptr.get_storage().grads
-        return np.vstack([c_tensor_as_np(vals[row]).reshape(1,-1,order='F') for row in rows])
+        return np.stack([c_tensor_as_np(vals[row]) for row in rows])
 
     
     cpdef scale(self,float s):

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -804,6 +804,34 @@ cdef class LookupParameters: # {{{
         """
         self.thisptr.initialize(i, row)
 
+    cpdef row_as_array(self, row):
+        """Return row as a numpy array.
+        
+        Args:
+            row (int): row to return
+
+        Returns:
+            np.array: Values
+        """
+        cdef CTensor val
+        val = self.thisptr.get_storage().values[row]
+        return c_tensor_as_np(val)
+
+    cpdef rows_as_array(self, rows):
+        """Return rows as a numpy array.
+
+        The first dimension is the lookup dimension
+        
+        Args:
+            rows (list): rows to return
+
+        Returns:
+            np.array: Values
+        """
+        cdef vector[CTensor] vals
+        vals = self.thisptr.get_storage().values
+        return np.vstack([c_tensor_as_np(vals[row]).reshape(1,-1,order='F') for row in rows])
+
     cpdef as_array(self):
         """Return as a numpy array.
 
@@ -827,6 +855,35 @@ cdef class LookupParameters: # {{{
         cdef vector[CTensor] grads
         grads = self.thisptr.get_storage().grads
         return np.vstack([c_tensor_as_np(t).reshape(1,-1,order='F') for t in grads])
+
+    cpdef row_grad_as_array(self, row):
+        """Return row gradient as a numpy array.
+        
+        Args:
+            row (int): row to return
+
+        Returns:
+            np.array: Values
+        """
+        cdef CTensor val
+        val = self.thisptr.get_storage().grads[row]
+        return c_tensor_as_np(val)
+
+    cpdef rows_grad_as_array(self, rows):
+        """Return rows gradients as a numpy array.
+
+        The first dimension is the lookup dimension
+        
+        Args:
+            rows (list): rows to return
+
+        Returns:
+            np.array: Values
+        """
+        cdef vector[CTensor] vals
+        vals = self.thisptr.get_storage().grads
+        return np.vstack([c_tensor_as_np(vals[row]).reshape(1,-1,order='F') for row in rows])
+
     
     cpdef scale(self,float s):
         """Scales the parameter

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -96,6 +96,18 @@ class TestParameters(unittest.TestCase):
         self.trainer = dy.SimpleSGDTrainer(self.m, learning_rate=0.1)
         self.trainer.set_clip_threshold(-1)
 
+    def test_as_array(self):
+        # Values
+        self.p1.as_array()
+        self.lp1.as_array()
+        self.lp1.row_as_array(0)
+        self.lp1.rows_as_array([5, 6, 9])
+        # Gradients
+        self.p1.grad_as_array()
+        self.lp1.as_array()
+        self.lp1.row_grad_as_array(0)
+        self.lp1.rows_grad_as_array([5, 6, 9])
+
     def test_grad(self):
         # add parameter
         p = self.m.parameters_from_numpy(np.arange(5))


### PR DESCRIPTION
This makes it possible to get the numpy value (or gradient value) of a lookup parameter for certain rows only (so that the whole array doesn't need to be transferred). !tested and documented