### PR TITLE
Allow adding model parameters after update

### DIFF
--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -255,9 +255,14 @@ ParameterCollectionStorage::~ParameterCollectionStorage() {
 }
 
 void ParameterCollectionStorage::project_weights(float radius) {
-  static float* project_scratch = 0;
-  if (!project_scratch)
-    project_scratch = (float*)default_device->mem->malloc(all_params.size() * sizeof(float));
+  static float* project_scratch = nullptr;
+  auto scratch_size = all_params.size() * sizeof(float);
+  if (project_scratch == nullptr || sizeof(project_scratch) < scratch_size) {
+    if (project_scratch != nullptr) {
+      default_device->mem->free(gradient_norm_scratch);
+    }
+    project_scratch = (float *) default_device->mem->malloc(scratch_size);
+  }
   int pi = 0;
   for (auto p : all_params) {
     p->squared_l2norm(&project_scratch[pi]);

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -782,8 +782,12 @@ void LookupParameterStorage::scale_gradient(float a) {
 
 template <class MyDevice>
 float ParameterCollectionStorage::gradient_l2_norm_dev(MyDevice &dev) const {
-  if (gradient_norm_scratch == nullptr) {
-    gradient_norm_scratch = (float*)dev.mem->malloc((all_params.size() + 1) * sizeof(float));
+  auto scratch_size = (all_params.size() + 1) * sizeof(float);
+  if (gradient_norm_scratch == nullptr || sizeof(gradient_norm_scratch) < scratch_size) {
+    if (gradient_norm_scratch != nullptr) {
+      dev.mem->free(gradient_norm_scratch);
+    }
+    gradient_norm_scratch = (float*)dev.mem->malloc(scratch_size);
   }
   size_t pi;
   size_t k1 = 0, k2 = 0;

--- a/dynet/shadow-params.cc
+++ b/dynet/shadow-params.cc
@@ -33,24 +33,21 @@ void ShadowLookupParameters::initialize_lookups() {
   }
 }
 
-vector<ShadowParameters> allocate_shadow_parameters(const ParameterCollection& m, unsigned allocated) {
+void allocate_shadow_parameters(const ParameterCollection& m, unsigned allocated, vector<ShadowParameters>& target) {
   auto& params = m.parameters_list();
   vector<ParameterStorage*> to_allocate(params.begin() + allocated, params.end());
   vector<ShadowParameters> v;
-  v.reserve(to_allocate.size());
+  target.reserve(params.size());
   for (auto& p : to_allocate)
-    v.emplace_back(*p);
-  return v;
+    target.emplace_back(*p);
 }
 
-vector<ShadowLookupParameters> allocate_shadow_lookup_parameters(const ParameterCollection& m, unsigned allocated) {
+void allocate_shadow_lookup_parameters(const ParameterCollection& m, unsigned allocated, vector<ShadowLookupParameters>& target) {
   auto& params = m.lookup_parameters_list();
   vector<LookupParameterStorage*> to_allocate(params.begin() + allocated, params.end());
-  vector<ShadowLookupParameters> v;
-  v.reserve(to_allocate.size());
+  target.reserve(params.size());
   for (auto& p : to_allocate)
-    v.emplace_back(*p);
-  return v;
+    target.emplace_back(*p);
 }
 
 } // namespace dynet

--- a/dynet/shadow-params.cc
+++ b/dynet/shadow-params.cc
@@ -33,18 +33,22 @@ void ShadowLookupParameters::initialize_lookups() {
   }
 }
 
-vector<ShadowParameters> allocate_shadow_parameters(const ParameterCollection& m) {
+vector<ShadowParameters> allocate_shadow_parameters(const ParameterCollection& m, unsigned allocated) {
+  auto& params = m.parameters_list();
+  vector<ParameterStorage*> to_allocate(params.begin() + allocated, params.end());
   vector<ShadowParameters> v;
-  v.reserve(m.parameters_list().size());
-  for (auto& p : m.parameters_list())
+  v.reserve(to_allocate.size());
+  for (auto& p : to_allocate)
     v.emplace_back(*p);
   return v;
 }
 
-vector<ShadowLookupParameters> allocate_shadow_lookup_parameters(const ParameterCollection& m) {
+vector<ShadowLookupParameters> allocate_shadow_lookup_parameters(const ParameterCollection& m, unsigned allocated) {
+  auto& params = m.lookup_parameters_list();
+  vector<LookupParameterStorage*> to_allocate(params.begin() + allocated, params.end());
   vector<ShadowLookupParameters> v;
-  v.reserve(m.lookup_parameters_list().size());
-  for (auto& p : m.lookup_parameters_list())
+  v.reserve(to_allocate.size());
+  for (auto& p : to_allocate)
     v.emplace_back(*p);
   return v;
 }

--- a/dynet/shadow-params.h
+++ b/dynet/shadow-params.h
@@ -30,9 +30,9 @@ struct ShadowLookupParameters {
 };
 
 // one per element in model.parameters_list
-std::vector<ShadowParameters> allocate_shadow_parameters(const ParameterCollection& model, unsigned allocated);
+void allocate_shadow_parameters(const ParameterCollection& model, unsigned allocated, std::vector<ShadowParameters>& target);
 // one per element in model.lookup_parameters_list
-std::vector<ShadowLookupParameters> allocate_shadow_lookup_parameters(const ParameterCollection& model, unsigned allocated);
+void allocate_shadow_lookup_parameters(const ParameterCollection& model, unsigned allocated, std::vector<ShadowLookupParameters>& target);
 
 } // namespace dynet
 

--- a/dynet/shadow-params.h
+++ b/dynet/shadow-params.h
@@ -30,9 +30,9 @@ struct ShadowLookupParameters {
 };
 
 // one per element in model.parameters_list
-std::vector<ShadowParameters> allocate_shadow_parameters(const ParameterCollection& model);
+std::vector<ShadowParameters> allocate_shadow_parameters(const ParameterCollection& model, unsigned allocated);
 // one per element in model.lookup_parameters_list
-std::vector<ShadowLookupParameters> allocate_shadow_lookup_parameters(const ParameterCollection& model);
+std::vector<ShadowLookupParameters> allocate_shadow_lookup_parameters(const ParameterCollection& model, unsigned allocated);
 
 } // namespace dynet
 

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -43,7 +43,7 @@ struct Trainer {
    */
   explicit Trainer(ParameterCollection& m, real learning_rate) :
     learning_rate(learning_rate), clipping_enabled(true), clip_threshold(5),
-    clips(), updates(), clips_since_status(), updates_since_status(), sparse_updates_enabled(true), aux_allocated(false), model(&m) {}
+    clips(), updates(), clips_since_status(), updates_since_status(), sparse_updates_enabled(true), aux_allocated(0), aux_allocated_lookup(0), model(&m) {}
   virtual ~Trainer();
 
   /**
@@ -121,7 +121,8 @@ struct Trainer {
    */
   bool sparse_updates_enabled;
 
-  bool aux_allocated;
+  unsigned aux_allocated;
+  unsigned aux_allocated_lookup;
 
   void status() {
     std::cerr << "[lr=" << learning_rate << " clips=" << clips_since_status << " updates=" << updates_since_status << "] ";
@@ -132,7 +133,12 @@ struct Trainer {
 
 protected:
   Trainer() {}
-  virtual void alloc_impl() { }
+  virtual unsigned alloc_impl() {
+      return model->parameters_list().size() - aux_allocated;
+  }
+  virtual unsigned alloc_lookup_impl() {
+      return model->lookup_parameters_list().size() - aux_allocated_lookup;
+  }
   /**
    * \brief The actual rule to update the parameters
    *
@@ -283,7 +289,8 @@ struct MomentumSGDTrainer : public Trainer {
   std::vector<ShadowLookupParameters> vlp;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
-  virtual void alloc_impl() override;
+  virtual unsigned alloc_impl() override;
+  virtual unsigned alloc_lookup_impl() override;
 
   real momentum;
 
@@ -316,7 +323,8 @@ struct AdagradTrainer : public Trainer {
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
-  virtual void alloc_impl() override;
+  virtual unsigned alloc_impl() override;
+  virtual unsigned alloc_lookup_impl() override;
 
   real epsilon;
   std::vector<ShadowParameters> vp;
@@ -352,7 +360,8 @@ struct AdadeltaTrainer : public Trainer {
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
-  virtual void alloc_impl() override;
+  virtual unsigned alloc_impl() override;
+  virtual unsigned alloc_lookup_impl() override;
 
   real epsilon;
   real rho;
@@ -389,7 +398,8 @@ struct RMSPropTrainer : public Trainer {
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
-  virtual void alloc_impl() override;
+  virtual unsigned alloc_impl() override;
+  virtual unsigned alloc_lookup_impl() override;
 
   real epsilon;
   real rho;
@@ -427,15 +437,16 @@ struct AdamTrainer : public Trainer {
 
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
-  virtual void alloc_impl() override;
+  virtual unsigned alloc_impl() override;
+  virtual unsigned alloc_lookup_impl() override;
 
   float beta_1;
   float beta_2;
   float epsilon;
   std::vector<ShadowParameters> m; // History of gradients
   std::vector<ShadowLookupParameters> lm;
-  std::vector<ShadowParameters> v; // History of deltas
-  std::vector<ShadowLookupParameters> lv;
+  std::vector<ShadowParameters> d; // History of deltas
+  std::vector<ShadowLookupParameters> ld;
 private:
   AdamTrainer() {}
 };
@@ -478,7 +489,8 @@ struct EGTrainer : public Trainer {
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
-  virtual void alloc_impl() override;
+  virtual unsigned alloc_impl() override;
+  virtual unsigned alloc_lookup_impl() override;
 
 //-----------------------------------------------------------------------------------------
   real momentum;// with momentum

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -445,8 +445,8 @@ protected:
   float epsilon;
   std::vector<ShadowParameters> m; // History of gradients
   std::vector<ShadowLookupParameters> lm;
-  std::vector<ShadowParameters> d; // History of deltas
-  std::vector<ShadowLookupParameters> ld;
+  std::vector<ShadowParameters> v; // History of deltas
+  std::vector<ShadowLookupParameters> lv;
 private:
   AdamTrainer() {}
 };

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -202,6 +202,15 @@ class TestParameters(unittest.TestCase):
                         0] * 0.9), msg=np.array_str(self.lp1.as_array()[1]))
         self.assertTrue(np.allclose(self.lp2.as_array()[1], ones[
                         0] * 0.9), msg=np.array_str(self.lp2.as_array()))
+     
+     def test_param_change_after_update(self):
+        trainer = dy.AdamTrainer(self.m)
+        trainer.update()
+        p = self.m.add_parameters((1,))
+        x = dy.parameter(p)
+        x.forward()
+        x.backward()
+        trainer.update()
 
 
 class TestBatchManipulation(unittest.TestCase):

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -204,13 +204,15 @@ class TestParameters(unittest.TestCase):
                         0] * 0.9), msg=np.array_str(self.lp2.as_array()))
 
     def test_param_change_after_update(self):
-        trainer = dy.AdamTrainer(self.m)
-        trainer.update()
-        p = self.m.add_parameters((1,))
-        x = dy.parameter(p)
-        x.forward()
-        x.backward()
-        trainer.update()
+        for trainer_type in dy.SimpleSGDTrainer, dy.AdamTrainer:
+            trainer = trainer_type(self.m)
+            for _ in range(100):
+                p = self.m.add_parameters((1,))
+                dy.renew_cg()
+                x = dy.parameter(p)
+                x.forward()
+                x.backward()
+                trainer.update()
 
 
 class TestBatchManipulation(unittest.TestCase):

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -202,8 +202,8 @@ class TestParameters(unittest.TestCase):
                         0] * 0.9), msg=np.array_str(self.lp1.as_array()[1]))
         self.assertTrue(np.allclose(self.lp2.as_array()[1], ones[
                         0] * 0.9), msg=np.array_str(self.lp2.as_array()))
-     
-     def test_param_change_after_update(self):
+
+    def test_param_change_after_update(self):
         trainer = dy.AdamTrainer(self.m)
         trainer.update()
         p = self.m.add_parameters((1,))


### PR DESCRIPTION
Instead of allocating shadow parameters (e.g. gradient history) just at the first call to `update()`, now the trainers check if there are more parameters in the models than there are shadow parameters, and if so, allocate additional ones.