### PR TITLE
Remove '-Wno-shorten-64-to-32' as gcc doesn't support it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,7 @@ if ENV.get("MSVC") == "1":
     append_cmake_lib_list(LIBRARIES, ENV.get("CUDA_RT_FILES"))
     append_cmake_list(LIBRARY_DIRS, ENV.get("CUDA_RT_DIRS"))
 else:
-    COMPILER_ARGS[:] = ["-std=c++11", "-Wno-shorten-64-to-32", "-Wno-unused-function"]
+    COMPILER_ARGS[:] = ["-std=c++11", "-Wno-unused-function"]
     RUNTIME_LIB_DIRS.extend([DYNET_LIB_DIR, LIBS_INSTALL_DIR])
     # in some OSX systems, the following extra flags are needed:
     if platform.system() == "Darwin":


### PR DESCRIPTION
`-Wno-shorten-64-to-32` was added in #887, but it turned out gcc doesn't support it. 
It's better to remove the option since that option is clang specific. Users who want to use gcc
would hit build failures in running `python setup.py`.

Alternatively, we could enable depending on available compiler, but this is the easiest way to fix the build failure, I think.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/900)
<!-- Reviewable:end -->
