### PR TITLE
examples: Use --hidden_size to set the size of hidden vectors

### DIFF
--- a/examples/cpp/rnnlm/README.md
+++ b/examples/cpp/rnnlm/README.md
@@ -9,19 +9,19 @@ This downloads the data used in this tutorial.
 Train an LSTM LM using a class-factor softmax:
 
     ./train_rnnlm -x -s -t ../rnnlm/ptb-mikolov/train.txt -d ../rnnlm/ptb-mikolov/valid.txt \
-         -c ../rnnlm/ptb-mikolov/clusters-mkcls.txt -D 0.3 -H 256 --eta_decay_onset_epoch 10 --eta_decay_rate 0.5
+         -c ../rnnlm/ptb-mikolov/clusters-mkcls.txt -D 0.3 --hidden_size 256 --eta_decay_onset_epoch 10 --eta_decay_rate 0.5
 
 Train an LSTM LM with a standard softmax:
 
     ./train_rnnlm -x -s -t ../rnnlm/ptb-mikolov/train.txt -d ../rnnlm/ptb-mikolov/valid.txt \
-         -D 0.3 -H 256 --eta_decay_onset_epoch 10 --eta_decay_rate 0.5
+         -D 0.3 --hidden_size 256 --eta_decay_onset_epoch 10 --eta_decay_rate 0.5
 
 ### Evaluation example
 
 Evaluate a trained model:
 
     ./train_rnnlm -t ../rnnlm/ptb-mikolov/train.txt -c ../rnnlm/ptb-mikolov/clusters-mkcls.txt \
-         -m lm_0.3_2_128_256-pid7865.params -H 256 -p ../rnnlm/ptb-mikolov/test.txt
+         -m lm_0.3_2_128_256-pid7865.params --hidden_size 256 -p ../rnnlm/ptb-mikolov/test.txt
 
 ### PTB Baselines
 


### PR DESCRIPTION
In rnnlm/README.md, "-H" is used to specify the size of hidden vectors.
There is no such option, though.  Current command line parser silently ignores the non-existent options. This is unfortunate for beginners who want to start with C++ examples.
We should fix the parser so that it can report errors on the use of non-existent options.

Also, "-x" is used in README.md but I can't find such option either. What's the correct option for it?
"--bidirectionnal"?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/902)
<!-- Reviewable:end -->
