### PR TITLE
examples: attempt to fix training with standard softmax

### DIFF
--- a/examples/cpp/rnnlm/train_rnnlm.cc
+++ b/examples/cpp/rnnlm/train_rnnlm.cc
@@ -194,8 +194,6 @@ int main(int argc, char** argv) {
   d.freeze(); // no new word types allowed
   d.set_unk("<unk>");
   VOCAB_SIZE = d.size();
-  if (!cfsm)
-    cfsm = new StandardSoftmaxBuilder(HIDDEN_DIM, VOCAB_SIZE, model);
 
   if (params.test_file != "") {
     string testf = params.test_file;


### PR DESCRIPTION
BuildLMGraph assumes "cfsm" points to an object
of class factored softmax, but it can point to
an object of StandardSoftmaxBuilder if users run
the command as documented in README.md.

I'm not sure this is a correct fix because the comments
in BuildLMGraph use a bit different term, "regular softmax".
If it refers to the standard softmax, removing allocating
StandardSoftmaxBuilder object seems correct.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/905)
<!-- Reviewable:end -->
