### PR TITLE
Fix timeout on Travis CI while installing packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,20 +10,6 @@ compiler:
   - gcc
   - clang
 dist: trusty
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-      - boost-latest
-    packages:
-      - gcc-4.8
-      - g++-4.8
-      - libboost-filesystem1.55-dev
-      - libboost-program-options1.55-dev
-      - libboost-serialization1.55-dev
-      - libboost-test1.55-dev
-      - libboost-regex1.55-dev
-      - pandoc
 env:
   global:
     - PYTHON=python CONDA_PACKAGES="numpy cython" TWINE_USERNAME=danielh
@@ -57,6 +43,7 @@ matrix:
       env: PYVER=3.6 PYNUM=3 PYTHON_INSTALL=pip BUILD_ARCH=i686
 
 before_install:
+  - travis_retry .travis/install_packages.sh
   - travis_retry .travis/install_conda.sh
   - export PATH="$PWD/miniconda/bin:$PATH"
   - source activate "$PYVER"

--- a/.travis/install_packages.sh
+++ b/.travis/install_packages.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -xe
+
+if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+  sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+  sudo apt-get -qq update
+  sudo apt-get install -y --allow-unauthenticated gcc-4.8 g++-4.8 libboost-filesystem1.55-dev libboost-program-options1.55-dev libboost-serialization1.55-dev libboost-test1.55-dev libboost-regex1.55-dev pandoc
+else
+  brew install pandoc
+fi


### PR DESCRIPTION
Using the `apt` Travis CI addon often fails due to timeout, since it doesn't use retry. We use `sudo` anyway, so might as well run `apt-get`.