### PR TITLE
Dynet-906. Fix hardcoded build folder name.

### DIFF
--- a/.travis/build_macos_wheel.sh
+++ b/.travis/build_macos_wheel.sh
@@ -6,6 +6,7 @@ source activate "$PYVER"
 pip install pypandoc delocate
 python setup.py bdist_wheel
 DYLIB="$TRAVIS_BUILD_DIR"/miniconda/envs/"$PYVER"/lib/libdynet.dylib
+cd build/py*/python
 WHEEL=dist/*.whl
 echo Trying to relink $DYLIB into $WHEEL...
 DEPS_BEFORE="$(delocate-listdeps $WHEEL)"

--- a/.travis/build_manylinux_wheel.sh
+++ b/.travis/build_manylinux_wheel.sh
@@ -14,7 +14,7 @@ else  # build
   python setup.py bdist_wheel
   source deactivate  # auditwheel installed in system but not in conda env
   export LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/miniconda/envs/$PYVER/lib" 
-  cd ./build/py*/python
+  cd build/py*/python
   auditwheel repair dist/*.whl
   rm -f dist/*.whl
   mv -f wheelhouse/*.whl dist/

--- a/.travis/build_manylinux_wheel.sh
+++ b/.travis/build_manylinux_wheel.sh
@@ -14,6 +14,7 @@ else  # build
   python setup.py bdist_wheel
   source deactivate  # auditwheel installed in system but not in conda env
   export LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/miniconda/envs/$PYVER/lib" 
+  cd ./build/py*/python
   auditwheel repair dist/*.whl
   rm -f dist/*.whl
   mv -f wheelhouse/*.whl dist/

--- a/.travis/test_dynet.sh
+++ b/.travis/test_dynet.sh
@@ -22,6 +22,7 @@ else
     cd python
     python ../../setup.py build --build-dir=.. --skip-build install --user
   else
+    cd ./build/py*/python
     pip install dynet --no-index -f dist
     if [[ "$TRAVIS_OS_NAME" == osx ]]; then
       export DYLD_LIBRARY_PATH=$(dirname $(which python))/../lib:$DYLD_LIBRARY_PATH

--- a/.travis/test_dynet.sh
+++ b/.travis/test_dynet.sh
@@ -22,7 +22,7 @@ else
     cd python
     python ../../setup.py build --build-dir=.. --skip-build install --user
   else
-    cd ./build/py*/python
+    cd build/py*/python
     pip install dynet --no-index -f dist
     if [[ "$TRAVIS_OS_NAME" == osx ]]; then
       export DYLD_LIBRARY_PATH=$(dirname $(which python))/../lib:$DYLD_LIBRARY_PATH

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,12 @@ except NameError:
     this_file = sys.argv[0]
 ORIG_DIR = os.getcwd()
 SCRIPT_DIR = os.path.dirname(os.path.abspath(this_file))
-BUILD_DIR = os.path.join(SCRIPT_DIR, "build")
+if ORIG_DIR.rstrip('/').endswith('python'):
+    BUILD_DIR = ORIG_DIR.rstrip('/').rstrip('python')
+    PYTHON_DIR = ORIG_DIR
+else:
+    BUILD_DIR = ORIG_DIR
+    PYTHON_DIR = ORIG_DIR + '/python'
 ENV = get_env(BUILD_DIR)
 
 # Find the paths
@@ -151,7 +156,7 @@ INCLUDE_DIRS[:] = filter(None, [PROJECT_SOURCE_DIR, EIGEN3_INCLUDE_DIR])
 
 TARGET = [Extension(
     "_dynet",  # name of extension
-    ["_dynet.pyx"],  # filename of our Pyrex/Cython source
+    [BUILD_DIR + "/python/_dynet.pyx"],  # filename of our Pyrex/Cython source
     language="c++",  # this causes Pyrex/Cython to create C++ source
     include_dirs=INCLUDE_DIRS,
     libraries=LIBRARIES,
@@ -291,7 +296,7 @@ class build_ext(_build_ext):
                 target_dir = os.path.join(SCRIPT_DIR, "build", d)
                 rmtree(target_dir, ignore_errors=True)
                 copytree(os.path.join("build", d), target_dir)
-        os.chdir(ORIG_DIR)
+        os.chdir(PYTHON_DIR)
 
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -296,7 +296,6 @@ class build_ext(_build_ext):
                 target_dir = os.path.join(SCRIPT_DIR, "build", d)
                 rmtree(target_dir, ignore_errors=True)
                 copytree(os.path.join("build", d), target_dir)
-        os.chdir(PYTHON_DIR)
 
 
 try:

--- a/setup.py
+++ b/setup.py
@@ -156,7 +156,7 @@ INCLUDE_DIRS[:] = filter(None, [PROJECT_SOURCE_DIR, EIGEN3_INCLUDE_DIR])
 
 TARGET = [Extension(
     "_dynet",  # name of extension
-    [BUILD_DIR + "/python/_dynet.pyx"],  # filename of our Pyrex/Cython source
+    [PYTHON_DIR + "/_dynet.pyx"],  # filename of our Pyrex/Cython source
     language="c++",  # this causes Pyrex/Cython to create C++ source
     include_dirs=INCLUDE_DIRS,
     libraries=LIBRARIES,


### PR DESCRIPTION
Address https://github.com/clab/dynet/issues/906. With this fix, we can create names(`build_gbd`, `build_opt`, `build_dynet-906`, etc) that user wants for manually build. 