### PR TITLE
Continuous integration for Windows using AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,70 @@
+os: Visual Studio 2015
+
+platform: x64
+
+environment:
+  global:
+    MSVC_DEFAULT_OPTIONS: ON
+    BOOST_ROOT: C:\Libraries\boost_1_59_0
+    BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
+    MSVC: 1
+  matrix:
+#    - MINICONDA: "C:\\Miniconda35-x64"  # 3.5
+#      PYTHON_INSTALL: manual
+    - MINICONDA: "C:\\Miniconda36-x64"  # 3.6
+#      PYTHON_INSTALL: manual
+#    - MINICONDA: "C:\\Miniconda35-x64"  # 3.5
+#      PYTHON_INSTALL: pip
+#    - MINICONDA: "C:\\Miniconda36-x64"  # 3.6
+#      PYTHON_INSTALL: pip
+
+configuration: Release
+
+init:
+  - cmd: cmake --version
+  - cmd: msbuild /version
+
+install:
+  - cmd: git submodule update --init --recursive
+  - ps: wget https://bitbucket.org/eigen/eigen/get/1f0f8337c029.zip -OutFile eigen.zip
+  - cmd: 7z x eigen.zip -o"C:\projects" -y > nul
+  - cmd: rename C:\projects\eigen-eigen-1f0f8337c029 eigen
+  - set PATH=%MINICONDA%;%MINICONDA%\Scripts;C:\Program Files (x86)\Pandoc;%PATH%
+  - conda config --set always_yes yes --set changeps1 no
+  - conda install -q conda setuptools pip wheel cython numpy pypandoc
+  - cinst pandoc
+
+before_build:
+  - cmd: md build
+  - cmd: cd build
+  - cmd: cmake -DEIGEN3_INCLUDE_DIR=C:/projects/eigen -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=%configuration% -DENABLE_BOOST=ON -DBOOST_ROOT:PATHNAME="%BOOST_ROOT%" -DBoost_LIBRARY_DIRS:FILEPATH="%BOOST_LIBRARYDIR%" -DBoost_NO_BOOST_CMAKE=TRUE -DBoost_NO_SYSTEM_PATHS=TRUE -DPYTHON=%MINICONDA%/python.exe .. 
+  - cmd: set VS90COMNTOOLS=%VS140COMNTOOLS%
+
+build:
+  project: C:\projects\dynet\build\dynet.sln
+  verbosity: normal
+
+after_build:
+#  - if [%PYTHON_INSTALL%]==[manual] (cd C:\projects\dynet\build\python &&
+#      python ../../setup.py EIGEN3_INCLUDE_DIR=C:/projects/eigen build --build-dir=.. --skip-build install)
+  - cmd: cd C:\projects\dynet\build\python
+  - python ../../setup.py EIGEN3_INCLUDE_DIR=C:/projects/eigen build --build-dir=.. --skip-build install
+#  - if [%PYTHON_INSTALL%]==[pip] (cd C:\projects\dynet && python setup.py sdist bdist_wheel)
+
+test_script:
+#  - cmd: ctest -VV --build-config %configuration% --output-on-failure
+#  - if [%PYTHON_INSTALL%]==[pip] (pip install dynet --no-index -f dist)
+# Gives mysterious "Command exited with code -1073740791":
+#  - python -m unittest discover C:\projects\dynet\tests\python -v
+
+#deploy:
+#  - provider: Script
+#    on:
+#      appveyor_repo_tag: true
+
+#deploy_script:
+#  - cmd: cd C:\projects\dynet
+#  - ps: cat setup.py | % { $_ -replace "0.0.0", %APPVEYOR_REPO_TAG_NAME% } > setup.py
+#  - python setup.py sdist bdist_wheel
+#  - python -m pip install -U twine
+#  - python -m twine upload --skip-existing dist/*

--- a/tests/test-rnn.cc
+++ b/tests/test-rnn.cc
@@ -361,12 +361,12 @@ BOOST_AUTO_TEST_CASE( lstm_node_gates_dropout_fwd ) {
   unsigned batch_size = 2;
   dynet::ComputationGraph cg;
 
-  Expression x_t = dynet::input(cg, Dim({input_dim}, batch_size), {0.0, 0.1, 0.2, 0.3});
+  Expression x_t = dynet::input(cg, Dim({input_dim}, batch_size), {0.0, 0.1f, 0.2f, 0.3f});
   Expression mask_x = dynet::input(cg, Dim({input_dim}, batch_size), {0.0, 1, 1, 1});
 //    cout << "x_t: " << print_vec(as_vector(x_t.value())) << "\n";
 //    cout << "x_t b0: " << print_vec(as_vector(pick_batch_elem(x_t, (unsigned)0).value())) << "\n";
 //    cout << "x_t b1: " << print_vec(as_vector(pick_batch_elem(x_t, (unsigned)1).value())) << "\n";
-  Expression h_tm1 = dynet::input(cg, Dim({input_dim}, batch_size), {0.f, -0.1, 0.2, -0.3});
+  Expression h_tm1 = dynet::input(cg, Dim({input_dim}, batch_size), {0.f, -0.1f, 0.2f, -0.3f});
   Expression mask_h = dynet::input(cg, Dim({input_dim}, batch_size), {0.0, 0.0, 1.0, 1.0});
   Expression Wx = dynet::input(cg, Dim({hidden_dim*4, input_dim}, 1), {0.f, 1.1f, 2.2f, 3.3f, 0.f, 1.1f, 2.2f, 3.3f, 0.f, 1.1f, 2.2f, 3.3f, 0.f, 1.1f, 2.2f, 3.3f});
   Expression Wh = dynet::input(cg, Dim({hidden_dim*4, hidden_dim}, 1), {0.1f, 1.2f, 2.3f, 3.4f, 0.1f, 1.2f, 2.3f, 3.4f, 0.1f, 1.2f, 2.3f, 3.4f, 0.1f, 1.2f, 2.3f, 3.4f});


### PR DESCRIPTION
Someone with write access to clab/dynet needs to create a project on https://ci.appveyor.com/projects/new for this to take effect.