### PR TITLE
Python multi device

### DIFF
--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -223,6 +223,13 @@ cdef extern from "dynet/training.h" namespace "dynet":
     cdef cppclass CAdamTrainer "dynet::AdamTrainer" (CTrainer):
         CAdamTrainer(CModel& m, float alpha, float beta_1, float beta_2, float eps) # TODO removed lam, update docs
 
+cdef extern from "dynet/devices.h" namespace "dynet":
+    cdef cppclass CDevice "dynet::Device":
+        pass
+    cdef cppclass CDeviceManager "dynet::DeviceManager":
+        CDevice* get_global_device(string name)
+
+    CDeviceManager* c_get_device_manager "dynet::get_device_manager" () 
 
 cdef extern from "dynet/expr.h" namespace "dynet":
     cdef cppclass CExpression "dynet::Expression":
@@ -388,6 +395,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_vanilla_lstm_gates_dropout_concat "dynet::vanilla_lstm_gates_dropout_concat" (const vector[CExpression]& x_t, CExpression& h_tm1, CExpression& Wx, CExpression& Wh, CExpression& b, CExpression& dropout_mask_x, CExpression& dropout_mask_h, float weightnoise_std) except + #
     CExpression c_vanilla_lstm_c "dynet::vanilla_lstm_c" (CExpression& c_tm1, CExpression& gates_t) except + #
     CExpression c_vanilla_lstm_h "dynet::vanilla_lstm_h" (CExpression& c_t, CExpression& gates_t) except + #
+    CExpression c_to_device "dynet::to_device" (CExpression& e, CDevice* d) except + #
 
 cdef extern from "dynet/rnn.h" namespace "dynet":
     cdef cppclass CRNNPointer "dynet::RNNPointer":

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -228,6 +228,8 @@ cdef extern from "dynet/training.h" namespace "dynet":
 cdef extern from "dynet/devices.h" namespace "dynet":
     cdef cppclass CDevice "dynet::Device":
         string name
+        int type # TODO how do we do enums in cython?
+        int device_id
 
     cdef cppclass CDeviceManager "dynet::DeviceManager":
         CDevice* get_global_device(string name) except +

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -249,8 +249,11 @@ cdef extern from "dynet/expr.h" namespace "dynet":
         const CTensor& gradient() except +
     #CExpression c_input "dynet::input" (CComputationGraph& g, float s)   #
     CExpression c_input "dynet::input" (CComputationGraph& g, float *ps) except + #
+    CExpression c_input "dynet::input" (CComputationGraph& g, float *ps, CDevice* device) except + #
     CExpression c_input "dynet::input" (CComputationGraph& g, CDim& d, vector[float]* pdata) except +
+    CExpression c_input "dynet::input" (CComputationGraph& g, CDim& d, vector[float]* pdata, CDevice* device) except +
     CExpression c_input "dynet::input" (CComputationGraph& g, CDim& d, vector[unsigned]& ids, vector[float]& data, float defdata) except +
+    CExpression c_input "dynet::input" (CComputationGraph& g, CDim& d, vector[unsigned]& ids, vector[float]& data, float defdata, CDevice* device) except +
     CExpression c_parameter "dynet::parameter" (CComputationGraph& g, CParameters p) except + #
     CExpression c_parameter "dynet::parameter" (CComputationGraph& g, CLookupParameters p) except + #
     CExpression c_const_parameter "dynet::const_parameter" (CComputationGraph& g, CParameters p) except + #

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -102,8 +102,10 @@ cdef extern from "dynet/model.h" namespace "dynet":
         #float gradient_l2_norm() const
         CParameters add_parameters(CDim& d)
         CParameters add_parameters(CDim& d, CParameterInit initializer, string name)
+        CParameters add_parameters(CDim& d, CParameterInit initializer, string name, CDevice *device)
         #CLookupParameters add_lookup_parameters(unsigned n, const CDim& d)
         CLookupParameters add_lookup_parameters(unsigned n, const CDim& d, CParameterInit initializer, string name)
+        CLookupParameters add_lookup_parameters(unsigned n, const CDim& d, CParameterInit initializer, string name, CDevice *device)
         vector[CParameterStorage] parameters_list()
         CModel add_subcollection(string name)
         string get_fullname()
@@ -225,9 +227,12 @@ cdef extern from "dynet/training.h" namespace "dynet":
 
 cdef extern from "dynet/devices.h" namespace "dynet":
     cdef cppclass CDevice "dynet::Device":
-        pass
+        string name
+
     cdef cppclass CDeviceManager "dynet::DeviceManager":
-        CDevice* get_global_device(string name)
+        CDevice* get_global_device(string name) except +
+        CDevice* get(unsigned i)
+        unsigned num_devices()
 
     CDeviceManager* c_get_device_manager "dynet::get_device_manager" () 
 

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -4054,7 +4054,15 @@ cpdef Expression vanilla_lstm_h(Expression c_t, Expression gates_t):
     return Expression.from_cexpr(c_t.cg_version, c_vanilla_lstm_h(c_t.c(),gates_t.c()))
 
 cpdef Expression to_device(Expression e, string device_str):
-    """TODO
+    """Copy Expression's values between devices.
+    Creates a new expression with e's values on device device_str.
+
+    Args:
+        e (dynet.Expression): Expression
+        device_str (string): a device name
+    
+    Returns:
+        dynet.Expression
     """
     ensure_freshness(e)
     cdef CDevice* dev

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1388,15 +1388,15 @@ cdef class ComputationGraph:
     cdef inputValue(self, float v = 0.0, device=""):
         return _inputExpression(self, v, device)
     cdef inputVector(self, int dim, device=""):
-        return _vecInputExpression(self, vector[float](dim), device)
+        return _vecInputExpression(self, vector[float](dim), device=device)
     cdef inputVectorLiteral(self, vector[float] v, device=""):
-        return _vecInputExpression(self, v, device)
+        return _vecInputExpression(self, v, device=device)
     cdef inputMatrix(self, int d1, int d2, device=""):
-        return _vecInputExpression(self, vector[float](d1*d2), (d1,d2), device)
+        return _vecInputExpression(self, vector[float](d1*d2), (d1,d2), device=device)
     def inputMatrixLiteral(self, vector[float] v, tuple d, int batch_size=1,device=""):
-        return _vecInputExpression(self, v, d,batch_size,device)
+        return _vecInputExpression(self, v, d,batch_size,device=device)
     def inputSparseTensor(self, vector[unsigned] idxs, vector[float] v, tuple dim, int batch_size=1, float defval=0, device=""):
-        return _sparseInputExpression(self, idxs, v, dim, batch_size, defval, device)
+        return _sparseInputExpression(self, idxs, v, dim, batch_size, defval, device=device)
     cdef lookup(self, LookupParameters p, unsigned v = 0, update=True):
         return _lookupExpression(self, p, v, update)
     cdef lookup_batch(self, LookupParameters p, vector[unsigned] vs, update=True):

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1432,6 +1432,19 @@ cpdef available_devices():
     dm = c_get_device_manager()
     return [dm.get(i).name for i in xrange(dm.num_devices())]
 
+class DeviceInfo(object):
+    def __init__(self, name, id, dtype):
+        self.name = name
+        self.type = dtype
+        self.id = id
+
+cpdef get_device_info(string name):
+    cdef CDevice *d = c_str2dev(name)
+    # TODO represent type (enum in cython)
+    # TODO enable query of memory size?
+    return DeviceInfo(d.name, d.device_id, -1)
+
+
 cdef CDevice* c_str2dev(string name):
     cdef CDevice* dev
     dev = c_get_device_manager().get_global_device(name)

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3984,6 +3984,14 @@ cpdef Expression vanilla_lstm_h(Expression c_t, Expression gates_t):
     ensure_freshness(gates_t)
     return Expression.from_cexpr(c_t.cg_version, c_vanilla_lstm_h(c_t.c(),gates_t.c()))
 
+cpdef Expression to_device(Expression e, string device_str):
+    """TODO
+    """
+    ensure_freshness(e)
+    cdef CDevice* dev
+    dev = c_get_device_manager().get_global_device(device_str)
+    return Expression.from_cexpr(e.cg_version, c_to_device(e.c(), dev))
+
 # }}}
     
 # {{{ RNNS / Builders


### PR DESCRIPTION
Multi-device support(https://github.com/clab/dynet/issues/92) in the python api. 

Currently there is no dedicated `Device` class, and we refer to devices by their string names.

This seem less cumbersome and more Pythonic to me. However, if we foresee a case where we would really want Device to be an object, we probably should add this now for backward compatibility.

The API is: 
- `dy.available_devices()` returns a list of device names. 
- `dy.to_device(expression, dev_name)` copies an expression across   devices.
- `param_colection.add_parameteres(..., device=name)`
- `param_colection.add_lookup_parameteres(..., device=name)` -
- `param_colection.parameteres_from_numpy(..., device=name)`
- `param_colection.lookup_parameteres_from_numpy(..., device=name)`

The devices mechanism documentation is in docstring of `available_devices()`

There is also a `DeviceInfo` class and `get_device_info(str)` stubs, which we could extend later. I think it could be nice to allow querying devices for their available memory, both on the Python and C++ apis.

[note: I didn't yet tested it on a GPU machine]


