### PR TITLE
replace --dynet-gpu with --dynet-gpus 1 instead of --dynet-devices GPU:0

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -96,11 +96,7 @@ cdef class DynetParams: # {{{
             shared_parameters([type]): [description] (default: None)
         """
         cpu_use = False
-        if '--dynet-gpu' in sys.argv: # the python gpu switch, use GPU:0 by default
-            sys.argv.remove('--dynet-gpu')
-            sys.argv.append('--dynet-devices')
-            sys.argv.append('GPU:0')
-        elif not ('--dynet-gpus' in sys.argv or
+        if not ('--dynet-gpus' in sys.argv or
                   '--dynet-devices' in sys.argv or
                   '--dynet-viz' in sys.argv):
             cpu_use = True

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -96,7 +96,11 @@ cdef class DynetParams: # {{{
             shared_parameters([type]): [description] (default: None)
         """
         cpu_use = False
-        if not ('--dynet-gpus' in sys.argv or
+        if '--dynet-gpu' in sys.argv:
+            sys.argv.remove('--dynet-gpu')
+            sys.argv.append('--dynet-gpus')
+            sys.argv.append('1')
+        elif not ('--dynet-gpus' in sys.argv or
                   '--dynet-devices' in sys.argv or
                   '--dynet-viz' in sys.argv):
             cpu_use = True


### PR DESCRIPTION
#933 
In _dynet.pyx, I noticed that the default configuration is set.

> the python gpu switch, use GPU:0 by default

By removing the replacement procedure,  `dynet/init.cc` will choose appropriate GPU (with most available memory)