### PR TITLE
Add const_parameter to python docs

### DIFF
--- a/doc/source/python_ref.rst
+++ b/doc/source/python_ref.rst
@@ -130,6 +130,8 @@ Input operations
 
 .. autofunction:: dynet.parameter
 
+.. autofunction:: dynet.const_parameter
+
 .. autofunction:: dynet.scalarInput
 
 .. autofunction:: dynet.vecInput


### PR DESCRIPTION
Function is missing documentation! Maybe this split should also be referred in Parameter.expr() docs?