### PR TITLE
Fix typo in tutorial-1-xor.ipynb

### DIFF
--- a/examples/python/tutorials/tutorial-1-xor.ipynb
+++ b/examples/python/tutorials/tutorial-1-xor.ipynb
@@ -44,7 +44,7 @@
     "3. Optimize the model for the objective of the network.\n",
     "\n",
     "As an example, consider a model for solving the \"xor\" problem. The network has two inputs, which can be 0 or 1, and a single output which should be the xor of the two inputs.\n",
-    "We will model this as a multi-layer perceptron with a single hidden node.\n",
+    "We will model this as a multi-layer perceptron with a single hidden layer.\n",
     "\n",
     "Let $x = x_1, x_2$ be our input. We will have a hidden layer of 8 nodes, and an output layer of a single node. The activation on the hidden layer will be a $\\tanh$. Our network will then be:\n",
     "\n",


### PR DESCRIPTION
The tutorial says "a single hidden node", and one line later "a hidden layer of 8 nodes" (which seems to be the case).