### PR TITLE
Multi-gpu support for basic add_parameters function.

### DIFF
--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -214,6 +214,12 @@ void initialize(DynetParams& params) {
   Device *d = new Device_CPU(device_manager->num_devices(), params.mem_descriptor, params.shared_parameters);
   device_manager->add(d);
   default_device = device_manager->get(default_index);
+#if HAVE_CUDA
+  if (default_device->type == DeviceType::GPU) {
+    auto default_gpu_device = static_cast<Device_GPU *>(default_device);
+    CUDA_CHECK(cudaSetDevice(default_gpu_device->cuda_device_id));
+  }
+#endif
 
   // TODO these should be accessed through the relevant device and removed here
   kSCALAR_MINUSONE = default_device->kSCALAR_MINUSONE;

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -54,6 +54,12 @@ ParameterStorage::ParameterStorage(const Dim& d, float scale, const std::string 
     : name(name), dim(d), updated(true), nonzero_grad(false), owner(nullptr), device(dev) {
   DYNET_ARG_CHECK(default_device != nullptr,
                   "Attempting to define parameters before initializing DyNet. Be sure to call dynet::initialize() before defining your model.");
+#if HAVE_CUDA
+  if (dev->type == DeviceType::GPU) {
+    auto gpu_dev = static_cast<Device_GPU *>(dev);
+    CUDA_CHECK(cudaSetDevice(gpu_dev->cuda_device_id));
+  }
+#endif
   values.d = g.d = d;
   values.device = g.device = device;
   device->allocate_tensor(DeviceMempool::PS, values);
@@ -73,6 +79,12 @@ ParameterStorage::ParameterStorage(const Dim& d, const ParameterInit & init,
     : name(name), dim(d), updated(true), nonzero_grad(false), owner(nullptr), device(dev) {
   DYNET_ARG_CHECK(default_device != nullptr,
                   "Attempting to define parameters before initializing DyNet. Be sure to call dynet::initialize() before defining your model.");
+#if HAVE_CUDA
+  if (dev->type == DeviceType::GPU) {
+    auto gpu_dev = static_cast<Device_GPU *>(dev);
+    CUDA_CHECK(cudaSetDevice(gpu_dev->cuda_device_id));
+  }
+#endif
   values.d = g.d = d;
   values.device = g.device = device;
   device->allocate_tensor(DeviceMempool::PS, values);


### PR DESCRIPTION
Address comment under dynet-916(https://github.com/clab/dynet/pull/916#issuecomment-331745925). With this enhancement, I think basically DyNet can support the multi-GPU case. But subtle changes are needed later on to switch between GPU devices before invoking CUDA calls.