### PR TITLE
Fix eigen version

### DIFF
--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -46,7 +46,7 @@ if [[ "$BACKEND" == cuda ]]; then
 fi
 
 # Eigen
-hg clone https://bitbucket.org/eigen/eigen/ -r 346ecdb
+hg clone https://bitbucket.org/eigen/eigen/ -r 699b659
 cd eigen
 mkdir build && cd build
 cmake ..

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -35,7 +35,7 @@ following command:
 
 ::
 
-    hg clone https://bitbucket.org/eigen/eigen/ -r 346ecdb
+    hg clone https://bitbucket.org/eigen/eigen/ -r 699b659
     
 The `-r NUM` specified a revision number that is known to work.  Adventurous
 users can remove it and use the very latest version, at the risk of the code

--- a/doc/source/python.rst
+++ b/doc/source/python.rst
@@ -66,7 +66,7 @@ The following is a list of all the commands needed to perform a manual install:
     cd dynet-base
     # getting dynet and eigen
     git clone https://github.com/clab/dynet.git
-    hg clone https://bitbucket.org/eigen/eigen -r 346ecdb  # -r NUM specified a known working revision
+    hg clone https://bitbucket.org/eigen/eigen -r 699b659  # -r NUM specified a known working revision
     cd dynet
     mkdir build
     cd build

--- a/setup.py
+++ b/setup.py
@@ -240,22 +240,22 @@ class build(_build):
             if os.path.isdir(EIGEN3_INCLUDE_DIR):
                 log.info("Found eigen in " + EIGEN3_INCLUDE_DIR)
             else:
-                try:
-                    # Can use BZ2 or zip, right now using zip
-                    # log.info("Fetching Eigen...")
-                    # urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.tar.bz2")
-                    # log.info("Unpacking Eigen...")
-                    # tfile = tarfile.open("eigen.tar.bz2", 'r')
-                    # tfile.extractall('eigen')
-                    log.info("Fetching Eigen...")
-                    urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.zip")
-                    log.info("Unpacking Eigen...")
-                    zfile = zipfile.open("eigen.zip", 'r')
-                    zfile.extractall('eigen')
-                    #BitBucket packages everything in a tarball with a changing root directory, so grab the only child
-                    EIGEN3_INCLUDE_DIR = os.path.join(BUILD_DIR, "eigen", os.listdir('eigen')[0])
-                except:
-                    raise DistutilsSetupError("Could not download Eigen from " + EIGEN3_DOWNLOAD_URL)
+                # try:
+                # Can use BZ2 or zip, right now using zip
+                # log.info("Fetching Eigen...")
+                # urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.tar.bz2")
+                # log.info("Unpacking Eigen...")
+                # tfile = tarfile.open("eigen.tar.bz2", 'r')
+                # tfile.extractall('eigen')
+                log.info("Fetching Eigen...")
+                urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.zip")
+                log.info("Unpacking Eigen...")
+                zfile = zipfile.open("eigen.zip", 'r')
+                zfile.extractall('eigen')
+                #BitBucket packages everything in a tarball with a changing root directory, so grab the only child
+                EIGEN3_INCLUDE_DIR = os.path.join(BUILD_DIR, "eigen", os.listdir('eigen')[0])
+                # except:
+                #     raise DistutilsSetupError("Could not download Eigen from " + EIGEN3_DOWNLOAD_URL)
 
             # Previously, we used mercurial to download the latest version as follows.
             # This is saved here in case we need to revert to this behavior to get

--- a/setup.py
+++ b/setup.py
@@ -250,7 +250,7 @@ class build(_build):
                 log.info("Fetching Eigen...")
                 urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.zip")
                 log.info("Unpacking Eigen...")
-                zfile = zipfile.open("eigen.zip", 'r')
+                zfile = zipfile.ZipFile("eigen.zip", 'r')
                 zfile.extractall('eigen')
                 #BitBucket packages everything in a tarball with a changing root directory, so grab the only child
                 EIGEN3_INCLUDE_DIR = os.path.join(BUILD_DIR, "eigen", os.listdir('eigen')[0])

--- a/setup.py
+++ b/setup.py
@@ -240,33 +240,22 @@ class build(_build):
             if os.path.isdir(EIGEN3_INCLUDE_DIR):
                 log.info("Found eigen in " + EIGEN3_INCLUDE_DIR)
             else:
-                # try:
-                # Can use BZ2 or zip, right now using zip
-                # log.info("Fetching Eigen...")
-                # urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.tar.bz2")
-                # log.info("Unpacking Eigen...")
-                # tfile = tarfile.open("eigen.tar.bz2", 'r')
-                # tfile.extractall('eigen')
-                log.info("Fetching Eigen...")
-                urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.zip")
-                log.info("Unpacking Eigen...")
-                zfile = zipfile.ZipFile("eigen.zip", 'r')
-                zfile.extractall('eigen')
-                #BitBucket packages everything in a tarball with a changing root directory, so grab the only child
-                EIGEN3_INCLUDE_DIR = os.path.join(BUILD_DIR, "eigen", os.listdir('eigen')[0])
-                # except:
-                #     raise DistutilsSetupError("Could not download Eigen from " + EIGEN3_DOWNLOAD_URL)
-
-            # Previously, we used mercurial to download the latest version as follows.
-            # This is saved here in case we need to revert to this behavior to get
-            # the most recent branch of Eigen.
-            # elif HG_PATH is None:
-            #     raise DistutilsSetupError("`hg` not found.")
-            # else:
-            #     hg_cmd = [HG_PATH, "clone", "https://bitbucket.org/eigen/eigen"]
-            #     log.info("Cloning Eigen...")
-            #     if run_process(hg_cmd) != 0:
-            #         raise DistutilsSetupError(" ".join(hg_cmd))
+                try:
+                    # Can use BZ2 or zip, right now using zip
+                    # log.info("Fetching Eigen...")
+                    # urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.tar.bz2")
+                    # log.info("Unpacking Eigen...")
+                    # tfile = tarfile.open("eigen.tar.bz2", 'r')
+                    # tfile.extractall('eigen')
+                    log.info("Fetching Eigen...")
+                    urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.zip")
+                    log.info("Unpacking Eigen...")
+                    zfile = zipfile.ZipFile("eigen.zip", 'r')
+                    zfile.extractall('eigen')
+                    #BitBucket packages everything in a tarball with a changing root directory, so grab the only child
+                    EIGEN3_INCLUDE_DIR = os.path.join(BUILD_DIR, "eigen", os.listdir('eigen')[0])
+                except:
+                    raise DistutilsSetupError("Could not download Eigen from " + EIGEN3_DOWNLOAD_URL)
 
             os.environ["CXX"] = CXX_PATH
             os.environ["CC"] = CC_PATH

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import distutils.sysconfig
 import logging as log
 import platform
 import tarfile
+import zipfile
 import sys
 from distutils.command.build import build as _build
 from distutils.command.build_py import build_py as _build_py
@@ -117,7 +118,8 @@ if (EIGEN3_INCLUDE_DIR is not None and
     os.path.isdir(os.path.join(os.pardir, EIGEN3_INCLUDE_DIR))):
     EIGEN3_INCLUDE_DIR = os.path.join(os.pardir, EIGEN3_INCLUDE_DIR)
 
-EIGEN3_DOWNLOAD_URL = ENV.get("EIGEN3_DOWNLOAD_URL", "https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2")
+EIGEN3_DOWNLOAD_URL = ENV.get("EIGEN3_DOWNLOAD_URL", "https://bitbucket.org/eigen/eigen/get/699b6595fc47.zip") 
+# EIGEN3_DOWNLOAD_URL = ENV.get("EIGEN3_DOWNLOAD_URL", "https://bitbucket.org/eigen/eigen/get/3.3.4.tar.bz2")
     
 # Remove the "-Wstrict-prototypes" compiler option, which isn't valid for C++.
 cfg_vars = distutils.sysconfig.get_config_vars()
@@ -239,11 +241,17 @@ class build(_build):
                 log.info("Found eigen in " + EIGEN3_INCLUDE_DIR)
             else:
                 try:
+                    # Can use BZ2 or zip, right now using zip
+                    # log.info("Fetching Eigen...")
+                    # urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.tar.bz2")
+                    # log.info("Unpacking Eigen...")
+                    # tfile = tarfile.open("eigen.tar.bz2", 'r')
+                    # tfile.extractall('eigen')
                     log.info("Fetching Eigen...")
-                    urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.tar.bz2")
+                    urlretrieve(EIGEN3_DOWNLOAD_URL, "eigen.zip")
                     log.info("Unpacking Eigen...")
-                    tfile = tarfile.open("eigen.tar.bz2", 'r')
-                    tfile.extractall('eigen')
+                    zfile = zipfile.open("eigen.zip", 'r')
+                    zfile.extractall('eigen')
                     #BitBucket packages everything in a tarball with a changing root directory, so grab the only child
                     EIGEN3_INCLUDE_DIR = os.path.join(BUILD_DIR, "eigen", os.listdir('eigen')[0])
                 except:


### PR DESCRIPTION
Fixes https://github.com/clab/dynet/issues/955

This upgrades the recommended version of Eigen, and also makes the install use a consistent version for both pip and the manual install directions.