### PR TITLE
Use reinterpret_cast to cast from 'const size_t' to 'float*'

### DIFF
--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -258,7 +258,7 @@ void BatchedExecutionEngine::combine_tensors(
 #if HAVE_CUDA
       locs[i] = my_src; // src
       locs[i + TRG] = dest;
-      locs[i + LEN] = static_cast<float*>(sz);
+      locs[i + LEN] = reinterpret_cast<float*>(sz);
       if (max_length < sz) max_length = sz;
       i++;
 #endif


### PR DESCRIPTION
Currently, HEAD of DyNet doesn't compile when CUDA backend is used.
This fixes the build error introduced in 07381369d.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/clab/dynet/968)
<!-- Reviewable:end -->
