### PR TITLE
Fix shape of lookup parameters in python

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -776,7 +776,11 @@ cdef class LookupParameters: # {{{
         Returns:
             tuple: Shape of the parameter
         """
-        return c_dim_as_shape(self.thisptr.get_storage().all_dim)
+        shape = c_dim_as_shape(self.thisptr.get_storage().all_dim)
+        # In C++, the lookup dimension is stored in the last dimension (go figure)
+        # So we need to rotate the shape left to right
+        rotated_shape = tuple([shape[-1]] + list(shape[:-1]))
+        return rotated_shape
 
     def __getitem__(self, int i):
         """

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -100,6 +100,14 @@ class TestParameters(unittest.TestCase):
         [p1, p2] = self.m.parameters_list()
         [lp1, lp2] = self.m.lookup_parameters_list()
 
+    def test_shape(self):
+        shape = (10, 5, 2)
+        lp = self.m.add_lookup_parameters(shape)
+        lp_shape = lp.shape()
+        self.assertEqual(shape[0], lp_shape[0])
+        self.assertEqual(shape[1], lp_shape[1])
+        self.assertEqual(shape[2], lp_shape[2])
+
     def test_as_array(self):
         # Values
         self.p1.as_array()


### PR DESCRIPTION
Hotfix for #971 