### PR TITLE
Multidim2

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -161,9 +161,9 @@ Expression sum_elems(const Expression& x) { return Expression(x.pg, x.pg->add_fu
 
 Expression sum_batches(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumBatches>({x.i})); }
 
-Expression mean_dim(const Expression& x, const vector<unsigned>& dims, bool b) { return Expression(x.pg, x.pg->add_function<MomentDimension>({x.i}, dims, 1, b)); }
-Expression moment_dim(const Expression& x, const vector<unsigned>& dims, unsigned r, bool b) { return Expression(x.pg, x.pg->add_function<MomentDimension>({x.i}, dims, r, b)); }
-Expression std_dim(const Expression& x, const vector<unsigned>& dims, bool b) { return Expression(x.pg, x.pg->add_function<StdDimension>({x.i}, dims, b)); }
+Expression mean_dim(const Expression& x, const vector<unsigned>& dims, bool b, unsigned n) { return Expression(x.pg, x.pg->add_function<MomentDimension>({x.i}, dims, 1, b, n)); }
+Expression moment_dim(const Expression& x, const vector<unsigned>& dims, unsigned r, bool b, unsigned n) { return Expression(x.pg, x.pg->add_function<MomentDimension>({x.i}, dims, r, b, n)); }
+Expression std_dim(const Expression& x, const vector<unsigned>& dims, bool b, unsigned n) { return Expression(x.pg, x.pg->add_function<StdDimension>({x.i}, dims, b, n)); }
 
 Expression moment_elems(const Expression& x, unsigned r) { 
   vector<unsigned> dims(x.dim().nd);

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1593,10 +1593,11 @@ Expression std_batches(const Expression& x);
  * \param x The input mini-batched expression
  * \param d Dimensions along which to reduce
  * \param b Whether to include batch dimension (default: false)
+ * \param n If > 0, overwrite the n in the equation by this value, useful for masking (default: 0)
  *
  * \return An expression with |d| less dimensions and possibly dropped batch dimension
  */
-Expression std_dim(const Expression& x, const std::vector<unsigned>& dims, bool b=false);
+Expression std_dim(const Expression& x, const std::vector<unsigned>& dims, bool b=false, unsigned n=0);
 
 /**
  * \ingroup flowoperations
@@ -1607,10 +1608,11 @@ Expression std_dim(const Expression& x, const std::vector<unsigned>& dims, bool 
  * \param d Dimensions along which to reduce
  * \param r Order of the moment
  * \param b Whether to include batch dimension (default: false)
+ * \param n If > 0, overwrite the n in the equation by this value, useful for masking (default: 0)
  *
  * \return An expression with |d| less dimensions and possibly dropped batch dimension
  */
-Expression moment_dim(const Expression& x, const std::vector<unsigned>& dims, unsigned r, bool b=false);
+Expression moment_dim(const Expression& x, const std::vector<unsigned>& dims, unsigned r, bool b=false, unsigned n=0);
 /**
  * \ingroup flowoperations
  * \brief Compute mean along  a specific dimension
@@ -1619,10 +1621,11 @@ Expression moment_dim(const Expression& x, const std::vector<unsigned>& dims, un
  * \param x The input mini-batched expression
  * \param d Dimensions along which to reduce
  * \param b Whether to include batch dimension (default: false)
+ * \param n If > 0, overwrite the n in the equation by this value, useful for masking (default: 0)
  *
  * \return An expression with |d| less dimensions and possibly dropped batch dimension
  */
-Expression mean_dim(const Expression& x, const std::vector<unsigned>& dims, bool b=false);
+Expression mean_dim(const Expression& x, const std::vector<unsigned>& dims, bool b=false, unsigned n=0);
 
 
 /**

--- a/dynet/nodes-arith-cwise.cc
+++ b/dynet/nodes-arith-cwise.cc
@@ -121,7 +121,7 @@ void CwiseSum::backward_helper(const MyDevice & dev,
   if(ReductionOrder>0) red_axis[ReductionOrder-1] = 4;
   int curr_red_axis = 0;
   for(int di=0; di < fx.d.nd; di++){
-    if(di >= xs[i]->d.nd || xs[i]->d[di] != fx.d[di]){
+    if((di >= xs[i]->d.nd && fx.d[di]>1) || xs[i]->d[di] != fx.d[di]){
       red_axis[curr_red_axis] = di;
       curr_red_axis++;
     }
@@ -242,7 +242,7 @@ void CwiseMultiply::backward_helper(const MyDevice & dev,
   if(ReductionOrder>0) red_axis[ReductionOrder-1] = 4;
   int curr_red_axis = 0;
   for(int di=0; di < fx.d.nd; di++){
-    if(di >= xs[i]->d.nd || xs[i]->d[di] != fx.d[di]){
+    if((di >= xs[i]->d.nd && fx.d[di]>1) || xs[i]->d[di] != fx.d[di]){
       red_axis[curr_red_axis] = di;
       curr_red_axis++;
     }

--- a/dynet/nodes-moments.cc
+++ b/dynet/nodes-moments.cc
@@ -226,9 +226,13 @@ template<class MyDevice>
 void MomentDimension::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in SumDimension");
 
-  float n = 1;
-  for(unsigned i=0; i<dims.size(); i++) n *= (float) xs[0]->d[dims[i]];
-  if(include_batch_dim) n *= xs[0]->d.bd;
+  float n = 1.0;
+  if(overwrite_n==0){
+    for(unsigned i=0; i<dims.size(); i++) n *= (float) xs[0]->d[dims[i]];
+    if(include_batch_dim) n *= xs[0]->d.bd;
+  } else {
+    n = overwrite_n;
+  }
 
   if(dims.size()==0 && include_batch_dim){
     Eigen::array<int, 1> reduction_axis = {1};
@@ -283,9 +287,13 @@ void MomentDimension::backward_dev_impl(const MyDevice & dev,
                              Tensor& dEdxi) const {
   DYNET_ARG_CHECK(i == 0, "Failed dimension check in MomentDimension::backward");
 
-  float n = 1;
-  for(unsigned i=0; i<dims.size(); i++) n *= (float) xs[0]->d[dims[i]];
-  if(include_batch_dim) n *= xs[0]->d.bd;
+  float n = 1.0;
+  if(overwrite_n==0){
+    for(unsigned i=0; i<dims.size(); i++) n *= (float) xs[0]->d[dims[i]];
+    if(include_batch_dim) n *= xs[0]->d.bd;
+  } else {
+    n = overwrite_n;
+  }
 
   if(dims.size()==0 && include_batch_dim){
     Eigen::array<int, 2> bcast = {1, (int)xs[0]->d.bd};
@@ -471,9 +479,13 @@ template<class MyDevice>
 void StdDimension::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   DYNET_ASSERT(xs.size() == 1, "Failed input count check in SumDimension");
 
-  float n = 1;
-  for(unsigned i=0; i<dims.size(); i++) n *= (float) xs[0]->d[dims[i]];
-  if(include_batch_dim) n *= xs[0]->d.bd;
+  float n = 1.0;
+  if(overwrite_n==0){
+    for(unsigned i=0; i<dims.size(); i++) n *= (float) xs[0]->d[dims[i]];
+    if(include_batch_dim) n *= xs[0]->d.bd;
+  } else {
+    n = overwrite_n;
+  }
 
   AlignedMemoryPool* scratch_allocator = fx.device->pools[(int)DeviceMempool::SCS];
 
@@ -531,9 +543,13 @@ void StdDimension::backward_dev_impl(const MyDevice & dev,
                              Tensor& dEdxi) const {
   DYNET_ARG_CHECK(i == 0, "Failed dimension check in StdDimension::backward");
 
-  float n = 1;
-  for(unsigned i=0; i<dims.size(); i++) n *= (float) xs[0]->d[dims[i]];
-  if(include_batch_dim) n *= xs[0]->d.bd;
+  float n = 1.0;
+  if(overwrite_n==0){
+    for(unsigned i=0; i<dims.size(); i++) n *= (float) xs[0]->d[dims[i]];
+    if(include_batch_dim) n *= xs[0]->d.bd;
+  } else {
+    n = overwrite_n;
+  }
 
   AlignedMemoryPool* scratch_allocator = fx.device->pools[(int)DeviceMempool::SCS];
 

--- a/dynet/nodes-moments.h
+++ b/dynet/nodes-moments.h
@@ -40,13 +40,14 @@ private:
 
 //y = \sum_i x_i
 struct MomentDimension : public Node {
-  template <typename T> explicit MomentDimension(const T& a, const std::vector<unsigned> & d, unsigned o, bool b=false) : Node(a), dims(d), order(o), include_batch_dim(b) {}
+  template <typename T> explicit MomentDimension(const T& a, const std::vector<unsigned> & d, unsigned o, bool b=false, unsigned n=0) : Node(a), dims(d), order(o), include_batch_dim(b), overwrite_n(n) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
   virtual bool supports_multibatch() const override { return true; }
 private:
   std::vector<unsigned> dims;
   unsigned order;
   bool include_batch_dim;
+  unsigned overwrite_n;
 };
 
 // y = \sum_i,j,... x[i,j,...]
@@ -65,12 +66,13 @@ struct StdBatches : public Node {
 
 //y = \sum_i x_i
 struct StdDimension : public Node {
-  template <typename T> explicit StdDimension(const T& a, const std::vector<unsigned> & d, bool b=false) : Node(a), dims(d), include_batch_dim(b) {}
+  template <typename T> explicit StdDimension(const T& a, const std::vector<unsigned> & d, bool b=false, unsigned n=0) : Node(a), dims(d), include_batch_dim(b), overwrite_n(n) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
   virtual bool supports_multibatch() const override { return true; }
 private:
   std::vector<unsigned> dims;
   bool include_batch_dim;
+  unsigned overwrite_n;
 };
 
 } // namespace dynet

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -360,11 +360,11 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_sum_elems "dynet::sum_elems" (CExpression& x) except +
     CExpression c_moment_batches "dynet::moment_batches" (CExpression& x, unsigned r) except +
     CExpression c_moment_elems "dynet::moment_elems" (CExpression& x, unsigned r) except +
-    CExpression c_moment_dim "dynet::moment_dim" (CExpression& x, vector[unsigned] dims, unsigned r, bool b) except +
+    CExpression c_moment_dim "dynet::moment_dim" (CExpression& x, vector[unsigned] dims, unsigned r, bool b, unsigned n) except +
     CExpression c_mean_elems "dynet::mean_elems" (CExpression& x) except +
     CExpression c_mean_batches "dynet::mean_batches" (CExpression& x) except +
-    CExpression c_mean_dim "dynet::mean_dim" (CExpression& x, vector[unsigned] dims, bool b) except +
-    CExpression c_std_dim "dynet::std_dim" (CExpression& x, vector[unsigned] dims, bool b) except +
+    CExpression c_mean_dim "dynet::mean_dim" (CExpression& x, vector[unsigned] dims, bool b, unsigned n) except +
+    CExpression c_std_dim "dynet::std_dim" (CExpression& x, vector[unsigned] dims, bool b, unsigned n) except +
     CExpression c_std_elems "dynet::std_elems" (CExpression& x) except +
     CExpression c_std_batches "dynet::std_batches" (CExpression& x) except +
 

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3216,7 +3216,7 @@ cpdef Expression std_batches(Expression x):
     """
     return Expression.from_cexpr(x.cg_version, c_std_batches(x.c()))
 
-cpdef Expression std_dim(Expression x, list d, bool b):
+cpdef Expression std_dim(Expression x, list d, bool b, unsigned n=0):
     """Standard deviation along an arbitrary dimension
     
     Computes the standard deviation :math:`\sigma=\sqrt{\\frac 1 n \sum_i(x_i-\mu)^2}` along arbitrary dimensions.
@@ -3226,14 +3226,15 @@ cpdef Expression std_dim(Expression x, list d, bool b):
         x (dynet.Expression): Input expression
         d (int): Dimensions along which to reduce
         b (bool): Whether to include batch dimension
+        n (int): If > 0, overwrite the n in the equation by this value, useful for masking
     
     Returns:
         dynet.Expression: An expression with |d| less dimensions and possibly dropped batch dimension
     """
-    return Expression.from_cexpr(x.cg_version, c_std_dim(x.c(), d, b))
+    return Expression.from_cexpr(x.cg_version, c_std_dim(x.c(), d, b, n=0))
 
 
-cpdef Expression mean_dim(Expression x, list d, bool b):
+cpdef Expression mean_dim(Expression x, list d, bool b, unsigned n=0):
     """Mean along an arbitrary dimension
     
     Computes the mean :math:`\\frac 1 n \sum_ix_i`  along an arbitrary dimension.
@@ -3241,13 +3242,14 @@ cpdef Expression mean_dim(Expression x, list d, bool b):
 
     Args:
         x (dynet.Expression): Input expression
-        d (int): Dimensions along which to reduce
+        d (list): Dimensions along which to reduce
         b (bool): Whether to include batch dimension
+        n (int): If > 0, overwrite the n in the equation by this value, useful for masking
     
     Returns:
         dynet.Expression: An expression with |d| less dimensions and possibly dropped batch dimension
     """
-    return Expression.from_cexpr(x.cg_version, c_mean_dim(x.c(), d, b))
+    return Expression.from_cexpr(x.cg_version, c_mean_dim(x.c(), d, b, n))
 
 cpdef Expression moment_elems(Expression x, unsigned r):
     """Statistical moment of elements of the tensor
@@ -3275,7 +3277,7 @@ cpdef Expression moment_batches(Expression x, unsigned r):
     """
     return Expression.from_cexpr(x.cg_version, c_moment_batches(x.c(), r))
 
-cpdef Expression moment_dim(Expression x, list d, unsigned r, bool b):
+cpdef Expression moment_dim(Expression x, list d, unsigned r, bool b, unsigned n=0):
     """Statistical moment along an arbitrary dimension
     
     Computes the statistical moment of order :math:`r`, :math:`\\frac 1 n \sum_ix_i^r`  along an arbitrary dimension.
@@ -3283,14 +3285,15 @@ cpdef Expression moment_dim(Expression x, list d, unsigned r, bool b):
 
     Args:
         x (dynet.Expression): Input expression
-        d (list): Dimension along which to reduce
+        d (list): Dimensions along which to reduce
         r (int): Moment order
         b (bool): Whether to include batch dimension
+        n (int): If > 0, overwrite the n in the equation by this value, useful for masking
     
     Returns:
         dynet.Expression: An expression with |d| less dimensions and possibly dropped batch dimension
     """
-    return Expression.from_cexpr(x.cg_version, c_moment_dim(x.c(), d, r, b))
+    return Expression.from_cexpr(x.cg_version, c_moment_dim(x.c(), d, r, b, n))
 
 #expr-opt
 cpdef Expression fold_rows(Expression x, unsigned nrows=2):

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1122,6 +1122,25 @@ BOOST_AUTO_TEST_CASE( trace_of_product_gradient ) {
 }
 
 // Expression cmult(const Expression& x, const Expression& y);
+BOOST_AUTO_TEST_CASE( cadd_broadcast_gradient_scalar ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = reshape(parameter(cg, param_scalar1), Dim({1},1));
+  Expression x2 = reshape(parameter(cg, param4), Dim({3,1,1},2));
+  Expression y = (x1 + x2) + (x2 + x1) + (x1 - x2) + (x2 - x1);
+  Expression z = sum_batches(sum_elems(y));
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+// Expression cmult(const Expression& x, const Expression& y);
+BOOST_AUTO_TEST_CASE( cdiv_broadcast_gradient_scalar ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = reshape(parameter(cg, param_scalar1), Dim({1},1));
+  Expression x2 = reshape(parameter(cg, param4), Dim({3,1,1},2));
+  Expression y = cdiv(x2, x1);
+  Expression z = sum_batches(sum_elems(y));
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression cmult(const Expression& x, const Expression& y);
 BOOST_AUTO_TEST_CASE( cmult_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param1);
@@ -1156,6 +1175,16 @@ BOOST_AUTO_TEST_CASE( scalar_cmult_batch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x1 = parameter(cg, param_scalar1);
   Expression x2 = reshape(parameter(cg, param_square1), Dim({1, 3}, 3));
+  Expression y = cmult(x1, x2) + cmult(x2, x1);
+  Expression z = sum_batches(sum_elems(y));
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression cmult(const Expression& x, const Expression& y);
+BOOST_AUTO_TEST_CASE( cmult_broadcast_gradient_scalar ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = reshape(parameter(cg, param_scalar1), Dim({1},1));
+  Expression x2 = reshape(parameter(cg, param4), Dim({3,1,1},2));
   Expression y = cmult(x1, x2) + cmult(x2, x1);
   Expression z = sum_batches(sum_elems(y));
   BOOST_CHECK(check_grad(mod, z, 0));


### PR DESCRIPTION
- fix an issue with broadcasting along batch dimension
- make it possible to overwrite normalizer in moment operations. This is helpful for computing moments over masked expressions, e.g. for implementing batch normalization.