### PR TITLE
 Run Python unit tests on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,6 +9,9 @@ environment:
     BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
     MSVC: 1
     MINICONDA: "C:\\Miniconda3-x64"
+    TWINE_USERNAME: danielh
+    TWINE_PASSWORD:
+      secure: cpMn69tLzuhwO7EPhhiVwA==
   matrix:
 #    - PYTHON_VERSION: 3.5
 #      PYTHON_INSTALL: manual
@@ -62,14 +65,16 @@ test_script:
 # Gives mysterious "Command exited with code -1073740791":
   - python -m unittest discover C:\projects\dynet\tests\python -v
 
-#deploy:
-#  - provider: Script
-#    on:
-#      appveyor_repo_tag: true
-
-#deploy_script:
-#  - cmd: cd C:\projects\dynet
-#  - ps: cat setup.py | % { $_ -replace "0.0.0", %APPVEYOR_REPO_TAG_NAME% } > setup.py
-#  - python setup.py sdist bdist_wheel
-#  - python -m pip install -U twine
-#  - python -m twine upload --skip-existing dist/*
+deploy_script:
+  - cmd: cd C:\projects\dynet
+  - ps: "(gc setup.py) -replace '0.0.0', '%APPVEYOR_REPO_TAG_NAME%' | Out-File -encoding 'UTF8' setup.py"
+  - python setup.py sdist #bdist_wheel
+  - echo [distutils]                                  > %USERPROFILE%\\.pypirc
+  - echo index-servers =                             >> %USERPROFILE%\\.pypirc
+  - echo     pypi                                    >> %USERPROFILE%\\.pypirc
+  - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
+  - echo repository=https://pypi.python.org/pypi     >> %USERPROFILE%\\.pypirc
+  - echo username=%PYPI_USERNAME%                    >> %USERPROFILE%\\.pypirc
+  - echo password=%PYPI_PASSWORD%                    >> %USERPROFILE%\\.pypirc
+  - python -m pip install twine
+  - if "%APPVEYOR_REPO_TAG%"=="true" ( python -m twine upload --skip-existing dist/* )

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,14 +8,15 @@ environment:
     BOOST_ROOT: C:\Libraries\boost_1_59_0
     BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
     MSVC: 1
+    MINICONDA: "C:\\Miniconda3-x64"
   matrix:
-#    - MINICONDA: "C:\\Miniconda35-x64"  # 3.5
+#    - PYTHON_VERSION: 3.5
 #      PYTHON_INSTALL: manual
-    - MINICONDA: "C:\\Miniconda36-x64"  # 3.6
+    - PYTHON_VERSION: 3.6
 #      PYTHON_INSTALL: manual
-#    - MINICONDA: "C:\\Miniconda35-x64"  # 3.5
+#    - PYTHON_VERSION: 3.5
 #      PYTHON_INSTALL: pip
-#    - MINICONDA: "C:\\Miniconda36-x64"  # 3.6
+#    - PYTHON_VERSION: 3.6
 #      PYTHON_INSTALL: pip
 
 configuration: Release
@@ -23,6 +24,7 @@ configuration: Release
 init:
   - cmd: cmake --version
   - cmd: msbuild /version
+  - "ECHO %PYTHON_VERSION% %MINICONDA%"
 
 install:
   - cmd: git submodule update --init --recursive
@@ -31,13 +33,16 @@ install:
   - cmd: rename C:\projects\eigen-eigen-1f0f8337c029 eigen
   - set PATH=%MINICONDA%;%MINICONDA%\Scripts;C:\Program Files (x86)\Pandoc;%PATH%
   - conda config --set always_yes yes --set changeps1 no
-  - conda install -q conda setuptools pip wheel cython numpy pypandoc
+  - conda update -q conda
+  - conda info -a
+  - conda create -q -n test-env python=%PYTHON_VERSION% cython numpy pypandoc
+  - activate test-env
   - cinst pandoc
 
 before_build:
   - cmd: md build
   - cmd: cd build
-  - cmd: cmake -DEIGEN3_INCLUDE_DIR=C:/projects/eigen -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=%configuration% -DENABLE_BOOST=ON -DBOOST_ROOT:PATHNAME="%BOOST_ROOT%" -DBoost_LIBRARY_DIRS:FILEPATH="%BOOST_LIBRARYDIR%" -DBoost_NO_BOOST_CMAKE=TRUE -DBoost_NO_SYSTEM_PATHS=TRUE -DPYTHON=%MINICONDA%/python.exe .. 
+  - cmd: cmake -DEIGEN3_INCLUDE_DIR=C:/projects/eigen -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=%configuration% -DENABLE_BOOST=ON -DBOOST_ROOT:PATHNAME="%BOOST_ROOT%" -DBoost_LIBRARY_DIRS:FILEPATH="%BOOST_LIBRARYDIR%" -DBoost_NO_BOOST_CMAKE=TRUE -DBoost_NO_SYSTEM_PATHS=TRUE -DPYTHON=python.exe .. 
   - cmd: set VS90COMNTOOLS=%VS140COMNTOOLS%
 
 build:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,7 +60,7 @@ test_script:
 #  - cmd: ctest -VV --build-config %configuration% --output-on-failure
 #  - if [%PYTHON_INSTALL%]==[pip] (pip install dynet --no-index -f dist)
 # Gives mysterious "Command exited with code -1073740791":
-#  - python -m unittest discover C:\projects\dynet\tests\python -v
+  - python -m unittest discover C:\projects\dynet\tests\python -v
 
 #deploy:
 #  - provider: Script

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,26 +47,27 @@ before_build:
   - cmd: cd build
   - cmd: cmake -DEIGEN3_INCLUDE_DIR=C:/projects/eigen -G "Visual Studio 14 2015 Win64" -DCMAKE_BUILD_TYPE=%configuration% -DENABLE_BOOST=ON -DBOOST_ROOT:PATHNAME="%BOOST_ROOT%" -DBoost_LIBRARY_DIRS:FILEPATH="%BOOST_LIBRARYDIR%" -DBoost_NO_BOOST_CMAKE=TRUE -DBoost_NO_SYSTEM_PATHS=TRUE -DPYTHON=python.exe .. 
   - cmd: set VS90COMNTOOLS=%VS140COMNTOOLS%
+  - cmd: cd ..
 
 build:
-  project: C:\projects\dynet\build\dynet.sln
+  project: build\dynet.sln
   verbosity: normal
 
 after_build:
-#  - if [%PYTHON_INSTALL%]==[manual] (cd C:\projects\dynet\build\python &&
+#  - if [%PYTHON_INSTALL%]==[manual] (cd %APPVEYOR_BUILD_FOLDER%\build\python &&
 #      python ../../setup.py EIGEN3_INCLUDE_DIR=C:/projects/eigen build --build-dir=.. --skip-build install)
-  - cmd: cd C:\projects\dynet\build\python
+  - cmd: cd %APPVEYOR_BUILD_FOLDER%\build\python
   - python ../../setup.py EIGEN3_INCLUDE_DIR=C:/projects/eigen build --build-dir=.. --skip-build install
-#  - if [%PYTHON_INSTALL%]==[pip] (cd C:\projects\dynet && python setup.py sdist bdist_wheel)
+#  - if [%PYTHON_INSTALL%]==[pip] (cd %APPVEYOR_BUILD_FOLDER% && python setup.py sdist bdist_wheel)
 
 test_script:
 #  - cmd: ctest -VV --build-config %configuration% --output-on-failure
 #  - if [%PYTHON_INSTALL%]==[pip] (pip install dynet --no-index -f dist)
 # Gives mysterious "Command exited with code -1073740791":
-  - python -m unittest discover C:\projects\dynet\tests\python -v
+  - python -m unittest discover %APPVEYOR_BUILD_FOLDER%\tests\python -v
 
 deploy_script:
-  - cmd: cd C:\projects\dynet
+  - cmd: cd %APPVEYOR_BUILD_FOLDER%
   - ps: "(gc setup.py) -replace '0.0.0', '%APPVEYOR_REPO_TAG_NAME%' | Out-File -encoding 'UTF8' setup.py"
   - python setup.py sdist #bdist_wheel
   - echo [distutils]                                  > %USERPROFILE%\\.pypirc

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ---
 
 [![Build Status](https://travis-ci.org/clab/dynet.svg?branch=master)](https://travis-ci.org/clab/dynet)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/clab/dynet?svg=true)](https://ci.appveyor.com/project/neubig/dynet)
+[![Build Status](https://ci.appveyor.com/api/projects/status/github/clab/dynet?svg=true)](https://ci.appveyor.com/project/danielh/dynet-c3iuq)
 [![Doc build Status](https://readthedocs.org/projects/dynet/badge/?version=latest)](http://dynet.readthedocs.io/en/latest/)
 [![PyPI version](https://badge.fury.io/py/dyNET.svg)](https://badge.fury.io/py/dyNET)
 


### PR DESCRIPTION
The tests didn't work, maybe because the global Conda environment was used. Now creating a local one with the correct Python version.

Also enabled deployment of Windows wheels on tag creation, but note it will currently work only on my fork because I encrypted my PyPI password using my AppVeyor account - you can't encrypt data using another AppVeyor user's account. @neubig, if you want to enable this you'll need to change `TWINE_USERNAME: danielh` to `TWINE_USERNAME: neubig` and `secure: cpMn69tLzuhwO7EPhhiVwA==` to the value you'll get by [encrypting](https://ci.appveyor.com/tools/encrypt) your PyPI passwod.