### PR TITLE
Change model parameters to be stored as shared pointers

### DIFF
--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -121,8 +121,8 @@ namespace std {
   %template(LongVector)                   vector<long>;
   %template(StringVector)                 vector<std::string>;
   %template(ExpressionVector)             vector<dynet::Expression>;
-  %template(ParameterStorageVector)       vector<dynet::ParameterStorage*>;
-  %template(LookupParameterStorageVector) vector<dynet::LookupParameterStorage*>;
+  %template(ParameterStorageVector)       vector<shared_ptr<dynet::ParameterStorage>>;
+  %template(LookupParameterStorageVector) vector<shared_ptr<dynet::LookupParameterStorage>>;
   %template(ExpressionVectorVector)       vector<vector<dynet::Expression>>;
   %template(ParameterVector)              vector<dynet::Parameter>;
   %template(ParameterVectorVector)        vector<vector<dynet::Parameter>>;
@@ -361,11 +361,11 @@ struct LookupParameterStorage : public ParameterStorageBase {
    // SWIG can't get the types right for `parameters_list`, so here are replacement methods
    // for which it can. (You might worry that these would cause infinite recursion, but
    // apparently they don't.
-   std::vector<ParameterStorage*> parameters_list() const {
+   std::vector<std::shared_ptr<ParameterStorage>> parameters_list() const {
      return $self->parameters_list();
    }
 
-   std::vector<LookupParameterStorage*> lookup_parameters_list() const {
+   std::vector<std::shared_ptr<LookupParameterStorage>> lookup_parameters_list() const {
      return $self->lookup_parameters_list();
    }
 };

--- a/dynet/grad-check.cc
+++ b/dynet/grad-check.cc
@@ -15,8 +15,8 @@ namespace dynet {
 bool check_grad(ParameterCollection& m, Expression& expr, int verbosity) {
   ComputationGraph& g = *expr.pg;
   // Clear the parameters first
-  const vector<ParameterStorage*>& params = m.parameters_list();
-  const vector<LookupParameterStorage*>& lookup_params = m.lookup_parameters_list();
+  const vector<shared_ptr<ParameterStorage>>& params = m.parameters_list();
+  const vector<shared_ptr<LookupParameterStorage>>& lookup_params = m.lookup_parameters_list();
   for (auto pp : params)
     pp->clear();
   for (auto pp : lookup_params)

--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -30,14 +30,14 @@
   void MyParam::regular_func(float *sqnorm) const { \
     if(device->type == DeviceType::CPU) { dev_func(*(Device_CPU*)device,sqnorm); } \
     else if(device->type == DeviceType::GPU) { dev_func(*(Device_GPU*)device,sqnorm); } \
-    else { throw std::runtime_error("Invalid device type in MyParam::dev_func"); } \
+    else { throw runtime_error("Invalid device type in MyParam::dev_func"); } \
   }
 #else
 #define DYNET_PARAMNORM_INST_DEV_IMPL(MyParam, regular_func, dev_func) \
   template void MyParam::dev_func<Device_CPU>(Device_CPU & dev, float *sqnorm) const; \
   void MyParam::regular_func(float *sqnorm) const { \
     if(device->type == DeviceType::CPU) { dev_func(*(Device_CPU*)device,sqnorm); } \
-    else { throw std::runtime_error("Invalid device type in MyParam::dev_func"); } \
+    else { throw runtime_error("Invalid device type in MyParam::dev_func"); } \
   }
 #endif
 
@@ -50,7 +50,7 @@ namespace dynet {
 
 ParameterStorageBase::~ParameterStorageBase() {}
 
-ParameterStorage::ParameterStorage(const Dim& d, float scale, const std::string & name, Device *dev)
+ParameterStorage::ParameterStorage(const Dim& d, float scale, const string & name, Device *dev)
     : name(name), dim(d), updated(true), nonzero_grad(false), owner(nullptr), device(dev) {
   DYNET_ARG_CHECK(default_device != nullptr,
                   "Attempting to define parameters before initializing DyNet. Be sure to call dynet::initialize() before defining your model.");
@@ -75,7 +75,7 @@ ParameterStorage::ParameterStorage(const Dim& d, float scale, const std::string 
 }
 
 ParameterStorage::ParameterStorage(const Dim& d, const ParameterInit & init,
-                                   const std::string & name, Device *dev)
+                                   const string & name, Device *dev)
     : name(name), dim(d), updated(true), nonzero_grad(false), owner(nullptr), device(dev) {
   DYNET_ARG_CHECK(default_device != nullptr,
                   "Attempting to define parameters before initializing DyNet. Be sure to call dynet::initialize() before defining your model.");
@@ -116,17 +116,17 @@ void ParameterStorage::clip(float left, float right) {
   TensorTools::clip(values, left, right);
 }
 
-void ParameterStorage::set_value(const std::vector<float>& val) {
+void ParameterStorage::set_value(const vector<float>& val) {
   TensorTools::set_elements(values, val);
 }
 
-bool valid_parameter(const std::string & s) {
-  auto it = std::find_if(s.begin(), s.end(), [] (char ch) { return ch == '/' || ch == '_'; });
+bool valid_parameter(const string & s) {
+  auto it = find_if(s.begin(), s.end(), [] (char ch) { return ch == '/' || ch == '_'; });
   return it == s.end();
 }
 
 LookupParameterStorage::LookupParameterStorage(unsigned n, const Dim& d, const ParameterInit & init,
-                                               const std::string & name, Device *dev)
+                                               const string & name, Device *dev)
     : name(name), dim(d), updated(true), all_updated(false),
     nonzero_grad(false), owner(nullptr), device(dev) {
   DYNET_ARG_CHECK(default_device != nullptr,
@@ -185,7 +185,7 @@ void LookupParameterStorage::clear() {
 
 Parameter::Parameter() : p(nullptr) {}
 
-Parameter::Parameter(ParameterStorage* p) : p(p) {}
+Parameter::Parameter(shared_ptr<ParameterStorage> p) : p(p) {}
 
 ParameterStorage& Parameter::get_storage() const {
   DYNET_ASSERT(p != nullptr, "Attempt to get pointer for null parameter");
@@ -206,7 +206,7 @@ void Parameter::clip_inplace(float left, float right){
   get_storage().clip(left * my_scale, right * my_scale);
 }
 
-void Parameter::set_value(const std::vector<float>& val){
+void Parameter::set_value(const vector<float>& val){
   get_storage().set_value(val);
 }
 
@@ -224,7 +224,7 @@ float Parameter::current_weight_decay() const {
 
 LookupParameter::LookupParameter() : p(nullptr) { }
 
-LookupParameter::LookupParameter(LookupParameterStorage* p) : p(p) {}
+LookupParameter::LookupParameter(shared_ptr<LookupParameterStorage> p) : p(p) {}
 
 LookupParameterStorage& LookupParameter::get_storage() const {
   DYNET_ASSERT(p != nullptr, "Attempt to get pointer for null LookupParameter");
@@ -235,7 +235,7 @@ void LookupParameter::zero() {
   get_storage().zero();
 }
 
-void LookupParameter::initialize(unsigned index, const std::vector<float>& val) const {
+void LookupParameter::initialize(unsigned index, const vector<float>& val) const {
   get_storage().initialize(index, val);
 }
 
@@ -261,7 +261,6 @@ ParameterCollectionStorage::ParameterCollectionStorage()
 }
 
 ParameterCollectionStorage::~ParameterCollectionStorage() {
-  for (auto p : all_params) delete p;
   if (gradient_norm_scratch)
     device_manager->get_global_device("CPU")->mem->free(gradient_norm_scratch);
 }
@@ -299,7 +298,7 @@ ParameterCollection ParameterCollection::add_subcollection(const string & sub_na
     oss << "/";
     return ParameterCollection(oss.str(), this);
   } else {
-    throw std::runtime_error("Submodel name could not include '/' and '_'");
+    throw runtime_error("Submodel name could not include '/' and '_'");
   }
 }
 
@@ -319,12 +318,12 @@ void ParameterCollection::project_weights(float radius) {
 Parameter ParameterCollection::add_parameters(const Dim & d, Device *device) {
   return add_parameters(d, ParameterInitGlorot(), "", device);
 }
-Parameter ParameterCollection::add_parameters(const Dim & d, const std::string & p_name, Device *device) {
+Parameter ParameterCollection::add_parameters(const Dim & d, const string & p_name, Device *device) {
   return add_parameters(d, ParameterInitGlorot(), p_name, device);
 }
 
 Parameter ParameterCollection::add_parameters(const Dim& d, float scale,
-                                              const std::string & p_name, Device *device) {
+                                              const string & p_name, Device *device) {
   if(scale == 0.0f)
     return add_parameters(d, ParameterInitGlorot(), p_name, device);
   else
@@ -332,21 +331,21 @@ Parameter ParameterCollection::add_parameters(const Dim& d, float scale,
 }
 
 Parameter ParameterCollection::add_parameters(const Dim& d, const ParameterInit & init,
-                                              const std::string & p_name, Device *device) {
+                                              const string & p_name, Device *device) {
   if (valid_parameter(p_name)) {
     ostringstream oss; oss << name << p_name;
     int idx = name_cntr[p_name]++;
     if (idx > 0 || p_name.size() == 0) oss << "_" << idx;
 
-    ParameterStorage* p = new ParameterStorage(d, init, oss.str(), device);
+    shared_ptr<ParameterStorage> p = ParameterStorageCreator::create(d, init, oss.str(), device);
     add_parameters_to_storage(p);
     return Parameter(p);
   } else {
-    throw std::runtime_error("Parameter name could not include '/' and '_'");
+    throw runtime_error("Parameter name could not include '/' and '_'");
   }
 }
 
-void ParameterCollection::add_parameters_to_storage(ParameterStorage *p) {
+void ParameterCollection::add_parameters_to_storage(shared_ptr<ParameterStorage>p) {
   if(parent != nullptr)
     parent->add_parameters_to_storage(p);
   else
@@ -357,8 +356,8 @@ void ParameterCollection::add_parameters_to_storage(ParameterStorage *p) {
   }
 }
 
-std::vector<ParameterStorageBase*> ParameterCollection::get_parameter_storages_base() const {
-  std::vector<ParameterStorageBase*> all_params;
+vector<shared_ptr<ParameterStorageBase>> ParameterCollection::get_parameter_storages_base() const {
+  vector<shared_ptr<ParameterStorageBase>> all_params;
   ParameterCollection *t = const_cast<ParameterCollection*>(this);
   while (t->parent != nullptr) { t = t->parent; }
   auto all_ps = t->get_storage().all_params;
@@ -381,7 +380,7 @@ std::vector<ParameterStorageBase*> ParameterCollection::get_parameter_storages_b
   return all_params;
 }
 
-ParameterStorage* ParameterCollection::get_parameter_storage(const std::string & pname) {
+shared_ptr<ParameterStorage> ParameterCollection::get_parameter_storage(const string & pname) {
   if (pname.find(name) == 0) {
     ParameterCollection *t = this;
     while (t->parent != nullptr) { t = t->parent; }
@@ -391,12 +390,12 @@ ParameterStorage* ParameterCollection::get_parameter_storage(const std::string &
       }
     }
   }
-  std::string errMsg = "No existing parameter " + pname + " found in " + name;
-  throw std::runtime_error(errMsg);
+  string errMsg = "No existing parameter " + pname + " found in " + name;
+  throw runtime_error(errMsg);
 }
 
-std::vector<ParameterStorage*> ParameterCollection::get_parameter_storages() const {
-  std::vector<ParameterStorage*> params;
+vector<shared_ptr<ParameterStorage>> ParameterCollection::get_parameter_storages() const {
+  vector<shared_ptr<ParameterStorage>> params;
   ParameterCollection *t = const_cast<ParameterCollection*>(this);
   while (t->parent != nullptr) { t = t->parent; }
   for (auto & param : t->get_storage().params) {
@@ -408,28 +407,28 @@ std::vector<ParameterStorage*> ParameterCollection::get_parameter_storages() con
 }
 
 LookupParameter ParameterCollection::add_lookup_parameters(unsigned n, const Dim& d,
-                                                           const std::string & p_name,
+                                                           const string & p_name,
                                                            Device *device) {
   return add_lookup_parameters(n, d, ParameterInitGlorot(true), p_name, device);
 }
 
 LookupParameter ParameterCollection::add_lookup_parameters(unsigned n, const Dim& d, const ParameterInit & init,
-                                                           const std::string & p_name,
+                                                           const string & p_name,
                                                            Device *device) {
   if (valid_parameter(p_name)) {
     ostringstream oss; oss << name << p_name;
     int idx = name_cntr[p_name]++;
     if (idx > 0 || p_name.size() == 0) oss << "_" << idx;
 
-    LookupParameterStorage* p = new LookupParameterStorage(n, d, init, oss.str(), device);
+    shared_ptr<LookupParameterStorage> p = LookupParameterStorageCreator::create(n, d, init, oss.str(), device);
     add_lookup_parameters_to_storage(p);
     return LookupParameter(p);
   } else {
-    throw std::runtime_error("LookupParameter name could not include '/' and '_'");
+    throw runtime_error("LookupParameter name could not include '/' and '_'");
   }
 }
 
-void ParameterCollection::add_lookup_parameters_to_storage(LookupParameterStorage *p) {
+void ParameterCollection::add_lookup_parameters_to_storage(shared_ptr<LookupParameterStorage>p) {
   if(parent != nullptr)
     parent->add_lookup_parameters_to_storage(p);
   else
@@ -440,7 +439,7 @@ void ParameterCollection::add_lookup_parameters_to_storage(LookupParameterStorag
   }
 }
 
-LookupParameterStorage* ParameterCollection::get_lookup_parameter_storage(const std::string & lookup_pname)
+shared_ptr<LookupParameterStorage> ParameterCollection::get_lookup_parameter_storage(const string & lookup_pname)
 {
   if (lookup_pname.find(name) == 0) {
     ParameterCollection *t = this;
@@ -451,13 +450,13 @@ LookupParameterStorage* ParameterCollection::get_lookup_parameter_storage(const 
       }
     }
   }
-  std::string errMsg = "No existing parameter " + lookup_pname + " found in " + name;
-  throw std::runtime_error(errMsg);
+  string errMsg = "No existing parameter " + lookup_pname + " found in " + name;
+  throw runtime_error(errMsg);
 }
 
-std::vector<LookupParameterStorage*>
+vector<shared_ptr<LookupParameterStorage>>
 ParameterCollection::get_lookup_parameter_storages() const {
-  std::vector<LookupParameterStorage*> lookup_params;
+  vector<shared_ptr<LookupParameterStorage>> lookup_params;
   ParameterCollection *t = const_cast<ParameterCollection*>(this);
   while (t->parent != nullptr) { t = t->parent; }
   for (auto & lookup_param: t->get_storage().lookup_params) {
@@ -475,14 +474,14 @@ void ParameterCollection::reset_gradient() {
 
 size_t ParameterCollection::parameter_count() const {
   size_t r = 0;
-  for (const ParameterStorageBase* param : get_storage().all_params)
+  for (const shared_ptr<ParameterStorageBase> param : get_storage().all_params)
     r += param->size();
   return r;
 }
 
 size_t ParameterCollection::updated_parameter_count() const {
   size_t r = 0;
-  for (const ParameterStorageBase* param : get_storage().all_params)
+  for (const shared_ptr<ParameterStorageBase> param : get_storage().all_params)
     if(param->is_updated())
       r += param->size();
   return r;
@@ -508,12 +507,12 @@ const ParameterCollectionStorage& ParameterCollection::get_storage() const {
   return *storage;
 }
 
-void save_dynet_model(std::string filename, ParameterCollection* model) {
+void save_dynet_model(string filename, ParameterCollection* model) {
   TextFileSaver saver(filename);
   saver.save(*model, "/model");
 };
 
-void load_dynet_model(std::string filename, ParameterCollection* model) {
+void load_dynet_model(string filename, ParameterCollection* model) {
   TextFileLoader loader(filename);
   loader.populate(*model, "/model");
 };
@@ -563,14 +562,14 @@ void ParameterStorage::accumulate_grad(const Tensor& d) {
   nonzero_grad = true;
   if (values.device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values.device, d); }
   else if (values.device->type == DeviceType::GPU) { accumulate_grad_dev(*(Device_GPU*)values.device, d); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void ParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, const Tensor& d);
 void ParameterStorage::accumulate_grad(const Tensor& d) {
   nonzero_grad = true;
   if (values.device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values.device, d); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -586,13 +585,13 @@ template void ParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & de
 void ParameterStorage::scale_parameters(float a) {
   if (values.device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values.device, a); }
   else if (values.device->type == DeviceType::GPU) { scale_parameters_dev(*(Device_GPU*)values.device, a); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void ParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
 void ParameterStorage::scale_parameters(float a) {
   if (values.device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values.device, a); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -608,13 +607,13 @@ template void ParameterStorage::scale_gradient_dev<Device_CPU>(Device_CPU & dev,
 void ParameterStorage::scale_gradient(float a) {
   if (g.device->type == DeviceType::CPU) { scale_gradient_dev(*(Device_CPU*)g.device, a); }
   else if (g.device->type == DeviceType::GPU) { scale_gradient_dev(*(Device_GPU*)g.device, a); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void ParameterStorage::scale_gradient_dev<Device_CPU>(Device_CPU & dev, float a);
 void ParameterStorage::scale_gradient(float a) {
   if (g.device->type == DeviceType::CPU) { scale_gradient_dev(*(Device_CPU*)g.device, a); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -637,13 +636,13 @@ template void LookupParameterStorage::initialize_dev<Device_CPU>(Device_CPU & de
 void LookupParameterStorage::initialize(unsigned index, const vector<float>& val) {
   if (values[index].device->type == DeviceType::CPU) { initialize_dev(*(Device_CPU*)values[index].device, index, val); }
   else if (values[index].device->type == DeviceType::GPU) { initialize_dev(*(Device_GPU*)values[index].device, index, val); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void LookupParameterStorage::initialize_dev<Device_CPU>(Device_CPU & dev, unsigned index, const vector<float>& val);
 void LookupParameterStorage::initialize(unsigned index, const vector<float>& val) {
   if (values[index].device->type == DeviceType::CPU) { initialize_dev(*(Device_CPU*)values[index].device, index, val); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -683,14 +682,14 @@ void LookupParameterStorage::accumulate_grad(const Tensor& d) {
   nonzero_grad = true;
   if (all_values.device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)all_values.device, d); }
   else if (all_values.device->type == DeviceType::GPU) { accumulate_grad_dev(*(Device_GPU*)all_values.device, d); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void LookupParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, const Tensor& d);
 void LookupParameterStorage::accumulate_grad(const Tensor& d) {
   nonzero_grad = true;
   if (all_values.device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)all_values.device, d); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -708,14 +707,14 @@ void LookupParameterStorage::accumulate_grad(unsigned index, const Tensor& d) {
   nonzero_grad = true;
   if (values[index].device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values[index].device, index, d); }
   else if (values[index].device->type == DeviceType::GPU) { accumulate_grad_dev(*(Device_GPU*)values[index].device, index, d); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void LookupParameterStorage::accumulate_grad_dev<Device_CPU>(Device_CPU & dev, unsigned index, const Tensor& d);
 void LookupParameterStorage::accumulate_grad(unsigned index, const Tensor& d) {
   nonzero_grad = true;
   if (values[index].device->type == DeviceType::CPU) { accumulate_grad_dev(*(Device_CPU*)values[index].device, index, d); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -743,13 +742,13 @@ template void LookupParameterStorage::accumulate_grads_dev<Device_CPU>(Device_CP
 void LookupParameterStorage::accumulate_grads(unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g) {
   if (all_values.device->type == DeviceType::CPU) { accumulate_grads_dev(*(Device_CPU*)all_values.device, n, ids_host, ids_dev, g); }
   else if (all_values.device->type == DeviceType::GPU) { accumulate_grads_dev(*(Device_GPU*)all_values.device, n, ids_host, ids_dev, g); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void LookupParameterStorage::accumulate_grads_dev<Device_CPU>(Device_CPU & dev, unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g);
 void LookupParameterStorage::accumulate_grads(unsigned n, const unsigned* ids_host, const unsigned* ids_dev, float* g) {
   if (all_values.device->type == DeviceType::CPU) { accumulate_grads_dev(*(Device_CPU*)all_values.device, n, ids_host, ids_dev, g); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -765,13 +764,13 @@ template void LookupParameterStorage::scale_parameters_dev<Device_CPU>(Device_CP
 void LookupParameterStorage::scale_parameters(float a) {
   if (values[0].device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values[0].device, a); }
   else if (values[0].device->type == DeviceType::GPU) { scale_parameters_dev(*(Device_GPU*)values[0].device, a); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void LookupParameterStorage::scale_parameters_dev<Device_CPU>(Device_CPU & dev, float a);
 void LookupParameterStorage::scale_parameters(float a) {
   if (values[0].device->type == DeviceType::CPU) { scale_parameters_dev(*(Device_CPU*)values[0].device, a); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -787,13 +786,13 @@ template void LookupParameterStorage::scale_gradient_dev<Device_CPU>(Device_CPU 
 void LookupParameterStorage::scale_gradient(float a) {
   if (grads[0].device->type == DeviceType::CPU) { scale_gradient_dev(*(Device_CPU*)grads[0].device, a); }
   else if (grads[0].device->type == DeviceType::GPU) { scale_gradient_dev(*(Device_GPU*)grads[0].device, a); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #else
 template void LookupParameterStorage::scale_gradient_dev<Device_CPU>(Device_CPU & dev, float a);
 void LookupParameterStorage::scale_gradient(float a) {
   if (grads[0].device->type == DeviceType::CPU) { scale_gradient_dev(*(Device_CPU*)grads[0].device, a); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 #endif
 
@@ -829,7 +828,7 @@ float ParameterCollectionStorage::gradient_l2_norm_dev(MyDevice &dev) const {
     else if (dev_k->type == DeviceType::GPU)
       cudaMemcpy(gradient_norm_scratch + pi, v, sizeof(float), cudaMemcpyDeviceToHost);
 #endif
-    else { throw std::runtime_error("Bad device type"); }
+    else { throw runtime_error("Bad device type"); }
     dev_k->mem->free(v);
   }
   Tensor scratch_t({(unsigned int)all_params.size()}, gradient_norm_scratch, &dev, DeviceMempool::NONE);
@@ -845,7 +844,7 @@ extern template float ParameterCollectionStorage::gradient_l2_norm_dev<Device_GP
 template float ParameterCollectionStorage::gradient_l2_norm_dev<Device_CPU>(Device_CPU & dev) const;
 float ParameterCollectionStorage::gradient_l2_norm() const {
   if (default_device->type == DeviceType::CPU || default_device->type == DeviceType::GPU) { return gradient_l2_norm_dev(*(Device_CPU*)device_manager->get_global_device("CPU")); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 float ParameterCollection::gradient_l2_norm() const {
   return get_storage().gradient_l2_norm();
@@ -854,7 +853,7 @@ float ParameterCollection::gradient_l2_norm() const {
 template float ParameterCollectionStorage::gradient_l2_norm_dev<Device_CPU>(Device_CPU & dev) const;
 float ParameterCollectionStorage::gradient_l2_norm() const {
   if (default_device->type == DeviceType::CPU) { return gradient_l2_norm_dev(*(Device_CPU*)device_manager->get_global_device("CPU")); }
-  else { throw std::runtime_error("Bad device type"); }
+  else { throw runtime_error("Bad device type"); }
 }
 float ParameterCollection::gradient_l2_norm() const {
   return get_storage().gradient_l2_norm();

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -7,6 +7,7 @@
 #ifndef DYNET_PARAMS_H_
 #define DYNET_PARAMS_H_
 
+#include <memory>
 #include <vector>
 #include <set>
 #include <unordered_set>
@@ -146,13 +147,24 @@ struct ParameterStorage : public ParameterStorageBase {
   ParameterCollection* owner; /**< Pointer to the collection that "owns" this parameter */
   Device *device;
 
-private:
+protected:
   ParameterStorage() : updated(true), owner(nullptr) {}
   explicit ParameterStorage(const Dim& d, float scale,
                             const std::string & name, Device *device); // initialize with a scale
   explicit ParameterStorage(const Dim& d, const ParameterInit & init,
                             const std::string & name, Device *device); // initialize with custom initializer
 }; // struct ParameterStorage
+
+struct ParameterStorageCreator : public ParameterStorage {
+  template <typename... Args>
+  explicit ParameterStorageCreator(Args &&...args)
+    : ParameterStorage(std::forward<Args>(args)...) {}
+
+  template <typename... Args>
+  static std::shared_ptr<ParameterStorage> create(Args &&...args) {
+    return std::make_shared<ParameterStorageCreator>(std::forward<Args>(args)...);
+  }
+};
 
 // represents a matrix/vector embedding of a discrete set
 /**
@@ -249,11 +261,22 @@ struct LookupParameterStorage : public ParameterStorageBase {
   bool nonzero_grad; /**< Whether the gradient is zero */
   ParameterCollection* owner; /**< Pointer to the collection that "owns" this parameter */
   Device *device;
-private:
+protected:
   LookupParameterStorage() : updated(true), all_updated(false), owner(nullptr) {}
   LookupParameterStorage(unsigned n, const Dim& d, const ParameterInit & init,
                          const std::string & name, Device *device);
-}; // // struct LookupParameterStorage
+}; // struct LookupParameterStorage
+
+struct LookupParameterStorageCreator : public LookupParameterStorage {
+  template <typename... Args>
+  explicit LookupParameterStorageCreator(Args &&...args)
+    : LookupParameterStorage(std::forward<Args>(args)...) {}
+
+  template <typename... Args>
+  static std::shared_ptr<LookupParameterStorage> create(Args &&...args) {
+    return std::make_shared<LookupParameterStorageCreator>(std::forward<Args>(args)...);
+  }
+};
 
 /**
  * \ingroup params
@@ -270,9 +293,9 @@ struct Parameter {
    * @brief Constructor
    * @details This is called by the model, you shouldn't need to use it
    *
-   * @param p Pointer to the parameter storage
+   * @param p Shared pointer to the parameter storage
    */
-  Parameter(ParameterStorage* p);
+  Parameter(std::shared_ptr<ParameterStorage> p);
   /**
    * @brief Get underlying ParameterStorage object
    * @return ParameterStorage holding the parameter values
@@ -289,7 +312,7 @@ struct Parameter {
    */
   void zero();
 
-  ParameterStorage* p; /**< Pointer to the storage for this Parameter */
+  std::shared_ptr<ParameterStorage> p; /**< Pointer to the storage for this Parameter */
 
   /**
    * \brief Shape of the parameter
@@ -365,7 +388,7 @@ struct Parameter {
  */
 struct LookupParameter {
   LookupParameter();
-  LookupParameter(LookupParameterStorage* p);
+  LookupParameter(std::shared_ptr<LookupParameterStorage> p);
   /**
    * @brief Get underlying LookupParameterStorage object
    * @return LookupParameterStorage holding the parameter values
@@ -384,7 +407,7 @@ struct LookupParameter {
    */
   void zero();
 
-  LookupParameterStorage* p; /**< Pointer to the storage for this Parameter */
+  std::shared_ptr<LookupParameterStorage> p; /**< Pointer to the storage for this Parameter */
 
   /**
    * @brief Get the full name of the ParameterStorage object
@@ -449,9 +472,9 @@ struct ParameterCollectionStorage {
   float gradient_l2_norm_dev(MyDevice & dev) const;
   float gradient_l2_norm() const;
 
-  std::vector<ParameterStorageBase*> all_params;
-  std::vector<ParameterStorage*> params;
-  std::vector<LookupParameterStorage*> lookup_params;
+  std::vector<std::shared_ptr<ParameterStorageBase>> all_params;
+  std::vector<std::shared_ptr<ParameterStorage>> params;
+  std::vector<std::shared_ptr<LookupParameterStorage>> lookup_params;
 
   mutable float* gradient_norm_scratch;
   L2WeightDecay weight_decay;
@@ -543,19 +566,19 @@ public:
    *
    * \return list of points to ParameterStorageBase objects
    */
-  std::vector<ParameterStorageBase*> get_parameter_storages_base() const;
+  std::vector<std::shared_ptr<ParameterStorageBase>> get_parameter_storages_base() const;
   /**
    * \brief Get parameter in current model
    * \details It is not recommended to use this
    * \return the pointer to the Parameter object
    */
-  ParameterStorage* get_parameter_storage(const std::string & pname);
+  std::shared_ptr<ParameterStorage> get_parameter_storage(const std::string & pname);
   /**
    * \brief Get parameters in current model
    *
    * \return list of points to ParameterStorage objects
    */
-  std::vector<ParameterStorage*> get_parameter_storages() const;
+  std::vector<std::shared_ptr<ParameterStorage>> get_parameter_storages() const;
   /**
    * \brief Add lookup parameter to model
    * \details Same as add_parameters. Initializes with Glorot
@@ -587,13 +610,13 @@ public:
    * \details It is not recommended to use this
    * \return the pointer to the LookupParameter object
    */
-  LookupParameterStorage* get_lookup_parameter_storage(const std::string & lookup_pname);
+  std::shared_ptr<LookupParameterStorage> get_lookup_parameter_storage(const std::string & lookup_pname);
   /**
    * \brief Get lookup parameters in current model
    *
    * \return list of points to LookupParameterStorage objects
    */
-  std::vector<LookupParameterStorage*> get_lookup_parameter_storages() const;
+  std::vector<std::shared_ptr<LookupParameterStorage>> get_lookup_parameter_storages() const;
   //
   /**
    * \brief project weights so their L2 norm = radius
@@ -609,19 +632,19 @@ public:
    */
   void set_weight_decay_lambda(float lambda);
 
-  //const std::vector<ParameterStorageBase*>& all_parameters_list() const { return all_params; }
+  //const std::vector<std::shared_ptr<ParameterStorageBase>>& all_parameters_list() const { return all_params; }
   /**
-   * \brief Returns list of pointers to ParameterSorages
+   * \brief Returns list of shared pointers to ParameterSorages
    * \details You shouldn't need to use this
-   * \return List of pointers to ParameterSorages
+   * \return List of shared pointers to ParameterSorages
    */
-  const std::vector<ParameterStorage*>& parameters_list() const { return get_storage().params; }
+  const std::vector<std::shared_ptr<ParameterStorage>>& parameters_list() const { return get_storage().params; }
   /**
    * \brief Returns list of pointers to LookupParameterSorages
    * \details You shouldn't need to use this
    * \return List of pointers to LookupParameterSorages
    */
-  const std::vector<LookupParameterStorage*>& lookup_parameters_list() const { return get_storage().lookup_params; }
+  const std::vector<std::shared_ptr<LookupParameterStorage>>& lookup_parameters_list() const { return get_storage().lookup_params; }
 
   //
   //
@@ -700,8 +723,8 @@ public:
   const ParameterCollectionStorage& get_storage() const;
 
 protected:
-  void add_parameters_to_storage(ParameterStorage* p);
-  void add_lookup_parameters_to_storage(LookupParameterStorage* p);
+  void add_parameters_to_storage(std::shared_ptr<ParameterStorage> p);
+  void add_lookup_parameters_to_storage(std::shared_ptr<LookupParameterStorage> p);
 
 private:
   ParameterCollection(const std::string & name, ParameterCollection* parent);

--- a/dynet/param-nodes.cc
+++ b/dynet/param-nodes.cc
@@ -128,7 +128,7 @@ Node* ScalarInputNode::autobatch_pseudo_node(const ComputationGraph & cg,
 
 int LookupNode::autobatch_sig(const ComputationGraph & cg, SigMap &sm) const {
   Sig s(nt::lookup);
-  s.add_int((size_t)params.p);
+  s.add_int((size_t)params.p.get());
   return sm.get_idx(s);
 }
 std::vector<int> LookupNode::autobatch_concat(const ComputationGraph & cg) const {

--- a/dynet/shadow-params.cc
+++ b/dynet/shadow-params.cc
@@ -35,7 +35,7 @@ void ShadowLookupParameters::initialize_lookups() {
 
 void allocate_shadow_parameters(const ParameterCollection& m, unsigned allocated, vector<ShadowParameters>& target) {
   auto& params = m.parameters_list();
-  vector<ParameterStorage*> to_allocate(params.begin() + allocated, params.end());
+  vector<shared_ptr<ParameterStorage>> to_allocate(params.begin() + allocated, params.end());
   vector<ShadowParameters> v;
   target.reserve(params.size());
   for (auto& p : to_allocate)
@@ -44,7 +44,7 @@ void allocate_shadow_parameters(const ParameterCollection& m, unsigned allocated
 
 void allocate_shadow_lookup_parameters(const ParameterCollection& m, unsigned allocated, vector<ShadowLookupParameters>& target) {
   auto& params = m.lookup_parameters_list();
-  vector<LookupParameterStorage*> to_allocate(params.begin() + allocated, params.end());
+  vector<shared_ptr<LookupParameterStorage>> to_allocate(params.begin() + allocated, params.end());
   target.reserve(params.size());
   for (auto& p : to_allocate)
     target.emplace_back(*p);

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -1,3 +1,4 @@
+from libcpp.memory cimport shared_ptr
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libcpp cimport bool
@@ -75,7 +76,7 @@ cdef extern from "dynet/model.h" namespace "dynet":
 
     cdef cppclass CParameters "dynet::Parameter":
         CParameters()
-        CParameters(CParameterStorage* p)
+        CParameters(shared_ptr[CParameterStorage] p)
         CParameterStorage& get_storage()
         void zero()
         void set_updated(bool b)
@@ -88,7 +89,7 @@ cdef extern from "dynet/model.h" namespace "dynet":
 
     cdef cppclass CLookupParameters "dynet::LookupParameter":
         CLookupParameters()
-        CLookupParameters(CLookupParameterStorage* p)
+        CLookupParameters(shared_ptr[CLookupParameterStorage] p)
         CLookupParameterStorage& get_storage()
         CDim dim
         void initialize(unsigned index, const vector[float]& val)
@@ -108,8 +109,8 @@ cdef extern from "dynet/model.h" namespace "dynet":
         #CLookupParameters add_lookup_parameters(unsigned n, const CDim& d)
         CLookupParameters add_lookup_parameters(unsigned n, const CDim& d, CParameterInit initializer, string name) except +
         CLookupParameters add_lookup_parameters(unsigned n, const CDim& d, CParameterInit initializer, string name, CDevice *device) except +
-        vector[CParameterStorage*] parameters_list()
-        vector[CLookupParameterStorage*] lookup_parameters_list()
+        vector[shared_ptr[CParameterStorage]] parameters_list()
+        vector[shared_ptr[CLookupParameterStorage]] lookup_parameters_list()
         CModel add_subcollection(string name) except +
         string get_fullname()
         int parameter_count() except +

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3,6 +3,7 @@ from __future__ import print_function
 import sys
 from cython.operator cimport dereference as deref
 from libc.stdlib cimport malloc, free
+from libcpp.memory cimport shared_ptr
 import numpy as np
 
 # python3 pickle already uses the c implementaion 
@@ -1074,7 +1075,7 @@ cdef class ParameterCollection: # {{{
         Returns:
             (list): All dy.Parameters in the collection
         """
-        cdef vector[CParameterStorage*] pl = self.thisptr.parameters_list()
+        cdef vector[shared_ptr[CParameterStorage]] pl = self.thisptr.parameters_list()
         parameters_list = []
         for p in pl:
             parameters_list.append(Parameters.wrap_ptr(CParameters(p)))
@@ -1086,7 +1087,7 @@ cdef class ParameterCollection: # {{{
         Returns:
             (list): All dy.LookupParameters in the collection
         """
-        cdef vector[CLookupParameterStorage*] pl = self.thisptr.lookup_parameters_list()
+        cdef vector[shared_ptr[CLookupParameterStorage]] pl = self.thisptr.lookup_parameters_list()
         lookup_parameters_list = []
         for p in pl:
             lookup_parameters_list.append(LookupParameters.wrap_ptr(CLookupParameters(p)))

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -980,15 +980,16 @@ cdef class ParameterCollection: # {{{
         separator) or :code:`_` (which is used as an index separator).
     """
     cdef CModel thisptr  # Not a pointer...
+    cdef ParameterCollection parent
     def __cinit__(self, ):
         pass
 
-    def __init__(self):
-        pass
+    def __init__(self, parent=None):
+        self.parent = parent
 
     @staticmethod
-    cdef wrap(CModel m):
-        self = ParameterCollection()
+    cdef wrap(CModel m, ParameterCollection parent=None):
+        self = ParameterCollection(parent)
         self.thisptr = m
         return self
 
@@ -1230,8 +1231,7 @@ cdef class ParameterCollection: # {{{
         Returns:
             (dynet.ParameterCollection) a parameter collection.
         """
-        if name is None: return ParameterCollection.wrap(self.thisptr.add_subcollection("".encode()))
-        else: return ParameterCollection.wrap(self.thisptr.add_subcollection(name.encode()))
+        return ParameterCollection.wrap(self.thisptr.add_subcollection((name or "").encode()), self)
 
     cpdef name(self):
         """

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -1,6 +1,7 @@
 import dynet as dy
 import numpy as np
 import unittest
+import gc
 
 
 def npvalue_callable(x):
@@ -227,8 +228,15 @@ class TestParameters(unittest.TestCase):
                 trainer.update()
 
     def test_delete_model(self):
-        import gc
         p = dy.parameter(dy.ParameterCollection().add_parameters((1,), init=dy.ConstInitializer(1)))
+        self.assertEqual(p.value(), 1)
+        gc.collect()
+        self.assertEqual(p.value(), 1)
+
+
+    def test_delete_parent_model(self):
+        model = dy.ParameterCollection().add_subcollection()
+        p = dy.parameter(model.add_parameters((1,), init=dy.ConstInitializer(1)))
         self.assertEqual(p.value(), 1)
         gc.collect()
         self.assertEqual(p.value(), 1)

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -229,17 +229,17 @@ class TestParameters(unittest.TestCase):
 
     def test_delete_model(self):
         p = dy.parameter(dy.ParameterCollection().add_parameters((1,), init=dy.ConstInitializer(1)))
-        self.assertEqual(p.value(), 1)
+        p.value()
         gc.collect()
-        self.assertEqual(p.value(), 1)
+        p.value()
 
 
     def test_delete_parent_model(self):
         model = dy.ParameterCollection().add_subcollection()
         p = dy.parameter(model.add_parameters((1,), init=dy.ConstInitializer(1)))
-        self.assertEqual(p.value(), 1)
+        p.value()
         gc.collect()
-        self.assertEqual(p.value(), 1)
+        p.value()
 
 
 class TestBatchManipulation(unittest.TestCase):

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -226,6 +226,13 @@ class TestParameters(unittest.TestCase):
                 x.backward()
                 trainer.update()
 
+    def test_delete_model(self):
+        import gc
+        p = dy.parameter(dy.ParameterCollection().add_parameters((1,), init=dy.ConstInitializer(1)))
+        self.assertEqual(p.value(), 1)
+        gc.collect()
+        self.assertEqual(p.value(), 1)
+
 
 class TestBatchManipulation(unittest.TestCase):
 

--- a/tests/test-params.cc
+++ b/tests/test-params.cc
@@ -121,7 +121,7 @@ BOOST_AUTO_TEST_CASE ( test_parameter_class ) {
     return p.get_storage().name;
   };
   auto save_parameters_lambda3 = [] (const std::string & fname,
-                                     dynet::ParameterStorage *p) ->std::string {
+                                     std::shared_ptr<dynet::ParameterStorage>p) ->std::string {
     std::cout << p->name << " saved in file " << fname << std::endl;
     return p->name;
   };

--- a/tests/test.h
+++ b/tests/test.h
@@ -93,13 +93,13 @@ void equal_check(ParameterCollection & model1,
   auto params2 = model2.get_parameter_storages();
   BOOST_CHECK_EQUAL(params1.size(), params2.size());
   for (size_t i = 0; i < params1.size(); ++i) {
-    equal_check(params1[i], params2[i]);
+    equal_check(params1[i].get(), params2[i].get());
   }
   auto lookup_params1 = model1.get_lookup_parameter_storages();
   auto lookup_params2 = model2.get_lookup_parameter_storages();
   BOOST_CHECK_EQUAL(lookup_params1.size(), lookup_params2.size());
   for (size_t i = 0; i < lookup_params1.size(); ++i) {
-    equal_check(lookup_params1[i], lookup_params2[i]);
+    equal_check(lookup_params1[i].get(), lookup_params2[i].get());
   }
 }
 


### PR DESCRIPTION
Deleting the ParameterCollection will no longer delete the Parameter objects. Instead, they will be deleted only when their last reference is deleted.