### PR TITLE
Remove useless external dependency on easylogging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "external/easyloggingpp"]
-	path = external/easyloggingpp
-	url = https://github.com/easylogging/easyloggingpp.git


### PR DESCRIPTION
There was a dependency on easylogging via a git submodule for an example (which has been deleted since then I believe).

This PR removes the dependency.