### PR TITLE
fix parameter set_value

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -621,7 +621,7 @@ cdef class Parameters: # {{{
 
         """
         if not isinstance(arr, np.ndarray):
-            arr = np.array(arr)
+            arr = np.asarray(arr)
         shape = arr.shape
         if self.shape() != shape:
             raise ValueError("Shape of values and parameter don't match in Parameters.set_value")

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -606,20 +606,22 @@ cdef class Parameters: # {{{
         """
         cdef CTensor t
         return c_tensor_as_np(self.thisptr.get_storage().g)
-    
+
     cpdef clip_inplace(self, float left, float right):
         """Clip the values in the parameter to a fixed range [left, right] (in place)
-        
+
         Args:
             arr(np.ndarray): Scale
         """
         self.thisptr.clip_inplace(left, right)
-        
+
     # TODO: make more efficient
     cpdef set_value(self, arr):
         """Set value of the parameter
 
         """
+        if not isinstance(arr, np.ndarray):
+            arr = np.array(arr)
         shape = arr.shape
         if self.shape() != shape:
             raise ValueError("Shape of values and parameter don't match in Parameters.set_value")


### PR DESCRIPTION
Support both np.ndarray and python list used in the `parameter.set_value`

```python
import dynet

m = dynet.ParameterCollection()
pX = m.add_parameters((2,))
pY = m.add_parameters((2,))

pX.set_value([2,1])
p = dynet.parameter(pX)
print p.value()

pY.set_value(np.array([2,1]))
q = dynet.parameter(pY)
print q.value()
```