### PR TITLE
Fix scala bindings

### DIFF
--- a/contrib/swig/build.sbt
+++ b/contrib/swig/build.sbt
@@ -2,7 +2,7 @@ lazy val root = (project in file("."))
     .settings(
       name         := "dynet_scala_helpers",
       organization := "edu.cmu.dynet",
-      scalaVersion := "2.11.8",
+      scalaVersion := "2.11.11",
       version      := "0.0.1-SNAPSHOT"
     )
 

--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -100,6 +100,10 @@ VECTORCONSTRUCTOR(std::vector<dynet::Parameter>, ParameterVector, ParameterVecto
 %include "std_string.i"
 %include "std_pair.i"
 %include "cpointer.i"
+%include <std_shared_ptr.i>
+
+%shared_ptr(dynet::ParameterStorage)
+%shared_ptr(dynet::LookupParameterStorage)
 
 // Convert C++ exceptions into Java exceptions. This provides
 // nice error messages for each listed exception, and a default

--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -598,7 +598,7 @@ Expression block_dropout(const Expression& x, real p);
 Expression filter1d_narrow(const Expression& x, const Expression& f);
 Expression kmax_pooling(const Expression& x, unsigned k);
 Expression fold_rows(const Expression& x, unsigned nrows=2);
-Expression sum_dim(const Expression& x, unsigned d);
+Expression sum_dim(const Expression& x, const std::vector<unsigned>& dims, bool b=false);
 Expression sum_cols(const Expression& x);
 Expression sum_rows(const Expression& x);
 Expression average_cols(const Expression& x);

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
@@ -244,7 +244,7 @@ object Expression {
   def filter1DNarrow(x: Expression, f: Expression): Expression = binary(x, f, dn.filter1d_narrow)
   def kMaxPooling(x: Expression, k: Long): Expression = unary(x, x => dn.kmax_pooling(x, k))
   def foldRows(x: Expression, nRows: Long = 2l): Expression = unary(x, x => dn.fold_rows(x, nRows))
-  def sumDim(x: Expression, d: Long): Expression = unary(x, x => dn.sum_dim(x, d))
+  def sumDim(x: Expression, dims: UnsignedVector): Expression = unary(x, x => dn.sum_dim(x, dims.vector))
   def sumCols(x: Expression): Expression = unary(x, dn.sum_cols)
   def sumRows(x: Expression): Expression = unary(x, dn.sum_rows)
   def averageCols(x: Expression): Expression = unary(x, dn.average_cols)


### PR DESCRIPTION
Scala bindings can't be built with the latest master and this PR fixes it.
I've also changed the Scala version from 2.11.8 to 2.11.11.