### PR TITLE
FIX: compiler warnings

### DIFF
--- a/dynet/nodes-arith-cwise.cc
+++ b/dynet/nodes-arith-cwise.cc
@@ -20,11 +20,11 @@ string CwiseSum::as_string(const vector<string>& arg_names) const {
 Dim CwiseSum::dim_forward(const vector<Dim>& xs) const {
   DYNET_ARG_CHECK(xs.size() == 2, "Failed input count check in CwiseSum");
   std::vector<long> dims({});
-  for(int i=0; i < min(xs[0].nd, xs[1].nd); i++){
+  for(unsigned int i = 0; i < min(xs[0].nd, xs[1].nd); i++){
     DYNET_ARG_CHECK(xs[0].d[i]==xs[1].d[i] || min(xs[0].d[i], xs[1].d[i])==1, "CwiseSum: For each dimension, the dim size needs to match or equal 1.");
   }
   DYNET_ARG_CHECK(xs[0].bd==xs[1].bd || min(xs[0].bd, xs[1].bd)==1, "CwiseSum: batch size must match or equal 1");
-  for(int i=0; i < max(xs[0].nd, xs[1].nd); i++){
+  for(unsigned int i = 0; i < max(xs[0].nd, xs[1].nd); i++){
     if(i < min(xs[0].nd, xs[1].nd)) dims.push_back(max(xs[0].d[i], xs[1].d[i]));
     else if(i < xs[0].nd) dims.push_back(xs[0].d[i]);
     else dims.push_back(xs[1].d[i]);
@@ -42,7 +42,7 @@ void CwiseSum::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*
   Eigen::array<int, 5> bcast_left = {1,1,1,1,1};
   Eigen::array<int, 5> bcast_right = {1,1,1,1,1};
   bool same_nonbatch_dims = true;
-  for(int i=0; i < max(xs[0]->d.nd, xs[1]->d.nd); i++){
+  for(unsigned int i = 0; i < max(xs[0]->d.nd, xs[1]->d.nd); i++){
     if(i >= xs[0]->d.nd || (xs[0]->d[i] == 1 && xs[0]->d[i] != dim[i])){
       bcast_left[i] = dim[i];
       same_nonbatch_dims = false;
@@ -94,7 +94,7 @@ void CwiseSum::backward_dev_impl(const MyDevice & dev,
 #endif
   } else {
     int n_red = xs[i]->d.bd!=fx.d.bd?1:0;
-    for(int j=0; j < fx.d.nd; j++){
+    for(unsigned int j = 0; j < fx.d.nd; j++){
       unsigned dim_j = (j<xs[i]->d.nd ? xs[i]->d[j] : 1);
       if(dim_j != fx.d[j]){
         n_red++;
@@ -120,14 +120,14 @@ void CwiseSum::backward_helper(const MyDevice & dev,
   Eigen::array<int, ReductionOrder> red_axis;
   if(ReductionOrder>0) red_axis[ReductionOrder-1] = 4;
   int curr_red_axis = 0;
-  for(int di=0; di < fx.d.nd; di++){
+  for(unsigned int di = 0; di < fx.d.nd; di++){
     if((di >= xs[i]->d.nd && fx.d[di]>1) || xs[i]->d[di] != fx.d[di]){
       red_axis[curr_red_axis] = di;
       curr_red_axis++;
     }
   }
   Eigen::array<int, 5> morph = {1,1,1,1,1};
-  for(int di=0; di<xs[0]->d.nd; di++){
+  for(unsigned int di = 0; di < xs[0]->d.nd; di++){
     morph[di] = xs[i]->d[di];
   }
   morph[4] = xs[i]->d.bd;
@@ -148,11 +148,11 @@ string CwiseMultiply::as_string(const vector<string>& arg_names) const {
 Dim CwiseMultiply::dim_forward(const vector<Dim>& xs) const {
   DYNET_ARG_CHECK(xs.size() == 2, "Failed input count check in CwiseMultiply");
   std::vector<long> dims({});
-  for(int i=0; i < min(xs[0].nd, xs[1].nd); i++){
+  for(unsigned int i = 0; i < min(xs[0].nd, xs[1].nd); i++){
     DYNET_ARG_CHECK(xs[0].d[i]==xs[1].d[i] || min(xs[0].d[i], xs[1].d[i])==1, "CwiseMultiply: For each dimension, the dim size needs to match or equal 1.");
   }
   DYNET_ARG_CHECK(xs[0].bd==xs[1].bd || min(xs[0].bd, xs[1].bd)==1, "CwiseMultiply: batch size must match or equal 1");
-  for(int i=0; i < max(xs[0].nd, xs[1].nd); i++){
+  for(unsigned int i = 0; i < max(xs[0].nd, xs[1].nd); i++){
     if(i < min(xs[0].nd, xs[1].nd)) dims.push_back(max(xs[0].d[i], xs[1].d[i]));
     else if(i < xs[0].nd) dims.push_back(xs[0].d[i]);
     else dims.push_back(xs[1].d[i]);
@@ -179,7 +179,7 @@ void CwiseMultiply::forward_dev_impl(const MyDevice & dev, const vector<const Te
   Eigen::array<int, 5> bcast_left = {1,1,1,1,1};
   Eigen::array<int, 5> bcast_right = {1,1,1,1,1};
   bool same_dims = true;
-  for(int i=0; i < max(xs[0]->d.nd, xs[1]->d.nd); i++){
+  for(unsigned int i = 0; i < max(xs[0]->d.nd, xs[1]->d.nd); i++){
     if(i>=xs[0]->d.nd || xs[0]->d[i]==1){
       bcast_left[i] = dim[i];
       same_dims = false;
@@ -213,14 +213,14 @@ void CwiseMultiply::backward_dev_impl(const MyDevice & dev,
                              Tensor& dEdxi) const {
   DYNET_ASSERT(i < 2, "Failed dimension check in CwiseMultiply::backward (cmult)");
   int n_red = xs[i]->d.bd!=fx.d.bd?1:0;
-  for(int j=0; j < fx.d.nd; j++){
+  for(unsigned int j = 0; j < fx.d.nd; j++){
     unsigned dim_j = (j<xs[i]->d.nd ? xs[i]->d[j] : 1);
     if(dim_j != fx.d[j]){
       n_red++;
     }
   }
   bool same_dims = n_red==0 && xs[0]->d.bd == xs[1]->d.bd && xs[0]->d.nd == xs[1]->d.nd;
-  for(int j=0; j < min(xs[0]->d.nd, xs[1]->d.nd); j++) if(xs[0]->d[j] != xs[1]->d[j]) same_dims = false;
+  for(unsigned int j = 0; j < min(xs[0]->d.nd, xs[1]->d.nd); j++) if(xs[0]->d[j] != xs[1]->d[j]) same_dims = false;
   DYNET_ASSERT(n_red < 5, "Unsupported number of reductions check in CwiseMultiply::backward (cmult)");
   if(same_dims)     dEdxi.tb<4>().device(*dev.edevice) += dEdf.tb<4>() * xs[1-i]->tb<4>();
   else if(n_red==0) backward_helper<MyDevice, 0>(dev, xs, fx, dEdf, i, dEdxi);
@@ -241,20 +241,20 @@ void CwiseMultiply::backward_helper(const MyDevice & dev,
   Eigen::array<int, ReductionOrder> red_axis;
   if(ReductionOrder>0) red_axis[ReductionOrder-1] = 4;
   int curr_red_axis = 0;
-  for(int di=0; di < fx.d.nd; di++){
+  for(unsigned int di = 0; di < fx.d.nd; di++){
     if((di >= xs[i]->d.nd && fx.d[di]>1) || xs[i]->d[di] != fx.d[di]){
       red_axis[curr_red_axis] = di;
       curr_red_axis++;
     }
   }
   Eigen::array<int, 5> morph = {1,1,1,1,1};
-  for(int di=0; di<xs[i]->d.nd; di++){
+  for(unsigned int di = 0; di<xs[i]->d.nd; di++){
     morph[di] = xs[i]->d[di];
   }
   morph[4] = xs[i]->d.bd;
 
   Eigen::array<int, 5> bcast_other = {1,1,1,1,1};
-  for(int di=0; di < fx.d.nd; di++){
+  for(unsigned int di = 0; di < fx.d.nd; di++){
       if(di>=xs[1-i]->d.nd || xs[1-i]->d[di]==1) bcast_other[di] = fx.d[di];
   }
   if(xs[1-i]->d.bd == 1) bcast_other[4] = dim.bd;
@@ -275,11 +275,11 @@ string CwiseQuotient::as_string(const vector<string>& arg_names) const {
 Dim CwiseQuotient::dim_forward(const vector<Dim>& xs) const {
   DYNET_ARG_CHECK(xs.size() == 2, "Failed input count check in CwiseQuotient");
   std::vector<long> dims({});
-  for(int i=0; i < min(xs[0].nd, xs[1].nd); i++){
+  for(unsigned int i = 0; i < min(xs[0].nd, xs[1].nd); i++){
     DYNET_ARG_CHECK(xs[0].d[i]==xs[1].d[i] ||  xs[1].d[i]==1, "CwiseQuotient: For each dimension, the dim size needs to match or the right side needs to equal 1, but got dimensions: " << xs[0] << " and " << xs[1]);
   }
   DYNET_ARG_CHECK(xs[0].bd==xs[1].bd || xs[1].bd==1, "CwiseQuotient: batch size must match or right side must equal 1");
-  for(int i=0; i < max(xs[0].nd, xs[1].nd); i++){
+  for(unsigned int i = 0; i < max(xs[0].nd, xs[1].nd); i++){
     if(i < min(xs[0].nd, xs[1].nd)) dims.push_back(max(xs[0].d[i], xs[1].d[i]));
     else if(i < xs[0].nd) dims.push_back(xs[0].d[i]);
     else dims.push_back(xs[1].d[i]);
@@ -298,7 +298,7 @@ void CwiseQuotient::forward_dev_impl(const MyDevice & dev, const vector<const Te
     fx.tb<4>().device(*dev.edevice) = xs[0]->tb<4>() / xs[1]->tb<4>();
   } else {
   Eigen::array<int, 5> bcast = {1,1,1,1,1};
-  for(int di=0; di<xs[0]->d.nd; di++){
+  for(unsigned int di = 0; di<xs[0]->d.nd; di++){
     if(xs[1]->d[di]==1) bcast[di] = xs[0]->d[di];
   }
   if(xs[1]->d.bd == 1) bcast[4] = xs[0]->d.bd;
@@ -319,7 +319,7 @@ void CwiseQuotient::backward_dev_impl(const MyDevice & dev,
       dEdxi.tb<4>().device(*dev.edevice) += dEdf.tb<4>() / xs[1]->tb<4>();
     } else {
       Eigen::array<int, 5> bcast = {1,1,1,1,1};
-      for(int di=0; di<xs[0]->d.nd; di++){
+      for(unsigned int di = 0; di<xs[0]->d.nd; di++){
         if(xs[0]->d[di]!=xs[1]->d[di]) bcast[di] = xs[0]->d[di];
       }
       if(xs[0]->d.bd!=xs[1]->d.bd) bcast[4] = xs[0]->d.bd;
@@ -330,7 +330,7 @@ void CwiseQuotient::backward_dev_impl(const MyDevice & dev,
       dEdxi.tb<4>().device(*dev.edevice) -= (dEdf.tb<4>() / xs[1]->tb<4>().square() * xs[0]->tb<4>());
     } else {
       int n_red = xs[0]->d.bd!=xs[1]->d.bd?1:0;
-      for(int di=0;di<xs[0]->d.nd; di++) if(xs[0]->d[di]!=xs[1]->d[di]) n_red++;
+      for(unsigned int di = 0; di < xs[0]->d.nd; di++) if(xs[0]->d[di]!=xs[1]->d[di]) n_red++;
       DYNET_ASSERT(n_red < 5, "Unsupported number of reductions check in CwiseQuotient::backward (cdiv)");
       if(n_red==0)      backward_helper<MyDevice, 0>(dev, xs, fx, dEdf, i, dEdxi);
       else if(n_red==1) backward_helper<MyDevice, 1>(dev, xs, fx, dEdf, i, dEdxi);
@@ -352,19 +352,19 @@ void CwiseQuotient::backward_helper(const MyDevice & dev,
   Eigen::array<int, ReductionOrder> red_axis;
   if(ReductionOrder>0) red_axis[ReductionOrder-1] = 4;
   int curr_red_axis = 0;
-  for(int di=0;di<xs[0]->d.nd; di++){
+  for(unsigned int di = 0; di < xs[0]->d.nd; di++){
     if(xs[0]->d[di]!=xs[1]->d[di]){
       red_axis[curr_red_axis] = di;
       curr_red_axis++;
     }
   }
   Eigen::array<int, 5> morph = {1,1,1,1,1};
-  for(int di=0; di<xs[0]->d.nd; di++){
+  for(unsigned int di = 0; di < xs[0]->d.nd; di++){
     morph[di] = xs[i]->d[di];
   }
   morph[4] = xs[i]->d.bd;
     Eigen::array<int, 5> bcast = {1,1,1,1,1};
-    for(int di=0; di<xs[0]->d.nd; di++){
+    for(unsigned int di = 0; di < xs[0]->d.nd; di++){
       if(xs[0]->d[di]!=xs[1]->d[di]) bcast[di] = xs[0]->d[di];
     }
     if(xs[0]->d.bd!=xs[1]->d.bd) bcast[4] = xs[0]->d.bd;

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -134,10 +134,10 @@ struct Trainer {
 protected:
   Trainer() {}
   virtual unsigned alloc_impl() {
-      return model->parameters_list().size() - aux_allocated;
+      return static_cast<unsigned>(model->parameters_list().size()) - aux_allocated;
   }
   virtual unsigned alloc_lookup_impl() {
-      return model->lookup_parameters_list().size() - aux_allocated_lookup;
+      return static_cast<unsigned>(model->lookup_parameters_list().size()) - aux_allocated_lookup;
   }
   /**
    * \brief The actual rule to update the parameters

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -113,7 +113,7 @@ cdef extern from "dynet/model.h" namespace "dynet":
         vector[shared_ptr[CLookupParameterStorage]] lookup_parameters_list()
         CModel add_subcollection(string name) except +
         string get_fullname()
-        int parameter_count() except +
+        size_t parameter_count() except +
 
 cdef extern from "dynet/io.h" namespace "dynet":
     cdef cppclass CTextFileSaver "dynet::TextFileSaver":
@@ -239,7 +239,7 @@ cdef extern from "dynet/devices.h" namespace "dynet":
     cdef cppclass CDeviceManager "dynet::DeviceManager":
         CDevice* get_global_device(string name) except +
         CDevice* get(unsigned i)
-        unsigned num_devices()
+        size_t num_devices()
 
     CDeviceManager* c_get_device_manager "dynet::get_device_manager" () 
 
@@ -248,7 +248,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
         CExpression()
         CExpression(CComputationGraph *pg, VariableIndex i)
         CComputationGraph *pg
-        long i
+        unsigned i
         CDim dim() except +
         bool is_stale()
         const CTensor& gradient() except +

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -106,7 +106,8 @@ cdef class DynetParams: # {{{
                   '--dynet-viz' in sys.argv):
             cpu_use = True
 
-        cdef int argc = len(sys.argv) + 2 if cpu_use else len(sys.argv)
+        argv_count = int(len(sys.argv))
+        cdef int argc = argv_count + 2 if cpu_use else argv_count
         cdef char** c_argv
         c_argv = <char**>malloc(sizeof(char*) * argc) # TODO check failure?
         args = [bytearray(x, encoding="utf-8") for x in sys.argv]

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -764,7 +764,8 @@ cdef class LookupParameters: # {{{
         Args:
             arr (np.array): numpy array of shape :code:`(num_lookups,...)`
         """
-        if len(arr) > self.thisptr.get_storage().values.size():
+        rows = long(self.thisptr.get_storage().values.size())
+        if len(arr) > rows:
             raise Exception("too many rows")
         if arr.shape[1] != self.thisptr.get_storage().values[0].d.rows():
             raise Exception("dim mismatch")


### PR DESCRIPTION
Hopefully, this patch can remove remaining compiler warnings.
#885 

Remaining warning is in `linear_regression` test case. I have searched the doc. It is a known issue.