### PR TITLE
Softmax across rows

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -85,6 +85,7 @@ Expression sparsemax(const Expression& x) { return Expression(x.pg, x.pg->add_fu
 Expression sparsemax_loss(const Expression& x, const vector<unsigned>& target_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, target_support)); }
 Expression sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, ptarget_support)); }
 Expression softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i})); }
+Expression softmax_rows(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftmaxRows>({x.i})); }
 Expression softsign(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i})); }
 Expression pow(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Pow>({x.i, y.i})); }
 Expression min(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Min>({x.i, y.i})); }

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -84,8 +84,7 @@ Expression logsumexp_dim(const Expression& x, unsigned d) { return Expression(x.
 Expression sparsemax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Sparsemax>({x.i})); }
 Expression sparsemax_loss(const Expression& x, const vector<unsigned>& target_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, target_support)); }
 Expression sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, ptarget_support)); }
-Expression softmax(const Expression& x) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i})); }
-Expression softmax_rows(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftmaxRows>({x.i})); }
+Expression softmax(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i}, d)); }
 Expression softsign(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i})); }
 Expression pow(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Pow>({x.i, y.i})); }
 Expression min(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Min>({x.i, y.i})); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1123,23 +1123,11 @@ Expression colwise_add(const Expression& x, const Expression& bias);
  *          e^{x[i]}/{sum_j e^{x[j]}}.
  *
  * \param x A vector or matrix
+ * \param d dimension to normalize over (default: 0)
  *
  * \return A vector or matrix after calculating the softmax
  */
-Expression softmax(const Expression& x);
-
-/**
- * \ingroup lossoperations
- * \brief SoftmaxRows
- * \details This softmax function normalizes each row to ensure that all
- *          values are between 0 and 1 and add to one by applying the
- *          e^{x[j]}/{sum_i e^{x[i]}}.
- *
- * \param x A vector or matrix
- *
- * \return A vector or matrix after calculating the softmax
- */
-Expression softmax_rows(const Expression& x);
+Expression softmax(const Expression& x, unsigned d=0);
 
 /**
  * \ingroup lossoperations

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1130,6 +1130,19 @@ Expression softmax(const Expression& x);
 
 /**
  * \ingroup lossoperations
+ * \brief SoftmaxRows
+ * \details This softmax function normalizes each row to ensure that all
+ *          values are between 0 and 1 and add to one by applying the
+ *          e^{x[j]}/{sum_i e^{x[i]}}.
+ *
+ * \param x A vector or matrix
+ *
+ * \return A vector or matrix after calculating the softmax
+ */
+Expression softmax_rows(const Expression& x);
+
+/**
+ * \ingroup lossoperations
  * \brief Log softmax
  * \details The log softmax function normalizes each column to ensure that all
  *          values are between 0 and 1 and add to one by applying the

--- a/dynet/nodes-softmaxes.h
+++ b/dynet/nodes-softmaxes.h
@@ -9,9 +9,8 @@ namespace dynet {
 // z = \sum_j \exp (x_i)_j
 // y_i = (x_1)_i / z
 struct Softmax : public Node {
-  explicit Softmax(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  explicit Softmax(const std::initializer_list<VariableIndex>& a, unsigned d = 0) : Node(a), dimension(d) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
-  size_t aux_storage_size() const override;
   virtual bool supports_multibatch() const override { return true; }
   virtual int autobatch_sig(const ComputationGraph& cg,
                             SigMap& sm) const override;
@@ -24,6 +23,7 @@ struct Softmax : public Node {
                                  Tensor& fx) const override {
     autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
   }
+  unsigned dimension;
 };
 
 // z = \sum_j \exp (x_i)_j

--- a/dynet/nodes-softmaxes.h
+++ b/dynet/nodes-softmaxes.h
@@ -9,7 +9,7 @@ namespace dynet {
 // z = \sum_j \exp (x_i)_j
 // y_i = (x_1)_i / z
 struct Softmax : public Node {
-  explicit Softmax(const std::initializer_list<VariableIndex>& a, unsigned d = 0) : Node(a), dimension(d) {}
+  explicit Softmax(const std::initializer_list<VariableIndex>& a) : Node(a) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
   virtual bool supports_multibatch() const override { return true; }
   virtual int autobatch_sig(const ComputationGraph& cg,
@@ -23,7 +23,23 @@ struct Softmax : public Node {
                                  Tensor& fx) const override {
     autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
   }
-  unsigned dimension;
+};
+
+struct SoftmaxRows : public Node {
+  explicit SoftmaxRows(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+  virtual int autobatch_sig(const ComputationGraph& cg,
+                            SigMap& sm) const override;
+  virtual std::vector<int> autobatch_concat(
+      const ComputationGraph& cg) const override;
+  virtual void autobatch_reshape(const ComputationGraph& cg,
+                                 const std::vector<VariableIndex>& batch_ids,
+                                 const std::vector<int>& concat,
+                                 std::vector<const Tensor*>& xs,
+                                 Tensor& fx) const override {
+    autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
+  }
 };
 
 // z = \sum_j \exp (x_i)_j

--- a/dynet/nodes-softmaxes.h
+++ b/dynet/nodes-softmaxes.h
@@ -9,7 +9,7 @@ namespace dynet {
 // z = \sum_j \exp (x_i)_j
 // y_i = (x_1)_i / z
 struct Softmax : public Node {
-  explicit Softmax(const std::initializer_list<VariableIndex>& a) : Node(a) {}
+  explicit Softmax(const std::initializer_list<VariableIndex>& a, unsigned d=0) : Node(a), dimension(d) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
   virtual bool supports_multibatch() const override { return true; }
   virtual int autobatch_sig(const ComputationGraph& cg,
@@ -23,23 +23,7 @@ struct Softmax : public Node {
                                  Tensor& fx) const override {
     autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
   }
-};
-
-struct SoftmaxRows : public Node {
-  explicit SoftmaxRows(const std::initializer_list<VariableIndex>& a) : Node(a) {}
-  DYNET_NODE_DEFINE_DEV_IMPL()
-  virtual bool supports_multibatch() const override { return true; }
-  virtual int autobatch_sig(const ComputationGraph& cg,
-                            SigMap& sm) const override;
-  virtual std::vector<int> autobatch_concat(
-      const ComputationGraph& cg) const override;
-  virtual void autobatch_reshape(const ComputationGraph& cg,
-                                 const std::vector<VariableIndex>& batch_ids,
-                                 const std::vector<int>& concat,
-                                 std::vector<const Tensor*>& xs,
-                                 Tensor& fx) const override {
-    autobatch_reshape_concatonly(cg, batch_ids, concat, xs, fx);
-  }
+  unsigned dimension;
 };
 
 // z = \sum_j \exp (x_i)_j

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -315,8 +315,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     # CExpression c_hinge_dim "dynet::hinge_dim" (CExpression& x, vector[vector[unsigned]] indices, unsigned d, float m) except + #
     CExpression c_log_softmax "dynet::log_softmax" (CExpression& x) except + #
     CExpression c_log_softmax "dynet::log_softmax" (CExpression& x, vector[unsigned]& restriction) except + #?
-    CExpression c_softmax "dynet::softmax" (CExpression& x) except + #
-    CExpression c_softmax_rows "dynet::softmax_rows" (CExpression& x) except + #
+    CExpression c_softmax "dynet::softmax" (CExpression& x, unsigned d) except + #
     CExpression c_sparsemax "dynet::sparsemax" (CExpression& x) except + #
     CExpression c_softsign "dynet::softsign" (CExpression& x) except + #
     CExpression c_pow "dynet::pow" (CExpression& x, CExpression& y) except + #

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -316,6 +316,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_log_softmax "dynet::log_softmax" (CExpression& x) except + #
     CExpression c_log_softmax "dynet::log_softmax" (CExpression& x, vector[unsigned]& restriction) except + #?
     CExpression c_softmax "dynet::softmax" (CExpression& x) except + #
+    CExpression c_softmax_rows "dynet::softmax_rows" (CExpression& x) except + #
     CExpression c_sparsemax "dynet::sparsemax" (CExpression& x) except + #
     CExpression c_softsign "dynet::softsign" (CExpression& x) except + #
     CExpression c_pow "dynet::pow" (CExpression& x, CExpression& y) except + #

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3018,31 +3018,19 @@ cpdef Expression log_softmax(Expression x, list restrict=None):
     cdef vector[unsigned] vec = restrict
     return Expression.from_cexpr(x.cg_version, c_log_softmax(x.c(), vec))
 
-cpdef Expression softmax(Expression x):
+cpdef Expression softmax(Expression x, unsigned d=0):
     """Softmax
     
     The softmax function normalizes each column to ensure that all values are between 0 and 1 and add to one by applying the :math:`\\frac{e^{x_i}}{sum_j e^{x_j}}`.
     
     Args:
         x (dynet.Expression): Input expression
+        d (int): Dimension to normalize over
     
     Returns:
         dynet.Expression: :math:`\\frac{e^{x_i}}{\sum_j e^{x_j}}`
     """
-    return Expression.from_cexpr(x.cg_version, c_softmax(x.c()))
-
-cpdef Expression softmax_rows(Expression x):
-    """Softmax over rows
-    
-    This softmax function normalizes each row to ensure that all values are between 0 and 1 and add to one by applying the :math:`\\frac{e^{x_j}}{sum_i e^{x_i}}`.
-    
-    Args:
-        x (dynet.Expression): Input expression
-    
-    Returns:
-        dynet.Expression: :math:`\\frac{e^{x_j}}{\sum_i e^{x_i}}`
-    """
-    return Expression.from_cexpr(x.cg_version, c_softmax_rows(x.c()))
+    return Expression.from_cexpr(x.cg_version, c_softmax(x.c(), d))
 
 cpdef Expression sparsemax(Expression x):
     """Sparsemax

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3031,6 +3031,19 @@ cpdef Expression softmax(Expression x):
     """
     return Expression.from_cexpr(x.cg_version, c_softmax(x.c()))
 
+cpdef Expression softmax_rows(Expression x):
+    """Softmax over rows
+    
+    This softmax function normalizes each row to ensure that all values are between 0 and 1 and add to one by applying the :math:`\\frac{e^{x_j}}{sum_i e^{x_i}}`.
+    
+    Args:
+        x (dynet.Expression): Input expression
+    
+    Returns:
+        dynet.Expression: :math:`\\frac{e^{x_j}}{\sum_i e^{x_i}}`
+    """
+    return Expression.from_cexpr(x.cg_version, c_softmax_rows(x.c()))
+
 cpdef Expression sparsemax(Expression x):
     """Sparsemax
     

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -969,20 +969,10 @@ BOOST_AUTO_TEST_CASE( softmax_colbatch_gradient ) {
 }
 
 // Expression softmax(const Expression& x, unsigned v);
-BOOST_AUTO_TEST_CASE( softmax_rows_batch_gradient ) {
-  dynet::ComputationGraph cg;
-  Expression x1 = parameter(cg, param1);
-  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
-  Expression y = log(softmax_rows(x1 + x2));
-  Expression z = sum_batches(input(cg, {1, 3}, first_one_vals) * y);
-  BOOST_CHECK(check_grad(mod, z, 0));
-}
-
-// Expression softmax(const Expression& x, unsigned v);
-BOOST_AUTO_TEST_CASE( softmax_rows_colbatch_gradient ) {
+BOOST_AUTO_TEST_CASE( softmax_cols_colbatch_gradient ) {
   dynet::ComputationGraph cg;
   Expression x = reshape(parameter(cg, param_cube1), Dim({3, 3}, 3));
-  Expression y = softmax_rows(x);
+  Expression y = softmax(x, 1);
   Expression z = sum_batches(input(cg, {1, 3}, first_one_vals) * y * input(cg, {3}, first_one_vals));
   BOOST_CHECK(check_grad(mod, z, 0));
 }

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -968,6 +968,25 @@ BOOST_AUTO_TEST_CASE( softmax_colbatch_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression softmax(const Expression& x, unsigned v);
+BOOST_AUTO_TEST_CASE( softmax_rows_batch_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x1 = parameter(cg, param1);
+  Expression x2 = input(cg, Dim({3}, 2), batch_vals);
+  Expression y = log(softmax_rows(x1 + x2));
+  Expression z = sum_batches(input(cg, {1, 3}, first_one_vals) * y);
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
+// Expression softmax(const Expression& x, unsigned v);
+BOOST_AUTO_TEST_CASE( softmax_rows_colbatch_gradient ) {
+  dynet::ComputationGraph cg;
+  Expression x = reshape(parameter(cg, param_cube1), Dim({3, 3}, 3));
+  Expression y = softmax_rows(x);
+  Expression z = sum_batches(input(cg, {1, 3}, first_one_vals) * y * input(cg, {3}, first_one_vals));
+  BOOST_CHECK(check_grad(mod, z, 0));
+}
+
 // Expression sparsemax(const Expression& x);
 BOOST_AUTO_TEST_CASE( sparsemax_gradient ) {
   dynet::ComputationGraph cg;


### PR DESCRIPTION
- Introduce a softmax operator across rows, rather than columns as in the standard softmax.
- Both the softmax() and softmax_rows() are improved to use scratch memory rather than auxiliary memory.

Rather than introducing a new operator, I first tried to add a "dimension" parameter to the softmax that defaults to d=1, but that introduced inconsistency because softmax is also supposed to work for a vector input (for which d=1 makes no sense), so I went with the new operator instead.