### PR TITLE
Boundary check for pick_batch_elem

### DIFF
--- a/dynet/nodes-select.cc
+++ b/dynet/nodes-select.cc
@@ -298,6 +298,8 @@ Dim PickBatchElements::dim_forward(const vector<Dim>& xs) const {
 template<class MyDevice>
 void PickBatchElements::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   if (pval) {
+    DYNET_ARG_CHECK(*pval < xs[0]->d.bd,
+                    "PickBatchElements::forward_impl requested element " << *pval << " from a batch size of " << xs[0]->d.bd);
     fx.tvec().device(*dev.edevice) = xs[0]->tbvec().chip<1>(*pval);
   } else {
     DYNET_ASSERT(pvals != nullptr, "Neither single nor vector of elements available in PickBatchElements::forward");


### PR DESCRIPTION
Fixes https://github.com/clab/dynet/issues/1037

pick_batch_elem wasn't properly checking for out of bounds indices, now it does.