### PR TITLE
Deploy macOS wheels

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ environment:
     BOOST_ROOT: C:\Libraries\boost_1_59_0
     BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
     MSVC: 1
-    MINICONDA: "C:\\Miniconda3-x64"
+    MINICONDA: "C:\\Miniconda36-x64"
     TWINE_USERNAME: danielh
     TWINE_PASSWORD:
       secure: cpMn69tLzuhwO7EPhhiVwA==

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,4 +140,4 @@ deploy:
   on:
     repo: clab/dynet
     tags: true
-    condition: "$PYTHON_INSTALL = pip && $TRAVIS_OS_NAME = linux"
+    condition: "$PYTHON_INSTALL = pip"

--- a/.travis/build_macos_wheel.sh
+++ b/.travis/build_macos_wheel.sh
@@ -5,19 +5,8 @@ cd "$TRAVIS_BUILD_DIR"
 source activate "$PYVER"
 pip install pypandoc delocate
 python setup.py bdist_wheel
-DYLIB="$TRAVIS_BUILD_DIR/miniconda/envs/$PYVER/lib/libdynet.dylib"
 mkdir -p dist
 for whl in build/py*/python/dist/*.whl; do
-  echo Trying to relink $DYLIB into $whl...
-  DEPS_BEFORE="$(delocate-listdeps $whl)"
   delocate-wheel -v "$whl" -w dist
-  DEPS_AFTER="$(delocate-listdeps $whl)"
-  if [[ "$DEPS_BEFORE" == "$DEPS_AFTER" ]]; then
-    echo "Failed fixing wheel, see https://github.com/clab/dynet/pull/841"
-    mkdir -p dist
-    cp -vf "$whl" dist/
-  else
-    echo "Success!"
-  fi
 done
 

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -2,5 +2,7 @@
 set -xe
 
 cd "$TRAVIS_BUILD_DIR"
-python setup.py sdist  # Build sdist
+if [[ "$TRAVIS_OS_NAME" == linux ]]; then
+  python setup.py sdist  # Build sdist
+fi
 twine upload --skip-existing dist/*  # Upload to PyPI

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -15,6 +15,7 @@ if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
     pip install -U $PYTHON_PACKAGES
   fi
 else
+  brew update
   brew install pandoc
   # Install Miniconda
   export MINICONDA_OS_NAME=MacOSX MINICONDA_ARCH=x86_64

--- a/setup.py
+++ b/setup.py
@@ -160,10 +160,11 @@ else:
     if platform.system() == "Darwin":
         COMPILER_ARGS.extend(["-stdlib=libc++", "-mmacosx-version-min=10.7"])
         EXTRA_LINK_ARGS.append("-Wl,-rpath," + LIBS_INSTALL_DIR)
+        DATA_FILES += [LIBS_INSTALL_DIR + "lib" + lib + ".dylib" for lib in LIBRARIES]
     else:
         EXTRA_LINK_ARGS.append("-Wl,-rpath=%r" % LIBS_INSTALL_DIR + ",--no-as-needed")
 
-LIBRARY_DIRS.append(DYNET_LIB_DIR)
+LIBRARY_DIRS.insert(0, DYNET_LIB_DIR)
 
 INCLUDE_DIRS[:] = filter(None, [PROJECT_SOURCE_DIR, EIGEN3_INCLUDE_DIR])
 


### PR DESCRIPTION
- Fixes #870 and #1034: create macOS wheel on Travis CI with the DyNet shared library and deploy to PyPI on tags.
- Unrelated fix for Travis CI installation retrying the `brew install`.
- Unrelated fix for AppVeyor failures.