### PR TITLE
Fix install name in macOS wheels with install_name_tool

### DIFF
--- a/.travis/build_macos_wheel.sh
+++ b/.travis/build_macos_wheel.sh
@@ -3,10 +3,6 @@ set -xe
 
 cd "$TRAVIS_BUILD_DIR"
 source activate "$PYVER"
-pip install pypandoc delocate
+pip install pypandoc
 python setup.py bdist_wheel
-mkdir -p dist
-for whl in build/py*/python/dist/*.whl; do
-  delocate-wheel -v "$whl" -w dist
-done
-
+cp -vr build/py*/python/dist ./

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -29,7 +29,7 @@ else
   # Useful for debugging any issues with conda
   conda info -a
   source activate "$PYVER"
-  pip install pypandoc twine delocate
+  pip install pypandoc twine
 fi
 
 # CUDA

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ---
 
-[![Build Status](https://travis-ci.org/clab/dynet.svg?branch=master)](https://travis-ci.org/clab/dynet)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/clab/dynet?svg=true)](https://ci.appveyor.com/project/danielh/dynet-c3iuq)
-[![Doc build Status](https://readthedocs.org/projects/dynet/badge/?version=latest)](http://dynet.readthedocs.io/en/latest/)
+[![Build Status (Travis CI)](https://travis-ci.org/clab/dynet.svg?branch=master)](https://travis-ci.org/clab/dynet)
+[![Build Status (AppVeyor)](https://ci.appveyor.com/api/projects/status/github/clab/dynet?svg=true)](https://ci.appveyor.com/project/danielh/dynet-c3iuq)
+[![Build Status (Docs)](https://readthedocs.org/projects/dynet/badge/?version=latest)](http://dynet.readthedocs.io/en/latest/)
 [![PyPI version](https://badge.fury.io/py/dyNET.svg)](https://badge.fury.io/py/dyNET)
 
 The Dynamic Neural Network Toolkit

--- a/setup.py
+++ b/setup.py
@@ -292,6 +292,14 @@ class build(_build):
             if run_process(make_cmd) != 0:
                 raise DistutilsSetupError(" ".join(make_cmd))
 
+            if platform.system() == "Darwin":
+                for lib in DATA_FILES:
+                    new_install_name = "@loader_path/" + os.path.basename(lib)
+                    install_name_tool_cmd = ["install_name_tool", "-id", new_install_name, lib]
+                    log.info("Fixing install_name for %r..." % lib)
+                    if run_process(install_name_tool_cmd) != 0:
+                        raise DistutilsSetupError(" ".join(install_name_tool_cmd))
+
         # This will generally be called by the manual install
         elif not os.path.isdir(EIGEN3_INCLUDE_DIR):
             raise RuntimeError("Could not find Eigen in EIGEN3_INCLUDE_DIR={}. If doing manual install, please set the EIGEN3_INCLUDE_DIR variable with the absolute path to Eigen manually. If doing install via pip, please file an issue on github.com/clab/dynet".format(EIGEN3_INCLUDE_DIR))

--- a/setup.py
+++ b/setup.py
@@ -339,6 +339,7 @@ class build_ext(_build_ext):
 try:
     import pypandoc
     long_description = pypandoc.convert("README.md", "rst")
+    long_description = "\n".join(line for line in long_description.splitlines() if "<#" not in line)
 except:
     long_description = ""
 


### PR DESCRIPTION
[Resulting wheels](https://pypi.python.org/pypi/dyNET/2.0.1.post13) verified to work without `DYLD_LIBRARY_PATH`. Just do `pip install dynet`.
Removed `delocate` because it doesn't work in our case (matthew-brett/delocate#22).