### PR TITLE
Changes to enable threadsafe operation

### DIFF
--- a/dynet/aligned-mem-pool.cc
+++ b/dynet/aligned-mem-pool.cc
@@ -4,6 +4,25 @@
 
 using namespace dynet;
 
+
+void DynamicCPUMemoryPool::zero(void* p, size_t n) {
+  auto rounded_n = a->round_up_align(n);
+  a->zero(p, rounded_n);
+}
+
+void* DynamicCPUMemoryPool::allocate(size_t n) {
+  auto rounded_n = a->round_up_align(n);
+  void* res = a->malloc(rounded_n);
+  if (res) {
+    ptrs.push_back(res);
+    sizes.push_back(rounded_n);
+  }
+  return res;
+}
+
+void DynamicCPUMemoryPool::sys_alloc(size_t cap) {}
+
+
 void* InternalMemoryPool::allocate(size_t n) {
   auto rounded_n = a->round_up_align(n);
   if (rounded_n + used > capacity) {
@@ -22,9 +41,13 @@ void InternalMemoryPool::sys_alloc(size_t cap) {
   used = 0;
 }
 
-AlignedMemoryPool::AlignedMemoryPool(const std::string &name, size_t initial_cap, MemAllocator *a, size_t expanding_unit) : name(name), cap(initial_cap), current(0), a(a), expanding_unit(expanding_unit) {
+AlignedMemoryPool::AlignedMemoryPool(const std::string &name, size_t initial_cap, MemAllocator *a, size_t expanding_unit, bool dynamic) : name(name), cap(initial_cap), current(0), a(a), expanding_unit(expanding_unit), dynamic(dynamic) {
   DYNET_ARG_CHECK(cap > 0, "Attempt to allocate memory of size 0 in AlignedMemoryPool");
-  pools.push_back(new InternalMemoryPool(name, cap, a));
+  if (dynamic) {
+    pools.push_back(new DynamicCPUMemoryPool(name, cap));
+  } else {
+    pools.push_back(new InternalMemoryPool(name, cap, a));
+  }
 }
 AlignedMemoryPool::~AlignedMemoryPool() {
   for ( auto p : pools) { delete p; }
@@ -35,7 +58,11 @@ void* AlignedMemoryPool::allocate(size_t n) {
   if (res == 0) {
     // round up to the nearest multiple of expanding_unit
     size_t new_pool_size  = (n + expanding_unit-1) / expanding_unit * expanding_unit;
-    pools.push_back(new InternalMemoryPool(name, new_pool_size, a));
+    if (dynamic) {
+      pools.push_back(new DynamicCPUMemoryPool(name, new_pool_size));
+    } else {
+      pools.push_back(new InternalMemoryPool(name, new_pool_size, a));
+    }
     cap += new_pool_size;
     current++;
     res = pools[current]->allocate(n);
@@ -47,7 +74,12 @@ void AlignedMemoryPool::free() {
   if (current > 0) {
     for (auto p : pools) { delete p; }
     pools.clear();
-    pools.push_back(new InternalMemoryPool(name, cap, a));
+    if (dynamic) {
+      pools.push_back(new DynamicCPUMemoryPool(name, cap));
+    } else {
+      pools.push_back(new InternalMemoryPool(name, cap, a));
+    }
+    cap = cap * (current + 1);
     current = 0;
   }
   pools[0]->free();

--- a/dynet/aligned-mem-pool.h
+++ b/dynet/aligned-mem-pool.h
@@ -8,9 +8,64 @@
 
 namespace dynet {
 
-class InternalMemoryPool {
+class BaseMemoryPool {
  public:
-  explicit InternalMemoryPool(const std::string & name, size_t cap, MemAllocator* a) : name(name), a(a) {
+  BaseMemoryPool(const std::string & name, MemAllocator* a) : name(name), a(a) {}
+  virtual ~BaseMemoryPool() {}
+  virtual void* allocate(size_t n) = 0; 
+
+  virtual void free() = 0;
+  // zeros out the amount of allocations
+  virtual void zero_allocated_memory() = 0;
+
+  size_t used;
+
+ protected:
+  virtual void sys_alloc(size_t cap) {}
+  virtual void zero_all() {}
+
+  MemAllocator* a;
+  std::string name;
+  void* mem;
+};
+
+class DynamicCPUMemoryPool : public BaseMemoryPool {
+ private:
+  std::vector<void*> ptrs;
+  std::vector<size_t> sizes;
+
+ public:
+  explicit DynamicCPUMemoryPool(const std::string & name, size_t cap)
+    : BaseMemoryPool(name, new CPUAllocator()) {}
+
+  ~DynamicCPUMemoryPool() {
+      free();
+      delete a;
+  }
+
+  void* allocate(size_t n); 
+  void zero(void* p, size_t n); 
+
+  void free() {
+    for (auto p : ptrs)
+      a->free(p);
+    ptrs.clear();
+    sizes.clear();
+  }
+  // zeros out the amount of allocations
+  void zero_allocated_memory() {
+    for (unsigned i = 0; i < ptrs.size(); i++)
+      zero(ptrs[i], sizes[i]);
+  }
+
+ private:
+  void sys_alloc(size_t cap);
+  void zero_all() {}
+};
+
+class InternalMemoryPool : public BaseMemoryPool {
+ public:
+  explicit InternalMemoryPool(const std::string & name, size_t cap, MemAllocator* a) : BaseMemoryPool(name, a) {
     sys_alloc(cap);
     zero_all();
   }
@@ -33,20 +88,18 @@ class InternalMemoryPool {
 
   size_t used;
  private:
+  size_t capacity;
+
   void sys_alloc(size_t cap);
 
   void zero_all() {
     a->zero(mem, capacity);
   }
-  std::string name;
-  size_t capacity;
-  MemAllocator* a;
-  void* mem;
 };
 
 class AlignedMemoryPool {
   public:
-    explicit AlignedMemoryPool(const std::string &name, size_t initial_cap, MemAllocator *a, size_t expanding_unit = 1<<24);
+    explicit AlignedMemoryPool(const std::string &name, size_t initial_cap, MemAllocator *a, size_t expanding_unit = 1<<24, bool dynamic = false);
     ~AlignedMemoryPool();
 
     void* allocate(size_t n);
@@ -58,13 +111,18 @@ class AlignedMemoryPool {
     size_t used();
     void set_used(size_t s);
 
+    size_t round_up_align(size_t n) const { return a->round_up_align(n); }
+
+    bool is_dynamic() { return dynamic; }
+
   private:
     std::string name;
-    std::vector<InternalMemoryPool *> pools;
+    std::vector<BaseMemoryPool *> pools;
     size_t cap;
     int current;
     MemAllocator* a;
     size_t expanding_unit;
+    bool dynamic;
 };
 
 } // namespace dynet

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -122,7 +122,7 @@ Device_GPU::Device_GPU(int my_id, const DeviceMempoolSizes & mbs, int device_id)
 Device_GPU::~Device_GPU() {}
 #endif
 
-Device_CPU::Device_CPU(int my_id, const DeviceMempoolSizes & mbs, bool shared) :
+Device_CPU::Device_CPU(int my_id, const DeviceMempoolSizes & mbs, bool shared, bool dynamic) :
   Device(my_id, DeviceType::CPU, &cpu_mem), shmem(mem) {
   if (shared) shmem = new SharedAllocator();
   kSCALAR_MINUSONE = (float*) mem->malloc(sizeof(float));
@@ -137,10 +137,11 @@ Device_CPU::Device_CPU(int my_id, const DeviceMempoolSizes & mbs, bool shared) :
   edevice = new Eigen::DefaultDevice;
 
   // this is the big memory allocation.
-  pools[0] = new AlignedMemoryPool("CPU forward memory", (mbs.used[0] << 20), &cpu_mem);
-  pools[1] = new AlignedMemoryPool("CPU backward memory", (mbs.used[1] << 20), &cpu_mem);
-  pools[2] = new AlignedMemoryPool("CPU parameter memory", (mbs.used[2] << 20), shmem);
-  pools[3] = new AlignedMemoryPool("CPU scratch memory", (mbs.used[3] << 20), &cpu_mem);
+  const size_t initial = 1<<24;
+  pools[0] = new AlignedMemoryPool("CPU forward memory",   (mbs.used[0] << 20), &cpu_mem, initial, dynamic);
+  pools[1] = new AlignedMemoryPool("CPU backward memory",  (mbs.used[1] << 20), &cpu_mem, initial, dynamic);
+  pools[2] = new AlignedMemoryPool("CPU parameter memory", (mbs.used[2] << 20), shmem,    initial, dynamic);
+  pools[3] = new AlignedMemoryPool("CPU scratch memory",   (mbs.used[3] << 20), &cpu_mem, initial, dynamic);
 }
 
 Device_CPU::~Device_CPU() {}

--- a/dynet/devices.h
+++ b/dynet/devices.h
@@ -163,7 +163,7 @@ class Device_GPU : public Device {
 class Device_CPU : public Device {
  public:
   typedef Eigen::DefaultDevice EigenDevice;
-  explicit Device_CPU(int my_id, const DeviceMempoolSizes & mb, bool shared);
+  explicit Device_CPU(int my_id, const DeviceMempoolSizes & mb, bool shared, bool dynamic);
   ~Device_CPU();
   CPUAllocator cpu_mem;
   Eigen::DefaultDevice* edevice;

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -111,7 +111,7 @@ ComputationGraph::ComputationGraph() {
   } else {
     ee.reset(new SimpleExecutionEngine(*this));
   }
-  if (n_hgs > 0) {
+  if (!default_device->pools[0]->is_dynamic() && n_hgs > 0) {
     cerr << "Memory allocator assumes only a single ComputationGraph at a time.\n";
     throw std::runtime_error("Attempted to create >1 CG");
   }
@@ -128,7 +128,7 @@ ComputationGraph::ComputationGraph(bool batched) {
   } else {
     ee.reset(new SimpleExecutionEngine(*this));
   }
-  if (n_hgs > 0) {
+  if (!default_device->pools[0]->is_dynamic() && n_hgs > 0) {
     cerr << "Memory allocator assumes only a single ComputationGraph at a time.\n";
     throw std::runtime_error("Attempted to create >1 CG");
   }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -35,7 +35,6 @@
 
 #include <stdexcept>
 
-
 namespace dynet {
 /**
  * \ingroup operations
@@ -49,6 +48,7 @@ struct Expression {
 
   Expression() : pg(nullptr), i(0), graph_id(0) {}
 
+  const bool is_dynamic() const {return default_device->pools[0]->is_dynamic();}
   /**
    * \brief Base expression constructor
    * \details Used when creating operations
@@ -75,7 +75,7 @@ struct Expression {
    * \return Value of the expression as a tensor
    */
   const Tensor& value() const {
-    if (this->is_stale()) {
+    if (!this->is_dynamic() && this->is_stale()) {
       throw std::runtime_error("Attempt to use a stale expression.");
     }
     return pg->get_value(i);
@@ -91,7 +91,7 @@ struct Expression {
    * \return Value of the expression as a tensor
    */
   const Tensor& gradient() const {
-    if (this->is_stale()) {
+    if (!this->is_dynamic() && this->is_stale()) {
       throw std::runtime_error("Attempt to use a stale expression.");
     }
     return pg->get_gradient(i);
@@ -102,7 +102,7 @@ struct Expression {
    * \return Dimension of the expression
    */
   const Dim& dim() const {
-    if (this->is_stale()) {
+    if (!this->is_dynamic() && this->is_stale()) {
       throw std::runtime_error("Attempt to use a stale expression.");
     }
     return pg->get_dimension(i);

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -61,6 +61,17 @@ DynetParams extract_dynet_params(int& argc, char**& argv, bool shared_parameters
       }
     }
 
+    // Memory
+    else if (arg == "--dynet-dynamic-mem" || arg == "--dynet_dynamic_mem") {
+      if ((argi + 1) >= argc) {
+        throw std::invalid_argument("[dynet] --dynet-dynemic-mem expects an argument (bool)");
+      } else {
+        string a2 = argv[argi + 1];
+        istringstream c(a2); c >> params.dynamic;
+        remove_args(argc, argv, argi, 2);
+      }
+    }
+
     // Weight decay
     else if (arg == "--dynet-weight-decay" || arg == "--dynet_weight_decay") {
       if ((argi + 1) >= argc) {
@@ -100,7 +111,7 @@ DynetParams extract_dynet_params(int& argc, char**& argv, bool shared_parameters
 
 #if HAVE_CUDA
     else if (arg == "--dynet-gpus" || arg == "--dynet_gpus") {
-      if ((argi + 1) > argc) {
+      if ((argi + 1) >= argc) {
         throw std::invalid_argument("[dynet] --dynet-gpus expects an argument (number of GPUs to use)");
       } else {
         if (params.ngpus_requested)
@@ -210,9 +221,9 @@ void initialize(DynetParams& params) {
 
   Device *d;
   if (gpudevices.size()) {
-    d = new Device_CPU(device_manager->num_devices(), std::string("128"), params.shared_parameters);
+    d = new Device_CPU(device_manager->num_devices(), std::string("128"), params.shared_parameters, false);
   } else {
-    d = new Device_CPU(device_manager->num_devices(), params.mem_descriptor, params.shared_parameters);
+    d = new Device_CPU(device_manager->num_devices(), params.mem_descriptor, params.shared_parameters, params.dynamic);
   }
   device_manager->add(d);
   default_device = device_manager->get(default_index);

--- a/dynet/init.h
+++ b/dynet/init.h
@@ -28,6 +28,7 @@ struct DynetParams {
   bool cpu_requested; /**< CPU requested in multi-device case */
   int requested_gpus; /**< Number of requested GPUs */
   std::vector<int> gpu_mask; /**< List of required GPUs by ids */
+  bool dynamic = false; /**< Dynamically allocate CPU memory for threadsafety */
 };
 
 DynetParams extract_dynet_params(int& argc, char**& argv, bool shared_parameters = false);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,7 @@ if (DEFINED ENV{DYNET_TEST_DEVICES})  # use env variable as preprocessor macro
   add_definitions(-DDYNET_TEST_DEVICES=$ENV{DYNET_TEST_DEVICES})
 endif()
 
-foreach(TESTNAME dim dynet exec io mem nodes params tensor trainers rnn softmax)
+foreach(TESTNAME dim dynet exec exec-dynamic io mem nodes params tensor trainers rnn softmax)
   add_executable(test-${TESTNAME} test-${TESTNAME}.cc)
   if (NOT MSVC)
     target_link_libraries(test-${TESTNAME} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/tests/test-exec-dynamic.cc
+++ b/tests/test-exec-dynamic.cc
@@ -1,0 +1,150 @@
+#define BOOST_TEST_MODULE TEST_RNN
+
+#include <dynet/dynet.h>
+#include <dynet/expr.h>
+#include <dynet/exec.h>
+#include <dynet/lstm.h>
+#include <dynet/fast-lstm.h>
+#include <dynet/gru.h>
+#include <dynet/grad-check.h>
+#include <dynet/param-init.h>
+#include <boost/test/unit_test.hpp>
+#include "test.h"
+#include <stdexcept>
+#include <fstream>
+#include <thread>
+
+using namespace dynet;
+using namespace std;
+
+
+struct ExecTest {
+  ExecTest() {
+    // initialize if necessary
+    if (default_device == nullptr) {
+      for (auto x : {"ExecTest", "--dynet-seed", "10", "--dynet-mem", "1",
+                     "--dynet-dynamic-mem", "1"}) {
+        av.push_back(strdup(x));
+      }
+      ADD_EXTRA_ARGUMENTS(av)
+      char **argv = &av[0];
+      int argc = av.size();
+      dynet::initialize(argc, argv);
+    }
+  }
+  ~ExecTest() {
+    // This was causing double deallocation errors?
+    // for (auto x : av) free(x);
+  }
+
+  template <class T>
+  std::string print_vec(const std::vector<T> vec) {
+    ostringstream oss;
+    if (vec.size()) oss << vec[0];
+    for (size_t i = 1; i < vec.size(); i++)
+      oss << ' ' << vec[i];
+    return oss.str();
+  }
+
+  std::vector<char*> av;
+
+};
+
+// define the test suite
+BOOST_FIXTURE_TEST_SUITE(exec_test, ExecTest);
+
+BOOST_AUTO_TEST_CASE( lstm ) {
+  vector<float> results;
+  dynet::ParameterCollection mod;
+  dynet::VanillaLSTMBuilder lstm(2, 3, 10, mod);
+  dynet::LookupParameter lp = mod.add_lookup_parameters(10, {3});
+  dynet::autobatch_flag = 0;
+  dynet::ComputationGraph cg;
+  lstm.new_graph(cg);
+  vector<Expression> losses;
+  for(size_t j = 0; j < 3; ++j) {
+    lstm.start_new_sequence();
+    for(size_t k = 0; k < 3; ++k) {
+      Expression x = dynet::lookup(cg, lp, j*3 + k);
+      lstm.add_input(x);
+    }
+    losses.push_back(squared_norm(lstm.final_h()[1]));
+  }
+  losses.push_back(losses[0] + losses[2]);
+  Expression z = dynet::sum(losses);
+  results.push_back(as_scalar(z.value()));
+
+  for (size_t i = 1; i < results.size(); ++i)
+    BOOST_CHECK_CLOSE(results[0], results[i], 0.0001);
+}
+
+BOOST_AUTO_TEST_CASE( param_after_node ) {
+  auto autobatch_cache = dynet::autobatch_flag;
+  dynet::autobatch_flag = 0;
+  ComputationGraph cg;
+  ParameterCollection model;
+  Parameter param = model.add_parameters({ 1 });
+  
+  Expression loss = zeroes(cg, { 1 });
+  parameter(cg, param);
+  
+  cg.incremental_forward(loss);
+  cg.backward(loss);
+  dynet::autobatch_flag = autobatch_cache;
+}
+
+BOOST_AUTO_TEST_CASE( param_after_node_2 ) {
+  auto autobatch_cache = dynet::autobatch_flag;
+  dynet::autobatch_flag = 0;
+  ComputationGraph cg;
+  ParameterCollection model;
+  LookupParameter param = model.add_lookup_parameters(10, { 1 });
+
+  lookup(cg, param, 1);
+  Expression loss = zeroes(cg, { 1 });
+
+  cg.incremental_forward(loss);
+  cg.backward(loss);
+  dynet::autobatch_flag = autobatch_cache;
+}
+
+BOOST_AUTO_TEST_CASE( multi_lstm ) {
+  vector<vector<float>> results(4);
+  dynet::ParameterCollection mod;
+  dynet::VanillaLSTMBuilder lstm_proto(2, 3, 10, mod);
+  dynet::LookupParameter lp_proto = mod.add_lookup_parameters(10, {3});
+  dynet::autobatch_flag = 0;
+  
+  vector<thread> threads(4);
+  for (size_t t = 0; t < 4; ++t) {
+    threads[t] = thread([&, t]() {
+      dynet::ComputationGraph cg;
+      dynet::VanillaLSTMBuilder lstm(lstm_proto);
+      dynet::LookupParameter lp(lp_proto);
+      lstm.new_graph(cg);
+        
+      vector<Expression> losses;
+      for(size_t j = 0; j < 3; ++j) {
+        lstm.start_new_sequence();
+        for(size_t k = 0; k < 3; ++k) {
+          Expression x = dynet::lookup(cg, lp, j*3 + k);
+          lstm.add_input(x);
+        }
+        losses.push_back(squared_norm(lstm.final_h()[1]));
+      }
+      losses.push_back(losses[0] + losses[2]);
+      Expression z = dynet::sum(losses);
+      results[t].push_back(as_scalar(z.value()));
+    });
+  }
+
+  for (size_t t = 0; t < 4; ++t) { threads[t].join(); }
+  for (size_t t = 0; t < 4; ++t) {
+    for(size_t i = 1; i < results[t].size(); ++i) {
+      BOOST_CHECK_CLOSE(results[t][0], results[t][i], 0.0001);
+    }
+  }
+}
+
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This PR includes changes to (optionally) enable threadsafe operation of dynet, providing the ability to run multiple dynet models within a single application, or executing a single dynet model over multiple data instances (computation graphs) concurrently.

This includes:

- Disabling the restriction that one CG should exist at a time, and disabling the notion of staleness
- Switching to a dynamic memory pool for memory allocation for tensors to avoid race conditions when managing memory for tensors / CGs from different threads.

Multithread data parallelism without copying a single model in memory works as follows:

- Have a single `dynet::ParameterCollection` object shared between threads containing (physical) model parameters
- Have multiple copies of a model object (e.g. `LSTMBuilder`). This copy causes copies of model parameters but that is okay because these are just shells that contain pointers to the same physical storage.
- Each thread runs one copy of these models.

Main motivation was multithreaded inference, but possibly the changes might apply to training-time as well, similar to asynchronous SGD training (which I did not test).

My implementation is limited (and tested on) only the `SimpleExecutionEngine` (so no autobatch) and only for CPU devices.
