### PR TITLE
implement strided_select

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -150,6 +150,8 @@ Expression pickrange(const Expression& x, unsigned v, unsigned u) {
   return Expression(x.pg, x.pg->add_function<PickRange>({x.i}, v, u, 0));
 }
 
+Expression strided_select(const Expression& x, const std::vector<int>& strides, const std::vector<int>& range_from, const std::vector<int>& range_to) { return Expression(x.pg, x.pg->add_function<StridedSelect>({x.i}, strides, range_from, range_to)); }
+
 Expression pickneglogsoftmax(const Expression& x, unsigned v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v)); }
 Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> & v) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, v)); }
 Expression pickneglogsoftmax(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv)); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1867,6 +1867,21 @@ inline Expression concatenate_to_batch(const T& xs) { return detail::f<Concatena
 
 /**
  * \ingroup flowoperations
+ * \brief Strided select in multiple dimensions
+ * \details Select a range and/or stride of elements from an expression.
+ *
+ * \param x The input expression
+ * \param strides List of strides for each dimension, must be >= 1. Dimensions not included default to 1. Batch dimension can be included as very last dimension.
+ * \param from    List of 0-based offsets (inclusive) for each dimension, must be >= 0. Dimensions not included default to 0. Batch dimension can be included as very last dimension.
+ * \param to      List of highest 0-based index to select (exclusive) for each dimension, must be >= 0. Dimensions not included default to the corresponding dim size. Batch dimension can be included as very last dimension.
+ *
+ * \return The value of x[from[0]:to[0]:strides[0],..] (as it would be in numpy syntax)
+ */
+Expression strided_select(const Expression& x, const std::vector<int>& strides, const std::vector<int>& from = {}, const std::vector<int>& to = {});
+
+
+/**
+ * \ingroup flowoperations
  * \brief Concatenate columns
  * \details Perform a concatenation of the columns in multiple expressions.
  *          All expressions must have the same number of rows.

--- a/dynet/nodes-select.cc
+++ b/dynet/nodes-select.cc
@@ -409,7 +409,7 @@ template<class MyDevice>
 void StridedSelect::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
   Eigen::array<int, 5> offsets = {0, 0, 0, 0, 0};
   Eigen::array<int, 5> extents = {(int)(xs[0]->d[0]), (int)(xs[0]->d.nd < 2 ? 1 : xs[0]->d[1]), (int)(xs[0]->d.nd < 3 ? 1 : xs[0]->d[2]), (int)(xs[0]->d.nd < 4 ? 1 : xs[0]->d[3]), (int)(xs[0]->d.bd)};
-  Eigen::array<int, 5> strides_arr({1,1,1,1,1});
+  Eigen::array<int, 5> strides_arr = {1,1,1,1,1};
   for(unsigned d=0; d<max(strides.size(), max(to.size(),from.size())); d++){
     offsets[d<xs[0]->d.nd?d:4] = (d<from.size())?from[d]:0;
     extents[d<xs[0]->d.nd?d:4] = ((d<to.size())?to[d]:(d<xs[0]->d.nd?xs[0]->d[d]:xs[0]->d.bd)) - offsets[d<xs[0]->d.nd?d:4];
@@ -436,7 +436,7 @@ void StridedSelect::backward_dev_impl(const MyDevice & dev,
                                   Tensor& dEdxi) const {
   Eigen::array<int, 5> offsets = {0, 0, 0, 0, 0};
   Eigen::array<int, 5> extents = {(int)(xs[0]->d[0]), (int)(xs[0]->d.nd < 2 ? 1 : xs[0]->d[1]), (int)(xs[0]->d.nd < 3 ? 1 : xs[0]->d[2]), (int)(xs[0]->d.nd < 4 ? 1 : xs[0]->d[3]), (int)(xs[0]->d.bd)};
-  Eigen::array<int, 5> strides_arr({1,1,1,1,1});
+  Eigen::array<int, 5> strides_arr = {1,1,1,1,1};
   for(unsigned d=0; d<max(strides.size(), max(to.size(),from.size())); d++){
     offsets[d<xs[0]->d.nd?d:4] = (d<from.size())?from[d]:0;
     extents[d<xs[0]->d.nd?d:4] = ((d<to.size())?to[d]:(d<xs[0]->d.nd?xs[0]->d[d]:xs[0]->d.bd)) - offsets[d<xs[0]->d.nd?d:4];

--- a/dynet/nodes-select.cc
+++ b/dynet/nodes-select.cc
@@ -332,4 +332,132 @@ void PickBatchElements::backward_dev_impl(const MyDevice & dev,
 }
 DYNET_NODE_INST_DEV_IMPL(PickBatchElements)
 
+
+// ************* StridedSelect *************
+
+#ifndef __CUDACC__
+
+string StridedSelect::as_string(const vector<string>& arg_names) const {
+  ostringstream s;
+  s << "StridedSelect(" << arg_names[0] << ',';
+  s << '[';
+  if (strides.size()) {
+    s << "strides=" << strides[0];
+    for (size_t i = 1; i < strides.size(); ++i)
+      s << ',' << strides[i];
+  }
+  if (from.size()) {
+    s << "from=" << from[0];
+    for (size_t i = 1; i < from.size(); ++i)
+      s << ',' << from[i];
+  }
+  if (to.size()) {
+    s << "to=" << to[0];
+    for (size_t i = 1; i < to.size(); ++i)
+      s << ',' << to[i];
+  }
+  s << "]";
+  s << ")";
+  return s.str();
+}
+
+Dim StridedSelect::dim_forward(const vector<Dim>& xs) const {
+  DYNET_ARG_CHECK(xs.size() == 1, "Failed input count check in StridedSelect")
+  DYNET_ARG_CHECK(xs[0].nd < 5, "StridedSelect not currently supported for tensors of 5 or more dimensions.");
+  DYNET_ARG_CHECK(strides.size() <= xs[0].nd+1, "StridedSelect: number of strides must be less than or equal to number of dimension in input");
+  DYNET_ARG_CHECK(from.size() <= xs[0].nd+1, "StridedSelect: from.size() must be less than or equal to number of dimension in input");
+  DYNET_ARG_CHECK(to.size() <= xs[0].nd+1, "StridedSelect: to.size() must be less than or equal to number of dimension in input");
+  Dim ret(xs[0]);
+  for(unsigned d=0; d<strides.size(); d++){
+    DYNET_ARG_CHECK(strides[d] > 0, "require stride > 0, was " << strides[d]);
+  }
+  for(unsigned d=0; d<from.size(); d++){
+    if(d<xs[0].nd){
+      DYNET_ARG_CHECK(from[d] < xs[0].d[d] && from[d] >= 0, "require 0 <= from < dim_size, was " << from[d]);
+    } else { // batch dim
+      DYNET_ARG_CHECK(from[d] < xs[0].bd && from[d] >= 0, "require 0 <= from < batch_size, was " << from[d]);
+    }
+  }
+  for(unsigned d=0; d<to.size(); d++){
+    if(d<xs[0].nd){
+      DYNET_ARG_CHECK(to[d] <= xs[0].d[d] && to[d] > 0, "require 0 < to <= dim_size, was " << to[d]);
+    } else { // batch dim
+      DYNET_ARG_CHECK(to[d] <= xs[0].bd && to[d] > 0, "require 0 < to <= batch_size, was " << to[d]);
+    }
+  }
+  for(unsigned d=0; d<max(strides.size(), max(to.size(), from.size())); d++){
+    unsigned from_d = 0; if(d<from.size()) from_d = from[d];
+    unsigned to_d;
+    if(d<to.size()) to_d = to[d];
+    else if(d<xs[0].nd) to_d = ret.d[d];
+    else to_d = ret.bd;
+    unsigned stride_d = 1; if(d<strides.size()) stride_d = strides[d];
+
+    unsigned dim_size = ceil((float)(to_d - from_d) / (float)stride_d);
+    if(d<xs[0].nd){
+      ret.d[d] = dim_size;
+    } else { // batch dim
+      ret.bd = dim_size;
+    }
+  }
+  return ret;
+}
+
+#endif
+
+template<class MyDevice>
+void StridedSelect::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>& xs, Tensor& fx) const {
+  Eigen::array<int, 5> offsets = {0, 0, 0, 0, 0};
+  Eigen::array<int, 5> extents = {(int)(xs[0]->d[0]), (int)(xs[0]->d.nd < 2 ? 1 : xs[0]->d[1]), (int)(xs[0]->d.nd < 3 ? 1 : xs[0]->d[2]), (int)(xs[0]->d.nd < 4 ? 1 : xs[0]->d[3]), (int)(xs[0]->d.bd)};
+  Eigen::array<int, 5> strides_arr({1,1,1,1,1});
+  for(unsigned d=0; d<max(strides.size(), max(to.size(),from.size())); d++){
+    offsets[d<xs[0]->d.nd?d:4] = (d<from.size())?from[d]:0;
+    extents[d<xs[0]->d.nd?d:4] = ((d<to.size())?to[d]:(d<xs[0]->d.nd?xs[0]->d[d]:xs[0]->d.bd)) - offsets[d<xs[0]->d.nd?d:4];
+    strides_arr[d<xs[0]->d.nd?d:4] = (d<strides.size())?strides[d]:1;
+  }
+
+  // this is a workaround using aux memory, since slice and stride operators don't seem to be chainable
+  AlignedMemoryPool* scratch_allocator = fx.device->pools[(int)DeviceMempool::SCS];
+  Tensor tmp_tensor(Dim({(unsigned)extents[0],(unsigned)extents[1],(unsigned)extents[2],(unsigned)extents[3]},(unsigned)extents[4]), nullptr, fx.device, fx.mem_pool);
+  tmp_tensor.v = static_cast<float*>(scratch_allocator->allocate(tmp_tensor.d.size() * sizeof(float)));
+
+  tmp_tensor.tb<4>().device(*dev.edevice) = xs[0]->tb<4>().slice(offsets, extents);
+  fx.tb<4>().device(*dev.edevice) = tmp_tensor.tb<4>().stride(strides_arr);
+
+  scratch_allocator->free();
+}
+
+template<class MyDevice>
+void StridedSelect::backward_dev_impl(const MyDevice & dev,
+                                  const vector<const Tensor*>& xs,
+                                  const Tensor& fx,
+                                  const Tensor& dEdf,
+                                  unsigned i,
+                                  Tensor& dEdxi) const {
+  Eigen::array<int, 5> offsets = {0, 0, 0, 0, 0};
+  Eigen::array<int, 5> extents = {(int)(xs[0]->d[0]), (int)(xs[0]->d.nd < 2 ? 1 : xs[0]->d[1]), (int)(xs[0]->d.nd < 3 ? 1 : xs[0]->d[2]), (int)(xs[0]->d.nd < 4 ? 1 : xs[0]->d[3]), (int)(xs[0]->d.bd)};
+  Eigen::array<int, 5> strides_arr({1,1,1,1,1});
+  for(unsigned d=0; d<max(strides.size(), max(to.size(),from.size())); d++){
+    offsets[d<xs[0]->d.nd?d:4] = (d<from.size())?from[d]:0;
+    extents[d<xs[0]->d.nd?d:4] = ((d<to.size())?to[d]:(d<xs[0]->d.nd?xs[0]->d[d]:xs[0]->d.bd)) - offsets[d<xs[0]->d.nd?d:4];
+    strides_arr[d<xs[0]->d.nd?d:4] = (d<strides.size())?strides[d]:1;
+  }
+
+  // same workaround as in forward pass
+  AlignedMemoryPool* scratch_allocator = fx.device->pools[(int)DeviceMempool::SCS];
+  Tensor tmp_tensor(Dim({(unsigned)extents[0],(unsigned)extents[1],(unsigned)extents[2],(unsigned)extents[3]},(unsigned)extents[4]), nullptr, fx.device, fx.mem_pool);
+  tmp_tensor.v = static_cast<float*>(scratch_allocator->allocate(tmp_tensor.d.size() * sizeof(float)));
+  TensorTools::zero(tmp_tensor);
+
+  tmp_tensor.tb<4>().stride(strides_arr).device(*dev.edevice) = dEdf.tb<4>();
+
+  dEdxi.tb<4>().slice(offsets, extents).device(*dev.edevice) += tmp_tensor.tb<4>();
+
+  scratch_allocator->free();
+}
+DYNET_NODE_INST_DEV_IMPL(StridedSelect)
+
+
+
+
 }

--- a/dynet/nodes-select.h
+++ b/dynet/nodes-select.h
@@ -78,6 +78,15 @@ struct PickBatchElements : public Node {
   std::vector<unsigned> vals;
   const std::vector<unsigned>* pvals;
 };
+// x is a batched tensor
+// y = (x)_{[*pval]}
+struct StridedSelect : public Node {
+  explicit StridedSelect(const std::initializer_list<VariableIndex>& a, const std::vector<int>& strides,
+                         const std::vector<int>& from, const std::vector<int>& to) : Node(a), strides(strides), from(from), to(to) {}
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
+  const std::vector<int> strides, from, to;
+};
 
 } // namespace dynet
 

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -380,6 +380,8 @@ cdef extern from "dynet/expr.h" namespace "dynet":
 
     CExpression c_pick_batch_elems "dynet::pick_batch_elems" (CExpression& x, vector[unsigned] vs) except + #
     CExpression c_pick_batch_elem "dynet::pick_batch_elem" (CExpression& x, unsigned v) except + #
+    CExpression c_strided_select "dynet::strided_select" (CExpression& x, vector[int] strides, vector[int] range_from, vector[int] range_to) except +
+
     CExpression c_pickneglogsoftmax "dynet::pickneglogsoftmax" (CExpression& x, unsigned v) except + #
     CExpression c_pickneglogsoftmax "dynet::pickneglogsoftmax" (CExpression& x, vector[unsigned] vs) except + #
 

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3620,6 +3620,23 @@ cpdef Expression pick_batch_elems(Expression x, vector[unsigned] vs):
         dynet.Expression: The expression of picked batch elements. The batch elements is a tensor whose batch dimension equals to the size of list `v`.
     """
     return Expression.from_cexpr(x.cg_version, c_pick_batch_elems(x.c(), vs))
+
+cpdef Expression strided_select(Expression x, vector[int] strides, vector[int] range_from, vector[int] range_to):
+    """Strided select in multiple dimensions.
+    
+    Select a range and/or stride of elements from an expression.
+
+    Args:
+        x (dynet.Expression): Input expression
+        strides (list): List of strides for each dimension, must be >= 1. Dimensions not included default to 1. Batch dimension can be included as very last dimension.
+        range_from (list):    List of 0-based offsets (inclusive) for each dimension, must be >= 0. Dimensions not included default to 0. Batch dimension can be included as very last dimension.
+        range_to (list):      List of highest 0-based index to select (exclusive) for each dimension, must be >= 0. Dimensions not included default to the corresponding dim size. Batch dimension can be included as very last dimension.
+            
+    Returns:
+        dynet.Expression: The value of x[from[0]:to[0]:strides[0],..] (as it would be in numpy syntax)
+    """
+    return Expression.from_cexpr(x.cg_version, c_strided_select(x.c(), strides, range_from, range_to))
+
 #expr-float
 cpdef Expression noise(Expression x, float stddev):
     """Additive gaussian noise

--- a/tests/test-nodes.cc
+++ b/tests/test-nodes.cc
@@ -1814,6 +1814,93 @@ BOOST_AUTO_TEST_CASE( pickneglogsoftmax_batch_gradient ) {
   BOOST_CHECK(check_grad(mod, z, 0));
 }
 
+// Expression strided_select(const Expression& x, vector<unsigned>& indices);
+BOOST_AUTO_TEST_CASE( strided_select_gradient_noop ) {
+  dynet::ComputationGraph cg;
+  const vector<int> strides = {};
+  Expression x1 = parameter(cg, param_square1);
+  Expression y = strided_select(x1, strides);
+  Expression z = sum_elems(y);
+  BOOST_CHECK(check_grad(mod, z, 0));
+  BOOST_CHECK(x1.dim().size() == y.dim().size());
+}
+
+// Expression strided_select(const Expression& x, vector<unsigned>& indices);
+BOOST_AUTO_TEST_CASE( strided_select_gradient ) {
+  dynet::ComputationGraph cg;
+  for(int stride=1;stride<4;stride++){
+    const vector<int> strides = {stride,stride,stride};
+    Expression x1 = parameter(cg, param_cube1);
+    Expression y3 = strided_select(x1, strides);
+    Expression z = sum_elems(y3);
+    BOOST_CHECK(check_grad(mod, z, 0));
+  }
+}
+// Expression strided_select(const Expression& x, vector<unsigned>& indices);
+BOOST_AUTO_TEST_CASE( strided_select_gradient2 ) {
+  dynet::ComputationGraph cg;
+  for(int from=0;from<2;from++){
+    for(int to=from+1;to<4;to++){
+      for(int stride=1;stride<4;stride++){
+        const vector<int> strides = {stride,stride,stride};
+        const vector<int> to_range = {to,to,to};
+        const vector<int> from_range = {from,from,from};
+        Expression x1 = parameter(cg, param_cube1);
+        Expression y = strided_select(x1, strides, from_range, to_range);
+        Expression z = sum_elems(y);
+        BOOST_CHECK(check_grad(mod, z, 0));
+      }
+    }
+  }
+}
+// Expression strided_select(const Expression& x, vector<unsigned>& indices);
+BOOST_AUTO_TEST_CASE( strided_select_gradient3 ) {
+  dynet::ComputationGraph cg;
+  for(int from=0;from<2;from++){
+    for(int stride=1;stride<4;stride++){
+      const vector<int> strides = {stride,stride,stride};
+      const vector<int> from_range = {from,from,from};
+      Expression x1 = parameter(cg, param_cube1);
+      Expression y2 = strided_select(x1, strides, from_range);
+      Expression z = sum_elems(y2);
+      BOOST_CHECK(check_grad(mod, z, 0));
+    }
+  }
+}
+// Expression strided_select(const Expression& x, vector<unsigned>& indices);
+BOOST_AUTO_TEST_CASE( strided_select_gradient4 ) {
+  dynet::ComputationGraph cg;
+  for(int from=0;from<2;from++){
+    for(int to=from+1;to<4;to++){
+      for(int stride=1;stride<4;stride++){
+        const vector<int> strides = {stride,1,stride,stride};
+        const vector<int> from_range = {from,0,from,from};
+        const vector<int> to_range = {to,1,to,to};
+        Expression x1 = reshape(parameter(cg, param_cube1), Dim({3,1,3},3));
+        Expression y = strided_select(x1, strides, from_range, to_range);
+        Expression z = sum_batches(sum_elems(y));
+        BOOST_CHECK(check_grad(mod, z, 0));
+      }
+    }
+  }
+}
+// Expression strided_select(const Expression& x, vector<unsigned>& indices);
+BOOST_AUTO_TEST_CASE( strided_select_gradient5 ) {
+  dynet::ComputationGraph cg;
+  for(int from=0;from<2;from++){
+    for(int to=from+1;to<4;to++){
+      for(int stride=1;stride<4;stride++){
+        const vector<int> strides = {stride,stride};
+        const vector<int> from_range = {from,from};
+        const vector<int> to_range = {to,to};
+        Expression x1 = reshape(parameter(cg, param_cube1), Dim({3,3,3,1},1));
+        Expression y = strided_select(x1, strides, from_range, to_range);
+        Expression z = sum_batches(sum_elems(y));
+        BOOST_CHECK(check_grad(mod, z, 0));
+      }
+    }
+  }
+}
 
 // Expression sum_elems(x);
 BOOST_AUTO_TEST_CASE( sum_elems_gradient ) {


### PR DESCRIPTION
This implements a striding operator, including specification of offset / range. It can be used as dy.strided_select(strides, offsets, to) and works over multiple dimensions (including batch dimension) at once. I tried to follow numpy selector conventions, although this is not as powerful, e.g. no negative indices or strides are supported. It could be extended toward #758 in the future.