### PR TITLE
After deployment, test pip installation from PyPI works

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ env:
 branches:
   only:
     - master
+stages:
+  - test
+  - name: test_pip
+    if: repo = clab/dynet AND tag IS present
 jobs:
   include:
     - os: osx
@@ -117,6 +121,43 @@ jobs:
       compiler: gcc
       language: cpp
       env: PYVER=3.6 PYNUM=3 PYTHON_INSTALL=manual BACKEND=cuda
+    - stage: test_pip
+      os: osx
+      env: PYVER=2.7 PYNUM=2
+      before_script: pip install dynet
+      script: python tests/python/test.py
+    - os: osx
+      env: PYVER=3.4 PYNUM=3
+      before_script: pip install dynet
+      script: python tests/python/test.py
+    - os: osx
+      env: PYVER=3.5 PYNUM=3
+      before_script: pip install dynet
+      script: python tests/python/test.py
+    - os: osx
+      env: PYVER=3.6 PYNUM=3
+      before_script: pip install dynet
+      script: python tests/python/test.py
+    - os: linux
+      language: python
+      python: 2.7
+      before_script: pip install dynet
+      script: python tests/python/test.py
+    - os: linux
+      language: python
+      python: 3.4
+      before_script: pip install dynet
+      script: python tests/python/test.py
+    - os: linux
+      language: python
+      python: 3.5
+      before_script: pip install dynet
+      script: python tests/python/test.py
+    - os: linux
+      language: python
+      python: 3.6
+      before_script: pip install dynet
+      script: python tests/python/test.py
 
 install:
   - travis_retry .travis/install_dependencies.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,32 +19,32 @@ jobs:
       compiler: clang
       language: cpp
       env: PYVER=2.7 PYNUM=2 PYTHON_INSTALL=manual
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: osx
       compiler: clang
       language: cpp
       env: PYVER=2.7 PYNUM=2 PYTHON_INSTALL=pip BUILD_ARCH=x86_64
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: osx
       compiler: clang
       language: cpp
       env: PYVER=3.4 PYNUM=3 PYTHON_INSTALL=manual
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: osx
       compiler: clang
       language: cpp
       env: PYVER=3.4 PYNUM=3 PYTHON_INSTALL=pip BUILD_ARCH=x86_64
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: osx
       compiler: clang
       language: cpp
       env: PYVER=3.5 PYNUM=3 PYTHON_INSTALL=manual
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: osx
       compiler: clang
       language: cpp
       env: PYVER=3.5 PYNUM=3 PYTHON_INSTALL=pip BUILD_ARCH=x86_64
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: osx
       compiler: clang
       language: cpp
@@ -62,7 +62,7 @@ jobs:
       language: python
       python: 2.7
       env: PYVER=2.7 PYNUM=2 PYTHON_INSTALL=pip BUILD_ARCH=i686
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: linux
       compiler: gcc
       language: python
@@ -72,36 +72,36 @@ jobs:
       compiler: gcc
       language: cpp
       env: PYVER=3.4 PYNUM=3 PYTHON_INSTALL=manual
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: linux
       compiler: gcc
       language: python
       python: 3.4
       env: PYVER=3.4 PYNUM=3 PYTHON_INSTALL=pip BUILD_ARCH=i686
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: linux
       compiler: gcc
       language: python
       python: 3.4
       env: PYVER=3.4 PYNUM=3 PYTHON_INSTALL=pip BUILD_ARCH=x86_64
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: linux
       compiler: gcc
       language: cpp
       env: PYVER=3.5 PYNUM=3 PYTHON_INSTALL=manual
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: linux
       compiler: gcc
       language: python
       python: 3.5
       env: PYVER=3.5 PYNUM=3 PYTHON_INSTALL=pip BUILD_ARCH=i686
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: linux
       compiler: gcc
       language: python
       python: 3.5
       env: PYVER=3.5 PYNUM=3 PYTHON_INSTALL=pip BUILD_ARCH=x86_64
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: linux
       compiler: gcc
       language: cpp
@@ -111,7 +111,7 @@ jobs:
       language: python
       python: 3.6
       env: PYVER=3.6 PYNUM=3 PYTHON_INSTALL=pip BUILD_ARCH=i686
-      if: type = cron
+      if: type = cron OR tag IS present
     - os: linux
       compiler: gcc
       language: python


### PR DESCRIPTION
Deployment to PyPI is done on tag creation. Adding a build stage (new Travis feature) to test the deployed wheels work in a fresh environment, to verify there is no dependence on any remaining build outputs.