### PR TITLE
profile fwd/bwd runtimes and memory

### DIFF
--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -1143,7 +1143,7 @@ struct DynetParams {
   std::string mem_descriptor = "512"; /**< Total memory to be allocated for Dynet */
   float weight_decay = 0; /**< Weight decay rate for L2 regularization */
   int autobatch = 0; /**< Whether to autobatch or not */
-  int autobatch_debug = 0; /**< Whether to show autobatch debug info or not */
+  int profiling = 0; /**< Whether to show profiling info or not */
   bool shared_parameters = false; /**< TO DOCUMENT */
 
 #ifdef SWIG_USE_CUDA

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Initialize.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Initialize.scala
@@ -28,8 +28,8 @@ object Initialize {
     args.get("autobatch")
         .foreach(arg => params.setAutobatch(arg.asInstanceOf[Int]))
 
-    args.get("autobatch_debug")
-        .foreach(arg => params.setAutobatch_debug(arg.asInstanceOf[Int]))
+    args.get("profiling")
+        .foreach(arg => params.setProfiling(arg.asInstanceOf[Int]))
 
     initialize(params)
   }

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -1,3 +1,5 @@
+#include <iomanip>
+
 #include "dynet/dynet.h"
 
 #include "dynet/exec.h"
@@ -405,8 +407,8 @@ void ComputationGraph::print_graphviz() const {
          << node->as_string(var_names);
     if (profiling_flag){
       cerr << " (MEM: ";
-      cerr << (node->aux_storage_size() + 2*node->dim.size()) * sizeof(real) / 1000.0;
-      cerr << " kB)";
+      cerr << std::setprecision(4) << std::setw(11) << (node->aux_storage_size() + 2*node->dim.size()) * sizeof(real) / 1024.0;
+      cerr << " KiB)";
     }
     cerr << "\"];\n";
     for (auto arg : node->args)
@@ -417,17 +419,19 @@ void ComputationGraph::print_graphviz() const {
 
   if(profiling_flag>1){
     cerr << "\nNodes sorted by memory consumption:\n";
-    // print nodes, sorted by memory consumption
     std::map<string,int> nodes_map;
+    unsigned total_memory = 0;
     for (auto node : nodes) {
       vector<string> var_names;
       for (auto arg : node->args)
         var_names.push_back(string("v") + to_string((unsigned)arg));
-      nodes_map[node->as_string(var_names)] = (node->aux_storage_size() + 2*node->dim.size()) * sizeof(real);
+      unsigned mem = (node->aux_storage_size() + 2*node->dim.size()) * sizeof(real);
+      nodes_map[node->as_string(var_names)] = mem;
+      total_memory += mem;
     }
     std::multimap<int,string> nodes_map_dst = flip_map(nodes_map);
     for (auto &item : nodes_map_dst) {
-      std::cerr << (item.first/1000.0) << " kB\t" << item.second << std::endl;
+      std::cerr << std::setprecision(4) << std::setw(11) << (item.first/1024.0) << " KiB\t" << (100.0*item.first/total_memory) << "%\t" << item.second << std::endl;
     }
   }
 }

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -418,15 +418,12 @@ void ComputationGraph::print_graphviz() const {
   cerr << "}\n";
 
   if(profiling_flag>1){
-    cerr << "\nNodes sorted by memory consumption:\n";
+    cerr << "\nAggregated nodes, sorted by memory consumption:\n";
     std::map<string,unsigned> nodes_map;
     double total_memory = 0;
     for (auto node : nodes) {
-      vector<string> var_names;
-      for (auto arg : node->args)
-        var_names.push_back(string("v") + to_string((unsigned)arg));
       unsigned mem = (node->aux_storage_size() + 2*node->dim.size()) * sizeof(real);
-      nodes_map[node->as_string(var_names)] = mem;
+      nodes_map[node->as_dummy_string()] = mem;
       total_memory += mem;
     }
     std::multimap<unsigned,string> nodes_map_dst = flip_map(nodes_map);

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -402,7 +402,7 @@ void ComputationGraph::print_graphviz() const {
          << node->as_string(var_names);
     if (profiling_flag){
       cerr << " (MEM: ";
-      cerr << (node->aux_storage_size() + node->dim.size()) * sizeof(real) / 1000.0;
+      cerr << (node->aux_storage_size() + 2*node->dim.size()) * sizeof(real) / 1000.0;
       cerr << " kB)";
     }
     cerr << "\"];\n";

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -399,7 +399,13 @@ void ComputationGraph::print_graphviz() const {
     for (auto arg : node->args)
       var_names.push_back(string("v") + to_string((unsigned)arg));
     cerr << "  N" << nc << " [label=\"v" << nc << " = "
-         << node->as_string(var_names) << "\"];\n";
+         << node->as_string(var_names);
+    if (profiling_flag){
+      cerr << " (MEM: ";
+      cerr << (node->aux_storage_size() + node->dim.size()) * sizeof(real) / 1000.0;
+      cerr << " kB)";
+    }
+    cerr << "\"];\n";
     for (auto arg : node->args)
       cerr << "  N" << ((unsigned)arg) << " -> N" << nc << ";\n";
     ++nc;

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -419,16 +419,21 @@ void ComputationGraph::print_graphviz() const {
 
   if(profiling_flag>1){
     cerr << "\nAggregated nodes, sorted by memory consumption:\n";
-    std::map<string,unsigned> nodes_map;
+    std::map<string,unsigned> nodes_map, count_map;
     double total_memory = 0;
     for (auto node : nodes) {
       unsigned mem = (node->aux_storage_size() + 2*node->dim.size()) * sizeof(real);
-      nodes_map[node->as_dummy_string()] = mem;
+      if(nodes_map.count(node->as_dummy_string()) == 0){
+        nodes_map[node->as_dummy_string()] = 0;
+        count_map[node->as_dummy_string()] = 0;
+      }
+      nodes_map[node->as_dummy_string()] += mem;
+      count_map[node->as_dummy_string()] += 1;
       total_memory += mem;
     }
     std::multimap<unsigned,string> nodes_map_dst = flip_map(nodes_map);
     for (auto &item : nodes_map_dst) {
-      std::cerr << std::setprecision(4) << std::setw(11) << (item.first/1024.0) << " KiB\t" << (100.0*(double)item.first/total_memory) << "%\t" << item.second << std::endl;
+      std::cerr << std::setprecision(4) << std::setw(11) << (item.first/1024.0) << " KiB\t" << (100.0*(double)item.first/total_memory) << "%\t" << "called " << count_map[item.second] << "x\t" << item.second << std::endl;
     }
     std::cerr << std::setprecision(4) << std::setw(11) << (total_memory/1024.0) << " KiB\t100%\t(total)" << std::endl;
   }

--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -419,8 +419,8 @@ void ComputationGraph::print_graphviz() const {
 
   if(profiling_flag>1){
     cerr << "\nNodes sorted by memory consumption:\n";
-    std::map<string,int> nodes_map;
-    unsigned total_memory = 0;
+    std::map<string,unsigned> nodes_map;
+    double total_memory = 0;
     for (auto node : nodes) {
       vector<string> var_names;
       for (auto arg : node->args)
@@ -429,10 +429,11 @@ void ComputationGraph::print_graphviz() const {
       nodes_map[node->as_string(var_names)] = mem;
       total_memory += mem;
     }
-    std::multimap<int,string> nodes_map_dst = flip_map(nodes_map);
+    std::multimap<unsigned,string> nodes_map_dst = flip_map(nodes_map);
     for (auto &item : nodes_map_dst) {
-      std::cerr << std::setprecision(4) << std::setw(11) << (item.first/1024.0) << " KiB\t" << (100.0*item.first/total_memory) << "%\t" << item.second << std::endl;
+      std::cerr << std::setprecision(4) << std::setw(11) << (item.first/1024.0) << " KiB\t" << (100.0*(double)item.first/total_memory) << "%\t" << item.second << std::endl;
     }
+    std::cerr << std::setprecision(4) << std::setw(11) << (total_memory/1024.0) << " KiB\t100%\t(total)" << std::endl;
   }
 }
 

--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -94,8 +94,8 @@ const Tensor& SimpleExecutionEngine::incremental_forward(VariableIndex i) {
 
     for (; num_nodes_evaluated <= i; ++num_nodes_evaluated) {
       const Node* node = cg.nodes[num_nodes_evaluated];
-      if (autobatch_debug_flag) {
-        current_node_name = node->as_dummy_string();
+      if (profiling_flag) {
+        current_node_name = "fwd " + node->as_dummy_string();
         timer.start(current_node_name);
       }
       xs.resize(node->arity());
@@ -138,7 +138,7 @@ const Tensor& SimpleExecutionEngine::incremental_forward(VariableIndex i) {
       // Compute f(xs) and store to node_fx.
       node->forward(xs, node_fx);
 
-      if (autobatch_debug_flag) { timer.stop(current_node_name); }
+      if (profiling_flag) { timer.stop(current_node_name); }
     }
   }
 
@@ -214,9 +214,14 @@ void SimpleExecutionEngine::backward(VariableIndex from_where, bool full) {
   vector<bool> in_computation(num_nodes, false);
   in_computation[num_nodes - 1] = true;
   vector<const Tensor*> xs(16);
+  string current_node_name;  // Optionally used for debugging (reused).
   for (int i = num_nodes - 1; i >= 0; --i) {
     if (!in_computation[i]) continue;
     const Node* node = cg.nodes[i];
+    if (profiling_flag) {
+      current_node_name = "BWD " + node->as_dummy_string();
+      timer.start(current_node_name);
+    }
     const auto& node_fx = nfxs[i];  // f(x_1, x_2, ..., x_arity), which
                                     // was previously computed by forward.
     const auto& node_dEdfx = ndEdfs[i];  // dE/df(x_1, x_2, ..., x_arity)
@@ -239,6 +244,7 @@ void SimpleExecutionEngine::backward(VariableIndex from_where, bool full) {
       }
       ++ai;
     }
+    if (profiling_flag) { timer.stop(current_node_name); }
   }
 
   // Accumulate gradients into parameters.
@@ -678,7 +684,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(
     }
 
     // 2.5 print some debug info
-    if (autobatch_debug_flag) {
+    if (profiling_flag) {
       cout << "Forward Call" << endl;
       for(VariableIndex bid = num_batches_evaluated; bid < batch_id; ++bid) {
         auto & batch_ids = batches[bid].ids;
@@ -775,7 +781,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(
     while(num_batches_evaluated < batch_id) {
       // Read in the stuff for this batch
       auto & my_batch = batches[num_batches_evaluated];
-      if (autobatch_debug_flag) {
+      if (profiling_flag) {
         VariableIndex nid = my_batch.ids[0];
         Node* node = cg.nodes[nid];
         current_batch_name = node->as_dummy_string();
@@ -845,7 +851,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(
         // cerr << "batched forward[" << num_batches_evaluated << "] (nodes:"; for(auto id : my_batch.ids) cerr << ' ' << id; cerr << ") == " << print_vec(as_vector(my_batch.nfx)) << endl;
         ++num_batches_evaluated;
       } // execute a batch node (not a single instance node)
-      if (autobatch_debug_flag) { timer.stop(current_batch_name); }
+      if (profiling_flag) { timer.stop(current_batch_name); }
     }
 
     free(node2profid);

--- a/dynet/globals.cc
+++ b/dynet/globals.cc
@@ -8,7 +8,7 @@ std::mt19937* rndeng = nullptr;
 Device* default_device = nullptr;
 float weight_decay_lambda;
 int autobatch_flag; 
-int autobatch_debug_flag = 0;
+int profiling_flag = 0;
 NamedTimer timer;
 
 }

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -94,8 +94,9 @@ DynetParams extract_dynet_params(int& argc, char**& argv, bool shared_parameters
       }
     }
     else if (arg == "--dynet-profiling" || arg == "--dynet_profiling") {
-      params.profiling = 1;
-        remove_args(argc, argv, argi, 1);
+      string a2 = argv[argi + 1];
+      istringstream c(a2); c >> params.profiling;
+      remove_args(argc, argv, argi, 1);
     }
 
 #if HAVE_CUDA

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -18,7 +18,7 @@ using namespace std;
 
 namespace dynet {
 
-DynetParams::DynetParams() : random_seed(0), mem_descriptor("512"), weight_decay(0), autobatch(0), autobatch_debug(0),
+DynetParams::DynetParams() : random_seed(0), mem_descriptor("512"), weight_decay(0), autobatch(0), profiling(0),
   shared_parameters(false), ngpus_requested(false), ids_requested(false), cpu_requested(false), requested_gpus(-1)
 {
 #if HAVE_CUDA
@@ -93,8 +93,8 @@ DynetParams extract_dynet_params(int& argc, char**& argv, bool shared_parameters
         remove_args(argc, argv, argi, 2);
       }
     }
-    else if (arg == "--dynet-autobatch-debug" || arg == "--dynet_autobatch_debug") {
-      params.autobatch_debug = 1;
+    else if (arg == "--dynet-profiling" || arg == "--dynet_profiling") {
+      params.profiling = 1;
         remove_args(argc, argv, argi, 1);
     }
 
@@ -200,9 +200,9 @@ void initialize(DynetParams& params) {
     cerr << "[dynet] using autobatching" << endl;
   autobatch_flag = params.autobatch;
   
-  if(params.autobatch_debug)
-    cerr << "[dynet] using autobatching debugging" << endl;
-  autobatch_debug_flag = params.autobatch_debug;
+  if(params.profiling)
+    cerr << "[dynet] using profiling level " << params.profiling << endl;
+  profiling_flag = params.profiling;
 
   // Allocate memory
   cerr << "[dynet] allocating memory: " << params.mem_descriptor << "MB\n";

--- a/dynet/init.h
+++ b/dynet/init.h
@@ -8,7 +8,7 @@ namespace dynet {
 
 extern float weight_decay_lambda;
 extern int autobatch_flag;
-extern int autobatch_debug_flag;
+extern int profiling_flag;
 
 /**
  * \brief Represents general parameters for dynet
@@ -21,7 +21,7 @@ struct DynetParams {
   std::string mem_descriptor; /**< Total memory to be allocated for Dynet */
   float weight_decay; /**< Weight decay rate for L2 regularization */
   int autobatch; /**< Whether to autobatch or not */
-  int autobatch_debug; /**< Whether to show autobatch debug info or not */
+  int profiling; /**< Whether to show autobatch debug info or not */
   bool shared_parameters; /**< TO DOCUMENT */
   bool ngpus_requested; /**< GPUs requested by number */
   bool ids_requested; /**< GPUs requested by ids */

--- a/dynet/timing.h
+++ b/dynet/timing.h
@@ -7,6 +7,10 @@
 #include <iomanip>
 #include <map>
 
+// for sorting timer output
+template<typename A, typename B> std::pair<B,A> flip_pair(const std::pair<A,B> &p) { return std::pair<B,A>(p.second, p.first); }
+template<typename A, typename B> std::multimap<B,A> flip_map(const std::map<A,B> &src) { std::multimap<B,A> dst; std::transform(src.begin(), src.end(), std::inserter(dst, dst.begin()),flip_pair<A,B>);return dst;}
+
 namespace dynet {
 
 struct Timer {
@@ -37,9 +41,19 @@ public:
       std::cout << "Timing Info:" << std::endl; show();
     }
   }
-  void start(std::string name) { Timing t; timers[name] = t; }
-  void stop(std::string name) { cumtimes[name] += (timers[name]).stop(); }
-  void show() { for (auto &item : cumtimes) { std::cout << std::setprecision(4) << std::setw(11) << item.second << '\t' << item.first << std::endl; } }
+  void start(std::string name) {
+    Timing t;
+    timers[name] = t;
+  }
+  void stop(std::string name) {
+    cumtimes[name] += (timers[name]).stop();
+  }
+  void show() {
+    std::multimap<double, std::string> cumtimes_dst = flip_map(cumtimes);
+    for (auto &item : cumtimes_dst) {
+      std::cout << std::setprecision(4) << std::setw(11) << item.first << '\t' << item.second << std::endl;
+    }
+  }
   std::map<std::string, double> cumtimes;
   std::map<std::string, Timing> timers;
 };

--- a/dynet/timing.h
+++ b/dynet/timing.h
@@ -58,6 +58,7 @@ public:
     for (auto &item : cumtimes_dst) {
       std::cout << std::setprecision(4) << std::setw(11) << item.first << '\t' << (100.0*item.first/total_time) << "%\t" << item.second << std::endl;
     }
+    std::cout << std::setprecision(4) << std::setw(11) << total_time << "\t100%\t(total time)" << std::endl;
   }
   std::map<std::string, double> cumtimes;
   std::map<std::string, Timing> timers;

--- a/dynet/timing.h
+++ b/dynet/timing.h
@@ -38,7 +38,8 @@ class NamedTimer {
 public:
   ~NamedTimer() { 
     if (timers.size()>0) {
-      std::cout << "Timing Info:" << std::endl; show();
+      std::cout << "Timing Info:" << std::endl;
+      show();
     }
   }
   void start(std::string name) {

--- a/dynet/timing.h
+++ b/dynet/timing.h
@@ -51,8 +51,12 @@ public:
   }
   void show() {
     std::multimap<double, std::string> cumtimes_dst = flip_map(cumtimes);
+    double total_time = 0.0;
     for (auto &item : cumtimes_dst) {
-      std::cout << std::setprecision(4) << std::setw(11) << item.first << '\t' << item.second << std::endl;
+      total_time += item.first;
+    }
+    for (auto &item : cumtimes_dst) {
+      std::cout << std::setprecision(4) << std::setw(11) << item.first << '\t' << (100.0*item.first/total_time) << "%\t" << item.second << std::endl;
     }
   }
   std::map<std::string, double> cumtimes;

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -11,7 +11,7 @@ cdef extern from "dynet/init.h" namespace "dynet":
         string mem_descriptor
         float weight_decay
         int autobatch
-        int autobatch_debug
+        int profiling
         bool shared_parameters
         bool ngpus_requested
         bool ids_requested

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -71,12 +71,12 @@ cdef class DynetParams: # {{{
         """Set parameters from config object:
         
         Attributes of conf object:
-            mem, seed, autobatch, autobatch_debug, weight_decay, shared_params, requested_gpus, gpu_mask
+            mem, seed, autobatch, profiling, weight_decay, shared_params, requested_gpus, gpu_mask
         """
         self.cparams.mem_descriptor = str(conf["mem"]).encode()
         self.cparams.random_seed=conf["seed"]
         self.cparams.autobatch = conf["autobatch"]
-        self.cparams.autobatch_debug = conf["autobatch_debug"]
+        self.cparams.profiling = conf["profiling"]
         self.cparams.weight_decay = conf["weight_decay"]
         self.cparams.shared_parameters = conf["shared_params"]
         if conf["requested_gpus"] >= 1:
@@ -160,16 +160,13 @@ cdef class DynetParams: # {{{
         else:
             self.cparams.autobatch = 0
 
-    cpdef set_autobatch_debug(self, bool autobatch_debug):
+    cpdef set_profiling(self, int profiling):
         """Activate autobatching debug
         
         Args:
-            autobatch(bool): Set to :code:`True` to activate autobatching debug
+            autobatch(int): Set to a value > 0 to activate profiling
         """
-        if autobatch_debug:
-            self.cparams.autobatch_debug = 1
-        else:
-            self.cparams.autobatch_debug = 0
+        self.cparams.profiling = profiling
 
     cpdef set_weight_decay(self, float weight_decay):
         """Set weight decay parameter

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -164,7 +164,7 @@ cdef class DynetParams: # {{{
         """Activate autobatching debug
         
         Args:
-            autobatch(int): Set to a value > 0 to activate profiling
+            profiling(int): Set to a value > 0 to activate profiling
         """
         self.cparams.profiling = profiling
 

--- a/python/dynet_config.py
+++ b/python/dynet_config.py
@@ -1,13 +1,13 @@
 def set(mem="512", random_seed=0, autobatch=0,
-        autobatch_debug=0, weight_decay=0, shared_parameters=0,
+        profiling=0, weight_decay=0, shared_parameters=0,
         requested_gpus=0, gpu_mask=None):
 
     if "__DYNET_CONFIG" in __builtins__:
-        (mem, random_seed, auto_batch, autobatch_debug) = (
+        (mem, random_seed, auto_batch, profiling) = (
             __builtins__["__DYNET_CONFIG"]["mem"] if __builtins__["__DYNET_CONFIG"].get("mem") == mem else mem,
             __builtins__["__DYNET_CONFIG"]["seed"] if __builtins__["__DYNET_CONFIG"].get("seed") == random_seed else random_seed,
             __builtins__["__DYNET_CONFIG"]["autobatch"] if __builtins__["__DYNET_CONFIG"].get("autobatch") == autobatch else autobatch,
-            __builtins__["__DYNET_CONFIG"]["autobatch_debug"] if __builtins__["__DYNET_CONFIG"].get("autobatch_debug") == autobatch_debug else autobatch_debug)
+            __builtins__["__DYNET_CONFIG"]["profiling"] if __builtins__["__DYNET_CONFIG"].get("profiling") == profiling else profiling)
         (weight_decay, shared_parameters, requested_gpus, gpu_mask) = (
             __builtins__["__DYNET_CONFIG"]["weight_decay"] if __builtins__["__DYNET_CONFIG"].get("weight_decay") == weight_decay else weight_decay,
             __builtins__["__DYNET_CONFIG"]["shared_params"] if __builtins__["__DYNET_CONFIG"].get("shared_params") == shared_parameters else shared_parameters,
@@ -17,7 +17,7 @@ def set(mem="512", random_seed=0, autobatch=0,
     # TODO read "gpu_mask" from list of IDs?
     __builtins__["__DYNET_CONFIG"] = {
       "mem":mem, "seed": random_seed, "autobatch": autobatch,
-      "autobatch_debug":autobatch_debug, "weight_decay": weight_decay,
+      "profiling":profiling, "weight_decay": weight_decay,
       "shared_params": shared_parameters,
       "requested_gpus": requested_gpus,
       "gpu_mask": gpu_mask if gpu_mask else list(),


### PR DESCRIPTION
- rename autobatch_debug to profiling
- if set:
  - print fwd / bwd runtimes upon program termination, sorted by runtime
  - using print_graphviz now prints node and auxiliary memory consumption
  - if >=2: print nodes sorted by memory consumption after the graph

related to #498 and #470