### PR TITLE
Make possible to set CUDA compute architecture

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -116,6 +116,10 @@ the same as with the CPU backend case.
 
     -L/path/to/dynet/build/dynet -ldynet
 
+If you know the CUDA architecture supported by your GPU (e.g. by referencing
+`this page <http://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/>`__)
+you can speed compilation significantly by adding ``-DCUDA_ARCH=XXX`` where
+``XXX`` is your architecture number.
 
 cuDNN support
 ~~~~~~~~~~~~~

--- a/doc/source/python.rst
+++ b/doc/source/python.rst
@@ -260,9 +260,14 @@ The installation process is pretty much the same, while adding the
 
     cmake .. -DEIGEN3_INCLUDE_DIR=$PATH_TO_EIGEN -DPYTHON=$PATH_TO_PYTHON -DBACKEND=cuda
 
-(if CUDA is installed in a non-standard location and ``cmake`` cannot
+
+If you know the CUDA architecture supported by your GPU (e.g. by referencing
+`this page <http://arnon.dk/matching-sm-architectures-arch-and-gencode-for-various-nvidia-cards/>`__)
+you can speed compilation significantly by adding ``-DCUDA_ARCH=XXX`` where
+``XXX`` is your architecture number.
+If CUDA is installed in a non-standard location and ``cmake`` cannot
 find it, you can specify also
-``-DCUDA_TOOLKIT_ROOT_DIR=/path/to/cuda``.)
+``-DCUDA_TOOLKIT_ROOT_DIR=/path/to/cuda``.
 
 Now, build the Python modules (as above, we assume Cython is installed):
 

--- a/dynet/CMakeLists.txt
+++ b/dynet/CMakeLists.txt
@@ -244,7 +244,12 @@ if(WITH_CUDA_BACKEND)
 
   # cuda flags
   set(CUDA_SEPARABLE_COMPILATION ON)
-  list(APPEND CUDA_NVCC_FLAGS "-gencode;arch=compute_30,code=sm_30;-gencode;arch=compute_35,code=sm_35;-gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_52,code=sm_52;-gencode;arch=compute_52,code=compute_52;-std=c++11;-DVERBOSE;-DEIGEN_USE_GPU;-DHAVE_CUDA;")
+
+  if(CUDA_ARCH)
+    list(APPEND CUDA_NVCC_FLAGS "-arch=sm_${CUDA_ARCH};-std=c++11;-DVERBOSE;-DEIGEN_USE_GPU;-DHAVE_CUDA;")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode;arch=compute_30,code=sm_30;-gencode;arch=compute_35,code=sm_35;-gencode;arch=compute_37,code=sm_37;-gencode;arch=compute_50,code=sm_50;-gencode;arch=compute_52,code=sm_52;-gencode;arch=compute_52,code=compute_52;-std=c++11;-DVERBOSE;-DEIGEN_USE_GPU;-DHAVE_CUDA;")
+  endif()
   if(CUDNN_FOUND)
     list(APPEND CUDA_NVCC_FLAGS "-DHAVE_CUDNN")
   endif()


### PR DESCRIPTION
Fixes https://github.com/clab/dynet/issues/661

You can now use `-DCUDA_ARCH=XXX` to specify your computing architecture.