### PR TITLE
Add forget bias choice for VanillaLSTM model

### DIFF
--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -975,7 +975,8 @@ struct VanillaLSTMBuilder : public RNNBuilder {
                        unsigned input_dim,
                        unsigned hidden_dim,
                        ParameterCollection& model,
-                       bool ln_lstm = false);
+                       bool ln_lstm = false,
+                       bool forget_bias = false);
 
   Expression back() const override;
   std::vector<Expression> final_h() const override;
@@ -1021,6 +1022,7 @@ struct VanillaLSTMBuilder : public RNNBuilder {
   unsigned input_dim, hid;
   float dropout_rate_h;
   bool ln_lstm;
+  bool forget_bias;
   bool dropout_masks_valid;
 };
 

--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -976,7 +976,7 @@ struct VanillaLSTMBuilder : public RNNBuilder {
                        unsigned hidden_dim,
                        ParameterCollection& model,
                        bool ln_lstm = false,
-                       bool forget_bias = false);
+                       bool forget_bias = true);
 
   Expression back() const override;
   std::vector<Expression> final_h() const override;

--- a/dynet/lstm.cc
+++ b/dynet/lstm.cc
@@ -293,13 +293,13 @@ void CoupledLSTMBuilder::disable_dropout() {
 enum { _X2I, _H2I, _BI, _X2F, _H2F, _BF, _X2O, _H2O, _BO, _X2G, _H2G, _BG };
 enum { LN_GH, LN_BH, LN_GX, LN_BX, LN_GC, LN_BC};
 
-VanillaLSTMBuilder::VanillaLSTMBuilder() : has_initial_state(false), layers(0), input_dim(0), hid(0), dropout_rate_h(0), ln_lstm(false), dropout_masks_valid(false) { }
+VanillaLSTMBuilder::VanillaLSTMBuilder() : has_initial_state(false), layers(0), input_dim(0), hid(0), dropout_rate_h(0), ln_lstm(false), forget_bias(true), dropout_masks_valid(false) { }
 
 VanillaLSTMBuilder::VanillaLSTMBuilder(unsigned layers,
                                        unsigned input_dim,
                                        unsigned hidden_dim,
                                        ParameterCollection& model,
-                                       bool ln_lstm) : layers(layers), input_dim(input_dim), hid(hidden_dim), ln_lstm(ln_lstm), dropout_masks_valid(false) {
+                                       bool ln_lstm, bool forget_bias) : layers(layers), input_dim(input_dim), hid(hidden_dim), ln_lstm(ln_lstm), forget_bias(forget_bias), dropout_masks_valid(false) {
   unsigned layer_input_dim = input_dim;
   local_model = model.add_subcollection("vanilla-lstm-builder");
   for (unsigned i = 0; i < layers; ++i) {
@@ -442,7 +442,7 @@ Expression VanillaLSTMBuilder::add_input_impl(int prev, const Expression& x) {
   if ((dropout_rate > 0.f || dropout_rate_h > 0.f) && !dropout_masks_valid) set_dropout_masks(x.dim().bd);
   for (unsigned i = 0; i < layers; ++i) {
     const vector<Expression>& vars = param_vars[i];
-    
+
     Expression i_h_tm1, i_c_tm1;
     bool has_prev_state = (prev >= 0 || has_initial_state);
     if (prev < 0) {
@@ -464,6 +464,7 @@ Expression VanillaLSTMBuilder::add_input_impl(int prev, const Expression& x) {
       i_h_tm1 = cmult(i_h_tm1, masks[i][1]);
     // input
     Expression tmp;
+    Expression tmp2;
     Expression i_ait;
     Expression i_aft;
     Expression i_aot;
@@ -485,8 +486,11 @@ Expression VanillaLSTMBuilder::add_input_impl(int prev, const Expression& x) {
     i_aot = pick_range(tmp, hid * 2, hid * 3);
     i_agt = pick_range(tmp, hid * 3, hid * 4);
     Expression i_it = logistic(i_ait);
-    // TODO(odashi): Should the forget bias be a hyperparameter?
-    Expression i_ft = logistic(i_aft + 1.f);
+    if (forget_bias)
+        tmp2 = logistic(i_aft+ 1.f);
+    else
+        tmp2 = logistic(i_aft);
+    Expression i_ft = tmp2;
     Expression i_ot = logistic(i_aot);
     Expression i_gt = tanh(i_agt);
 

--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -198,12 +198,14 @@ struct VanillaLSTMBuilder : public RNNBuilder {
    * \param hidden_dim Dimention of the hidden states \f$h_t\f$ and \f$c_t\f$
    * \param model ParameterCollection holding the parameters
    * \param ln_lstm Whether to use layer normalization
+   * \param forget_bias Whether to use bias to forget gate(default = True)
    */
   explicit VanillaLSTMBuilder(unsigned layers,
                               unsigned input_dim,
                               unsigned hidden_dim,
                               ParameterCollection& model,
-                              bool ln_lstm = false);
+                              bool ln_lstm = false,
+                              bool forget_bias = true);
 
   Expression back() const override { return (cur == -1 ? h0.back() : h[cur].back()); }
   std::vector<Expression> final_h() const override { return (h.size() == 0 ? h0 : h.back()); }
@@ -266,7 +268,7 @@ struct VanillaLSTMBuilder : public RNNBuilder {
    */
   void set_dropout_masks(unsigned batch_size = 1);
   /**
-   * \brief Get parameters in VanillaLSTMBuilder 
+   * \brief Get parameters in VanillaLSTMBuilder
    * \return list of points to ParameterStorage objects
    */
   ParameterCollection & get_parameter_collection() override;
@@ -304,6 +306,7 @@ public:
   unsigned input_dim, hid;
   float dropout_rate_h;
   bool ln_lstm;
+  bool forget_bias;
   bool dropout_masks_valid;
 
 private:

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -41,7 +41,7 @@ cdef extern from "dynet/dim.h" namespace "dynet":
         CDim transpose()
 
 cdef extern from "dynet/tensor.h" namespace "dynet":
-    cdef cppclass CTensor "dynet::Tensor": 
+    cdef cppclass CTensor "dynet::Tensor":
         CDim d
         float* v
         pass
@@ -49,15 +49,15 @@ cdef extern from "dynet/tensor.h" namespace "dynet":
     vector[float] c_as_vector "dynet::as_vector" (CTensor& t)
 
 cdef extern from "dynet/tensor.h" namespace "dynet":
-    cdef cppclass CIndexTensor "dynet::IndexTensor": 
+    cdef cppclass CIndexTensor "dynet::IndexTensor":
         CDim d
         pass
     vector[ptrdiff_t] c_index_tensor_as_vector "dynet::as_vector" (CIndexTensor& t)
     cdef cppclass CTensorTools "dynet::TensorTools":
         @staticmethod
-        CIndexTensor argmax(CTensor& t, unsigned dim, unsigned num) 
+        CIndexTensor argmax(CTensor& t, unsigned dim, unsigned num)
         @staticmethod
-        CIndexTensor categorical_sample_log_prob(CTensor& t, unsigned dim, unsigned num) 
+        CIndexTensor categorical_sample_log_prob(CTensor& t, unsigned dim, unsigned num)
 
 cdef extern from "dynet/model.h" namespace "dynet":
     cdef cppclass CParameterStorage "dynet::ParameterStorage":
@@ -177,7 +177,7 @@ cdef extern from "dynet/dynet.h" namespace "dynet":
         VariableIndex add_lookup(CLookupParameters* p, unsigned index) except +
         VariableIndex add_const_lookup(CLookupParameters* p, const unsigned* pindex) except +
         VariableIndex add_const_lookup(CLookupParameters* p, unsigned index) except +
-        
+
         const CTensor& forward(VariableIndex index) except +
         const CTensor& incremental_forward(VariableIndex index) except +
         const CTensor& get_value(VariableIndex i) except +
@@ -241,7 +241,7 @@ cdef extern from "dynet/devices.h" namespace "dynet":
         CDevice* get(unsigned i)
         size_t num_devices()
 
-    CDeviceManager* c_get_device_manager "dynet::get_device_manager" () 
+    CDeviceManager* c_get_device_manager "dynet::get_device_manager" ()
 
 cdef extern from "dynet/expr.h" namespace "dynet":
     cdef cppclass CExpression "dynet::Expression":
@@ -281,7 +281,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_nobackprop "dynet::nobackprop" (CExpression& x) except + #
     # identity function, but derivative takes negative as propagated through it
     CExpression c_flip_gradient "dynet::flip_gradient" (CExpression& x) except + #
-    
+
     CExpression c_op_neg "dynet::operator-" (CExpression& x) except + #
     CExpression c_op_add "dynet::operator+" (CExpression& x, CExpression& y) except + #
     CExpression c_op_scalar_add "dynet::operator+" (CExpression& x, float y) except + #
@@ -289,7 +289,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_op_scalar_mul "dynet::operator*" (CExpression& x, float y) except + #
     CExpression c_op_scalar_div "dynet::operator/" (CExpression& x, float y) except + #
     CExpression c_op_scalar_sub "dynet::operator-" (float y, CExpression& x) except + #
-    
+
     CExpression c_bmax "dynet::max" (CExpression& x, CExpression& y) except + #
     CExpression c_bmin "dynet::min" (CExpression& x, CExpression& y) except + #
 
@@ -308,7 +308,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_log "dynet::log" (CExpression& x) except + #
     CExpression c_lgamma "dynet::lgamma" (CExpression& x) except + #
     CExpression c_logistic "dynet::logistic" (CExpression& x) except + #
-    CExpression c_rectify "dynet::rectify" (CExpression& x) except + #        
+    CExpression c_rectify "dynet::rectify" (CExpression& x) except + #
     CExpression c_hinge "dynet::hinge" (CExpression& x, unsigned index, float m) except + #
     CExpression c_hinge "dynet::hinge" (CExpression& x, vector[unsigned] vs, float m) except + #
     CExpression c_hinge_dim "dynet::hinge_dim" (CExpression& x, vector[unsigned] index, unsigned d, float m) except + #
@@ -391,7 +391,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_elu "dynet::elu" (CExpression& x, float alpha) except + #
     CExpression c_selu "dynet::selu" (CExpression& x) except + #
     CExpression c_silu "dynet::silu" (CExpression& x, float beta) except + #
-    
+
     # expecting a vector of CExpression
     CExpression c_average     "dynet::average" (vector[CExpression]& xs) except +
     CExpression c_concat_cols "dynet::concatenate_cols" (vector[CExpression]& xs) except +
@@ -467,7 +467,7 @@ cdef extern from "dynet/lstm.h" namespace "dynet":
 
     cdef cppclass CVanillaLSTMBuilder "dynet::VanillaLSTMBuilder" (CRNNBuilder):
         CVanillaLSTMBuilder()
-        CVanillaLSTMBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model, bool ln_lstm)
+        CVanillaLSTMBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model, bool ln_lstm, bool forget_bias)
         void set_dropout(float d, float d_r)
         void set_dropout_masks(unsigned batch_size)
 
@@ -530,4 +530,3 @@ cdef extern from "dynet/cfsm-builder.h" namespace "dynet":
 
         CExpression subclass_log_distribution(CExpression &rep, unsigned classid) except +
         CExpression subclass_logits(CExpression &rep, unsigned classid) except +
-

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -6,12 +6,12 @@ from libc.stdlib cimport malloc, free
 from libcpp.memory cimport shared_ptr
 import numpy as np
 
-# python3 pickle already uses the c implementaion 
+# python3 pickle already uses the c implementaion
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
-    
+
 import os.path
 
 from _dynet cimport *
@@ -22,17 +22,17 @@ cimport _dynet as dynet
 #       (by prepending with _, and removing from docs)
 cdef class DynetParams: # {{{
     """This object holds the global parameters of Dynet
-    
+
     This is useful if you want to specify the global dynet parameters (memory, random seed...) programmatically, for example in a notebook.
-    
+
     .. code-block:: python
 
         import _dynet
-    
+
     You can then declare and use a :code:`DynetParams` object
-    
+
     .. code-block:: python
-        
+
         # Declare a DynetParams object
         dyparams = dy.DynetParams()
         # Fetch the command line arguments (optional)
@@ -48,7 +48,7 @@ cdef class DynetParams: # {{{
     :code:`import dynet`:
 
     .. code-block:: python
- 
+
         import dynet_config
         # Declare GPU as the default device type
         dynet_config.set_gpu()
@@ -56,7 +56,7 @@ cdef class DynetParams: # {{{
         dynet_config.set(mem=4,random_seed=9)
         # Initialize dynet import using above configuration in the current scope
         import dynet
-        
+
     Don't forget to initialize with :code:`dyparams.init()`, otherwise dynet will raise an error.
     """
     cdef CDynetParams cparams
@@ -69,7 +69,7 @@ cdef class DynetParams: # {{{
     #      should be adapted.
     cpdef from_config(self, conf):
         """Set parameters from config object:
-        
+
         Attributes of conf object:
             mem, seed, autobatch, profiling, weight_decay, shared_params, requested_gpus, gpu_mask
         """
@@ -89,10 +89,10 @@ cdef class DynetParams: # {{{
     # TODO can this be removed?
     cpdef from_args(self, shared_parameters=None):
         """Gets parameters from the command line arguments
-        
+
         You can still modify the parameters after calling this.
         See the documentation about command line arguments for more details
-        
+
         Keyword Args:
             shared_parameters([type]): [description] (default: None)
         """
@@ -114,7 +114,7 @@ cdef class DynetParams: # {{{
         for idx, s in enumerate(args):
             c_argv[idx] = s
         if cpu_use:
-            c_argv[argc-2] = '--dynet-devices' 
+            c_argv[argc-2] = '--dynet-devices'
             c_argv[argc-1] = 'CPU'
 
         if shared_parameters is None:
@@ -126,16 +126,16 @@ cdef class DynetParams: # {{{
 
     cpdef init(self):
         """Initialize dynet with the current dynetparams object.
-        
+
         This is one way, you can't uninitialize dynet
         """
         dynet.initialize(self.cparams)
 
     cpdef set_mem(self, unsigned mem):
         """Set the memory allocated to dynet
-        
+
         The unit is MB
-        
+
         Args:
             mem(number): memory size in MB
         """
@@ -143,7 +143,7 @@ cdef class DynetParams: # {{{
 
     cpdef set_random_seed(self, unsigned random_seed):
         """Set random seed for dynet
-        
+
         Args:
             random_seed(number): Random seed
         """
@@ -151,7 +151,7 @@ cdef class DynetParams: # {{{
 
     cpdef set_autobatch(self, bool autobatch):
         """Activate autobatching
-        
+
         Args:
             autobatch(bool): Set to :code:`True` to activate autobatching
         """
@@ -162,7 +162,7 @@ cdef class DynetParams: # {{{
 
     cpdef set_profiling(self, int profiling):
         """Activate autobatching debug
-        
+
         Args:
             profiling(int): Set to a value > 0 to activate profiling
         """
@@ -170,7 +170,7 @@ cdef class DynetParams: # {{{
 
     cpdef set_weight_decay(self, float weight_decay):
         """Set weight decay parameter
-        
+
         Args:
             weight_decay(float): weight decay parameter
         """
@@ -178,7 +178,7 @@ cdef class DynetParams: # {{{
 
     cpdef set_shared_parameters(self, bool shared_parameters):
         """Shared parameters
-        
+
         Args:
             shared_parameters(bool): shared parameters
         """
@@ -186,14 +186,14 @@ cdef class DynetParams: # {{{
 
     cpdef set_requested_gpus(self, int requested_gpus):
         """Number of requested gpus
-        
+
         Args:
             requested_gpus(number): number of requested gpus
         """
         self.cparams.requested_gpus = requested_gpus
         self.cparams.ngpus_requested = True
         self.cparams.ids_requested = False
-    
+
     cpdef set_gpu_mask(self, list gpu_mask):
         cdef vector[int] cgpu_mask
         for i in gpu_mask:
@@ -212,9 +212,9 @@ cdef class DynetParams: # {{{
 # Initialization {{{
 def init(shared_parameters=None):
     """Initialize dynet
-    
+
     Initializes dynet from command line arguments. Do not use after import dynet
-    
+
     Keyword Args:
         shared_parameters(bool): [description] (default: None)
     """
@@ -224,11 +224,11 @@ def init(shared_parameters=None):
 
 def init_from_params(DynetParams params):
     """Initialize from DynetParams
-    
-    Same as 
+
+    Same as
 
         params.init()
-    
+
     Args:
         params(DynetParams): dynet parameters
     """
@@ -238,12 +238,12 @@ def init_from_params(DynetParams params):
 # Dimensions {{{
 cdef CDim Dim(dim, unsigned int batch_size=1):
     """Get dynet Dim from tuple
-    
+
 
     Args:
         dim(tuple): Dimensions as a tuple
         batch_size(number): Batch size (default: 1)
-    
+
     Returns:
         CDim: Dynet dimension
     """
@@ -333,29 +333,29 @@ cpdef save(basename, lst):
         pc = dy.ParameterCollection()
         E2, builder2, W2 = dy.load("model", pc)
 
-    
+
     What can be saved:
         Each object in `lst` must be one of the following:
-        
+
         (1) Parameter
         (2) LookupParameter
         (3) one of the built-in types (CompactVanillaLSTMBuilder, VanillaLSTMBuilder, LSTMBuilder, GRUBuilder,
                                        SimpleRNNBuilder, BiRNNBuilder)
         (4) a type adhering to the following interface:
-            
+
             - has a `param_collection()` method returning a ParameterCollection object with the
               parameters in the object.
             - has a `.spec` property with picklable items describing the object
             - has a `.from_spec(spec, model)` static method that will create and return a
               new instane with the needed parameters/etc in the model.
 
-        Note, the built-in types in (3) above can be saved/loaded this way simply because 
+        Note, the built-in types in (3) above can be saved/loaded this way simply because
         they support this interface.
 
         behind the scenes:
-        
+
         - for each item, we write to `.meta`:
-            if its a Parameters/ParameterCollection: 
+            if its a Parameters/ParameterCollection:
                 its type and full name.
             if its a builder:
                 its class, its spec, the full name of its parameters collection.
@@ -372,7 +372,7 @@ cpdef load(basename, params):
     The loaded objects are added to the supplied params collection, and returned.
 
     Args:
-        basename (string):  The basename to read from. 
+        basename (string):  The basename to read from.
                             This is the same string that was used when saving the objects.
         params   (dynet.ParameterCollection): A ParameterCollection to add the loaded objects to.
 
@@ -432,7 +432,7 @@ cdef class PyInitializer:
 
 cdef class NormalInitializer(PyInitializer):
     """Initialize the parameters with a gaussian distribution
-    
+
     Keyword Arguments:
         mean (number): Mean of the distribution (default: 0)
         var (number): Variance of the distribution (default: 1)
@@ -442,7 +442,7 @@ cdef class NormalInitializer(PyInitializer):
 
 cdef class UniformInitializer(PyInitializer):
     """Initialize the parameters with a uniform distribution
-    
+
     Args:
         scale (number): Parmeters are sampled from :math:`\mathcal U([-\\texttt{scale},\\texttt{scale}])`
     """
@@ -451,7 +451,7 @@ cdef class UniformInitializer(PyInitializer):
 
 cdef class ConstInitializer(PyInitializer):
     """Initialize the parameters with a constant value
-    
+
     Args:
         c (number): Value to initialize the parameters
     """
@@ -460,24 +460,24 @@ cdef class ConstInitializer(PyInitializer):
 
 cdef class IdentityInitializer(PyInitializer):
     """Initialize the parameters as the identity
-    
+
     Only works with square matrices
     """
     def __init__(self):
         self.initializer = new CParameterInitIdentity()
 
 cdef class GlorotInitializer(PyInitializer):
-    """Initializes the weights according to `Glorot & Bengio (2011) <http://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf>`_ 
-    
+    """Initializes the weights according to `Glorot & Bengio (2011) <http://proceedings.mlr.press/v9/glorot10a/glorot10a.pdf>`_
+
     If the dimensions of the parameter matrix are :math:`m,n`, the weights are sampled from :math:`\mathcal U([-g\sqrt{\\frac{6}{m+n}},g\sqrt{\\frac{6}{m+n}}])`
-    
-    The gain :math:`g` depends on the activation function : 
+
+    The gain :math:`g` depends on the activation function :
 
     * :math:`\\text{tanh}` : 1.0
     * :math:`\\text{ReLU}` : 0.5
     * :math:`\\text{sigmoid}` : 4.0
     * Any smooth function :math:`f` : :math:`\\frac{1}{f'(0)}`
-    
+
     *Note:* This is also known as **Xavier initialization**
 
     Keyword Arguments:
@@ -499,7 +499,7 @@ cdef class SaxeInitializer(PyInitializer):
 
 cdef class FromFileInitializer(PyInitializer):
     """Initialize parameter from file
-    
+
     Args:
         fname (str): File name
     """
@@ -510,7 +510,7 @@ cdef class NumpyInitializer(PyInitializer):
     """Initialize from numpy array
 
     Alternatively, use :code:`ParameterCollection.parameters_from_numpy()`
-    
+
     Args:
         array (np.ndarray): Numpy array
     """
@@ -526,10 +526,10 @@ cdef class NumpyInitializer(PyInitializer):
         return vals
 # }}}
 
-# {{{ ParameterCollection / Parameters 
+# {{{ ParameterCollection / Parameters
 cdef class Parameters: # {{{
     """Parameters class
-    
+
     Parameters are things that are optimized. in contrast to a system like Torch where computational modules may have their own parameters, in DyNet parameters are just parameters.
     """
     cdef CParameters thisptr # TODO: no longer pointer
@@ -581,7 +581,7 @@ cdef class Parameters: # {{{
 
     cpdef shape(self):
         """Returns shape of the parameter
-        
+
         Returns:
             tuple: Shape of the parameter
         """
@@ -589,7 +589,7 @@ cdef class Parameters: # {{{
 
     cpdef as_array(self):
         """Return as a numpy array.
-        
+
         Returns:
             np.ndarray: values of the parameter
         """
@@ -598,7 +598,7 @@ cdef class Parameters: # {{{
 
     cpdef grad_as_array(self):
         """Return gradient as a numpy array.
-        
+
         Returns:
             np.ndarray: values of the gradient w.r.t. this parameter
         """
@@ -653,7 +653,7 @@ cdef class Parameters: # {{{
 
     cpdef bool is_updated(self):
         """check whether the parameter is updated or not
-        
+
         Returns:
             bool: Update status
         """
@@ -661,7 +661,7 @@ cdef class Parameters: # {{{
 
     cpdef set_updated(self, bool b):
         """Set parameter as "updated"
-        
+
         Args:
             b(bool): updated status
         """
@@ -679,7 +679,7 @@ cdef class Parameters: # {{{
         This is the same as calling
 
             dy.parameter(param)
-        
+
         Args:
             update(bool): If this is set to False, the parameter won't be updated during the backward pass
         Returns:
@@ -794,7 +794,7 @@ cdef class LookupParameters: # {{{
         """Returns a batched expression based on looked up indices
 
         This does the same as :code:`dynet.lookup_batch`
-        
+
         Args:
             i (list): list of indices
 
@@ -805,7 +805,7 @@ cdef class LookupParameters: # {{{
 
     cpdef init_row(self, unsigned i, vector[float] row):
         """Initialize one row with values
-        
+
         Args:
             i    (int): index
             row (list): values
@@ -814,7 +814,7 @@ cdef class LookupParameters: # {{{
 
     cpdef row_as_array(self, row):
         """Return row as a numpy array.
-        
+
         Args:
             row (int): row to return
 
@@ -829,7 +829,7 @@ cdef class LookupParameters: # {{{
         """Return rows as a numpy array.
 
         The first dimension is the lookup dimension
-        
+
         Args:
             rows (list): rows to return
 
@@ -866,7 +866,7 @@ cdef class LookupParameters: # {{{
 
     cpdef row_grad_as_array(self, row):
         """Return row gradient as a numpy array.
-        
+
         Args:
             row (int): row to return
 
@@ -881,7 +881,7 @@ cdef class LookupParameters: # {{{
         """Return rows gradients as a numpy array.
 
         The first dimension is the lookup dimension
-        
+
         Args:
             rows (list): rows to return
 
@@ -892,7 +892,7 @@ cdef class LookupParameters: # {{{
         vals = self.thisptr.get_storage().grads
         return np.stack([c_tensor_as_np(vals[row]) for row in rows])
 
-    
+
     cpdef scale(self,float s):
         """Scales the parameter
 
@@ -910,7 +910,7 @@ cdef class LookupParameters: # {{{
 
         """
         self.thisptr.scale_gradient(s)
-        
+
     cpdef Expression expr(self,bool update=True):
         """Returns an expression for the whole parameter
 
@@ -954,7 +954,7 @@ cdef class ParameterCollection: # {{{
 
     dynet.Trainer objects take ParameterCollection objects that define which parameters
     are being trained.
-    
+
     The values of the parameters in a collection can be persisted to and loaded from files.
 
     Hierarchy:
@@ -964,10 +964,10 @@ cdef class ParameterCollection: # {{{
 
     Naming:
         Parameters, LookupParameters and ParameterCollections have associated string names.
-        The names can be accessed using the `.name()` method. 
-        
-        The names are used for identifying the parameters and the collection hierarchy 
-        when loading from disk, and in particular when loading only a subset of the objects 
+        The names can be accessed using the `.name()` method.
+
+        The names are used for identifying the parameters and the collection hierarchy
+        when loading from disk, and in particular when loading only a subset of the objects
         in a saved file.
 
         The name of a parameter, lookup parameter or sub-collection is unique within
@@ -1073,7 +1073,7 @@ cdef class ParameterCollection: # {{{
 
     cpdef parameters_list(self):
         """Returns list of all parameters in the collection
-        
+
         Returns:
             (list): All dy.Parameters in the collection
         """
@@ -1085,7 +1085,7 @@ cdef class ParameterCollection: # {{{
 
     cpdef lookup_parameters_list(self):
         """Returns list of all looku parameters in the collection
-        
+
         Returns:
             (list): All dy.LookupParameters in the collection
         """
@@ -1097,12 +1097,12 @@ cdef class ParameterCollection: # {{{
 
     cpdef parameters_from_numpy(self, array, name="", device=""):
         """Create parameter from numpy array
-        
+
         Args:
             array (np.ndarray): Numpy array
             name  (string): optional name for this parameter.
             device (string)           : Optional device name for this parameter (default: "", default device)
-        
+
         Returns:
             (dynet.Parameters): Parameter
         """
@@ -1121,12 +1121,12 @@ cdef class ParameterCollection: # {{{
     # TODO this may fail with >2 dim arrays.
     cpdef lookup_parameters_from_numpy(self, array, name="", device=""):
         """Create LookupParameters from numpy array
-        
+
         Args:
             array (np.ndarray): Numpy array. rows: vocab_size, cols: dims.
             name  (string): optional name for this parameter.
             device (string)           : Optional device name for this parameter (default: "", default device)
-        
+
         Returns:
             (dynet.LookupParameters): LookupParameter
         """
@@ -1146,15 +1146,15 @@ cdef class ParameterCollection: # {{{
 
     cpdef add_parameters(self, dim, PyInitializer init=None, name="", device=""):
         """Add a parameter to the ParameterCollection
-        
+
         Args:
             dim (tuple): Shape of the parameter
-        
+
         Keyword Arguments:
             init (dynet.PyInitializer): Initializer (default: GlorotInitializer)
             name (string)             : Optional name for this parameter (default: "")
             device (string)           : Optional device name for this parameter (default: "", default device)
-        
+
         Returns:
             (dynet.Parameters): Created Parameter
         """
@@ -1176,15 +1176,15 @@ cdef class ParameterCollection: # {{{
 
     cpdef add_lookup_parameters(self, dim, PyInitializer init=None, name="", device=""):
         """Add a lookup parameter to the ParameterCollection
-        
+
         Args:
             dim (tuple): Shape of the parameter. The first dimension is the vocab size
-        
+
         Keyword Arguments:
             init (dynet.PyInitializer): Initializer (default: GlorotInitializer)
             name (string)             : Optional name for this parameter (default: "")
             device (string)           : Optional device name for this parameter (default: "", default device)
-        
+
         Returns:
             (dynet.LookupParameters): Created LookupParameter
         """
@@ -1207,7 +1207,7 @@ cdef class ParameterCollection: # {{{
 
     cpdef add_subcollection(self, name=None):
         """Creates a sub-collection of the current collection, and returns it.
-        
+
         A sub-collection is simply a ParameterCollection object which is tied to a
         parent collection. ParameterCollections can be nested to arbitraty depth.
 
@@ -1297,17 +1297,17 @@ cdef class FloatVectorValue:
 
 # }}}
 
-# {{{ Computation Graph 
+# {{{ Computation Graph
 cdef int SECRET = 923148
 cdef ComputationGraph _cg = ComputationGraph(SECRET)
 
-def cg_version(): 
+def cg_version():
     """
     Varsion of the current computation graph
     """
     return _cg._cg_version
 
-def renew_cg(immediate_compute=False, check_validity=False, autobatching=None): 
+def renew_cg(immediate_compute=False, check_validity=False, autobatching=None):
     """
     Renew the computation graph.
 
@@ -1316,7 +1316,7 @@ def renew_cg(immediate_compute=False, check_validity=False, autobatching=None):
     return _cg.renew(immediate_compute, check_validity, autobatching)
 
 def print_text_graphviz(): return _cg.print_graphviz()
-def cg_checkpoint(): 
+def cg_checkpoint():
     """
     Saves the state of the computation graph
     """
@@ -1340,7 +1340,7 @@ cdef class ComputationGraph:
 
     While the ComputationGraph is central to the inner workings of DyNet, from the user's perspective, the only responsibility is to create a new computation graph for each training example.
     """
-    cdef CComputationGraph *thisptr, 
+    cdef CComputationGraph *thisptr,
     cdef list _inputs
     cdef int _cg_version
     def __cinit__(self, int guard=0):
@@ -1366,7 +1366,7 @@ cdef class ComputationGraph:
         self._cg_version += 1
         return self
 
-    cpdef version(self): 
+    cpdef version(self):
         """
         Same as :code:`dynet.cg_version()`
         """
@@ -1418,7 +1418,7 @@ cdef class ComputationGraph:
     #   lookup(params, unsigned*)
     #   const_lookup(params, unsigned*)
     #   pick(unsigned*)
-    # 
+    #
     # We have the classes UnsignedValue, FloatValue and FloatVectorValue for
     # this purpose.
     cdef inputValue(self, float v = 0.0, device=""):
@@ -1446,13 +1446,13 @@ cdef class ComputationGraph:
 # }}}
 
 # {{{ Devices
-    
+
 cpdef available_devices():
     """We use the term Device to refer to a Computation Device.
     A computation device is a piece of hardware performing computation (e.g., CPU, GPU).
     Computation devices are identified by string names (e.g., 'CPU', 'GPU:0').
     This returns the list of available devices.
-    
+
     Devices have both a processor and an associated memory.
     Hence, each Parameters, LookupParameters and Expression are tied to devices.
     - Parameter and LookupParameters are associated with a device at creation time.
@@ -1540,7 +1540,7 @@ cdef class Tensor: #{{{
         Keyword Args:
             dim(integer): which dimension to take the argmax over
             num(integer): the number of kmax values
-        
+
         Returns:
             A newly allocated Tensor consisting of argmax IDs. The length of the
         """
@@ -1550,7 +1550,7 @@ cdef class Tensor: #{{{
         """Calculate samples from a log probability
 
         Assumes each row in the tensor represents a log probabiity distribution
-        
+
         Keyword Args:
             dim(integer): Which dimension to take the sample over
             num(integer): num The number of samples for each row
@@ -1576,7 +1576,7 @@ cdef _cdiv(Expression a, float b): return Expression.from_cexpr(a.cg_version, c_
 
 cdef class Expression: #{{{
     """Expressions are the building block of a Dynet computation graph.
-    
+
     Expressions are the main data types being manipulated in a DyNet program. Each expression represents a sub-computation in a computation graph.
     """
     #cdef CComputationGraph* cg
@@ -1608,7 +1608,7 @@ cdef class Expression: #{{{
         """Dimension of the expression
 
         Returns a tuple (dims,batch_dim) where dims is the tuple of dimensions of each batch element
-        
+
         Returns:
             tuple: dimension
         """
@@ -1622,7 +1622,7 @@ cdef class Expression: #{{{
         return str(self)
     def __str__(self):
         """Returns a string representation of the expression
-        
+
         The format is "expression [expression id]/[computation graph id]"
         """
         return "expression %s/%s" % (<int>self.vindex, self.cg_version)
@@ -1630,26 +1630,26 @@ cdef class Expression: #{{{
     # __getitem__ and __getslice__ in one for python 3 compatibility
     def __getitem__(self, index):
         """Access elements of the expression by rows
-        
+
         This supports slices as well.
         Example usage :
 
             x = dy.inputTensor(np.arange(9).reshape(3,3))
             # x = [[1, 2, 3],
             #      [4, 5, 6],
-            #      [7, 8, 9]] 
+            #      [7, 8, 9]]
             y = x[1]
             # y = [4, 5, 6]
-            z = x[0:1] 
+            z = x[0:1]
             # z = [[1, 2, 3],
-            #      [4, 5, 6]] 
-        
+            #      [4, 5, 6]]
+
         Args:
             index(int,slice): Slice or index
-        
+
         Returns:
             Expression: Slice of the expression
-        
+
         Raises:
             IndexError: If the indices are too large
             ValueError: In case of improper slice or if step is used
@@ -1693,12 +1693,12 @@ cdef class Expression: #{{{
 
     cpdef scalar_value(self, recalculate=False):
         """Returns value of an expression as a scalar
-        
+
         This only works if the expression is a scalar
-        
+
         Keyword Args:
             recalculate(bool): Recalculate the computation graph (for static graphs with new inputs) (default: False)
-        
+
         Returns:
             float: Scalar value of the expression
         """
@@ -1708,12 +1708,12 @@ cdef class Expression: #{{{
 
     cpdef vec_value(self, recalculate=False):
         """Returns the value of the expression as a vector
-        
+
         In case of a multidimensional expression, the values are flattened according to a column major ordering
-        
+
         Keyword Args:
             recalculate(bool): Recalculate the computation graph (for static graphs with new inputs) (default: False)
-        
+
         Returns:
             list: Array of values
         """
@@ -1723,12 +1723,12 @@ cdef class Expression: #{{{
 
     cpdef npvalue(self, recalculate=False):
         """Returns the value of the expression as a numpy array
-        
+
         The last dimension is the batch size (if it's > 1)
-        
+
         Keyword Args:
             recalculate(bool): Recalculate the computation graph (for static graphs with new inputs) (default: False)
-        
+
         Returns:
             np.ndarray: numpy array of values
         """
@@ -1746,10 +1746,10 @@ cdef class Expression: #{{{
 
         This is useful if you want to use the value for other on-device calculations
         that are not part of the computation graph, i.e. using argmax.
-        
+
         Keyword Args:
             recalculate(bool): Recalculate the computation graph (for static graphs with new inputs) (default: False)
-        
+
         Returns:
             Tensor: a dynet Tensor object.
         """
@@ -1762,12 +1762,12 @@ cdef class Expression: #{{{
 
     cpdef value(self, recalculate=False):
         """Gets the value of the expression in the most relevant format
-        
+
         this returns the same thing as :code:`scalar_value`, :code:`vec_value`, :code:`npvalue` depending on whether the number of dimensions of the expression is 0, 1 or 2+
-        
+
         Keyword Args:
             recalculate(bool): Recalculate the computation graph (for static graphs with new inputs) (default: False)
-        
+
         Returns:
             float, list, np.ndarray: Value of the expression
         """
@@ -1783,13 +1783,13 @@ cdef class Expression: #{{{
 
     cpdef gradient(self):
         """Returns the value of the expression as a numpy array
-        
+
         The last dimension is the batch size (if it's > 1).
 
         Make sure to call :code:`backward` on a downstream expression before calling this.
 
         If the Expression is a constant expression (meaning it's not a function of a parameter), dynet won't compute it's gradient for the sake of efficiency. You need to manually force the gradient computation by adding the agument :code:`full=True` to :code:`backward`
-        
+
         Returns:
             np.ndarray: numpy array of values
         """
@@ -1803,10 +1803,10 @@ cdef class Expression: #{{{
     # TODO this runs incremental forward on the entire graph, may not be optimal in terms of efficiency.
     cpdef forward(self, recalculate=False):
         """This runs incremental forward on the entire graph
-        
+
         May not be optimal in terms of efficiency.
         Prefer :code:`values`
-        
+
         Keyword Args:
             recalculate(bool): Recalculate the computation graph (for static graphs with new inputs) (default: False)
         """
@@ -1816,16 +1816,16 @@ cdef class Expression: #{{{
 
     cpdef backward(self, bool full=False):
         """Run the backward pass based on this expression
-        
+
         The parameter :code:`full` specifies whether the gradients should be computed for all nodes (:code:`True`) or only non-constant nodes (:code:`False`).
-        
+
         By default, a node is constant unless
-        
+
         1. it is a parameter node
         2. it depends on a non-constant node
-        
+
         Thus, functions of constants and inputs are considered as constants.
-        
+
         Turn :code:`full` on if you want to retrieve gradients w.r.t. inputs for instance. By default this is turned off, so that the backward pass ignores nodes which have no influence on gradients w.r.t. parameters for efficiency.
 
         Args:
@@ -1858,7 +1858,7 @@ cdef class Expression: #{{{
     def __truediv__(self, other):
         if isinstance(self, Expression) and isinstance(other, (int,float)):
             return _cdiv(self, other)
-        else: raise NotImplementedError()  
+        else: raise NotImplementedError()
     def __neg__(self):        return _neg(self)
     def __sub__(self, other):
         if isinstance(self,Expression) and isinstance(other,Expression):
@@ -1949,7 +1949,7 @@ def const_parameter(*args):
 
 cdef class _inputExpression(Expression):
     """Subclass of Expression corresponding to scalar input expressions
-    
+
     """
     cdef FloatValue val
     def __cinit__(self, ComputationGraph g, float s, device=""):
@@ -1967,10 +1967,10 @@ cdef class _inputExpression(Expression):
         g._inputs.append(self)
     def set(self, float s):
         """Change the value of the expression
-        
+
         This is useful if you want to to change the input and recompute the graph without needing to re-create it. Don't forget to use :code:`recalculate=True` when calling :code:`.value()` on the output.
         This allows you to use dynet as a static framework.
-        
+
         Args:
             s(float): New value
         """
@@ -1982,7 +1982,7 @@ def scalarInput(float s, device=""):
 
 cdef class _vecInputExpression(Expression):
     """Subclass of Expression corresponding to any non-scalar input expressions
-    
+
     Despite the name, this also represents tensors (in column major format).
     TODO : change this
     """
@@ -2003,7 +2003,7 @@ cdef class _vecInputExpression(Expression):
         g._inputs.append(self)
     def set(self, vector[float] data):
         """Change the value of the expression
-        
+
         This is useful if you want to to change the input and recompute the graph without needing to re-create it. Don't forget to use :code:`recalculate=True` when calling :code:`.value()` on the output.
         This allows you to use dynet as a static framework.
         For now this only accepts new values as flattened arrays (column majors). TODO : change this
@@ -2016,7 +2016,7 @@ cdef class _vecInputExpression(Expression):
 
 cdef class _sparseInputExpression(Expression):
     """Subclass of Expression corresponding to any non-scalar input expressions
-    
+
     Despite the name, this also represents tensors (in column major format).
     TODO : change this
     """
@@ -2035,7 +2035,7 @@ cdef class _sparseInputExpression(Expression):
 
     def set(self, vector[float] data):
         """Change the value of the expression
-        
+
         This is useful if you want to to change the input and recompute the graph without needing to re-create it. Don't forget to use :code:`recalculate=True` when calling :code:`.value()` on the output.
         This allows you to use dynet as a static framework.
         For now this only accepts new values as flattened arrays (column majors). TODO : change this
@@ -2047,11 +2047,11 @@ cdef class _sparseInputExpression(Expression):
 
 def vecInput(int dim, device=""):
     """Input an empty vector
-    
+
     Args:
         dim(number): Size
         device(string): Optional, device on which to create the expression.
-    
+
     Returns:
         _vecInputExpression: Corresponding expression
     """
@@ -2059,11 +2059,11 @@ def vecInput(int dim, device=""):
 
 def inputVector(vector[float] v, device=""):
     """Input a vector by values
-    
+
     Args:
         v(vector[float]): Values
         device(string): Optional, device on which to create the expression.
-    
+
     Returns:
         _vecInputExpression: Corresponding expression
     """
@@ -2071,13 +2071,13 @@ def inputVector(vector[float] v, device=""):
 
 def matInput(int d1, int d2):
     """DEPRECATED : use inputTensor
-    
+
     TODO : remove this
-    
+
     Args:
         int d1([type]): [description]
         int d2([type]): [description]
-    
+
     Returns:
         dynet.Expression: [description]
     """
@@ -2098,7 +2098,7 @@ def inputMatrix(vector[float] v, tuple d):
 
         x = inputMatrix([1,2,3,4,5,6],(2,3))
         x.npvalue()
-        --> 
+        -->
         array([[ 1.,  3.,  5.],
                [ 2.,  4.,  6.]])
     """
@@ -2106,21 +2106,21 @@ def inputMatrix(vector[float] v, tuple d):
 
 def inputTensor(arr,batched=False,device=""):
     """Creates a tensor expression based on a numpy array or a list.
-    
+
     The dimension is inferred from the shape of the input.
     if batched=True, the last dimension is used as a batch dimension
     if arr is a list of numpy ndarrays, this returns a batched expression where the batch elements are the elements of the list
-    
+
     Args:
         arr(list,np.ndarray): Values : numpy ndarray OR list of np.ndarray OR multidimensional list of floats
-    
+
     Keyword Args:
         batched(bool): Whether to use the last dimension as a batch dimension (default: False)
         device(string): Optional, device on which to create the expression.
-    
+
     Returns:
         _vecInputExpression: Input expression
-    
+
     Raises:
         TypeError: If the type is not respected
     """
@@ -2144,11 +2144,11 @@ def inputTensor(arr,batched=False,device=""):
 
 def sparse_inputTensor(idxs, values, shape, batched=False, defval=0,device=""):
     """Creates a tensor expression based on indices and values
-    
+
     The dimension is inferred from the shape of the input.
     if batched=True, the last dimension is used as a batch dimension
     if arr is a list of numpy ndarrays, this returns a batched expression where the batch elements are the elements of the list
-    
+
     Args:
         idxs(tuple, list): A tuple/list of integer arrays, one array for each dimension (including the batch dimension)
         values(list,np.ndarray): A 1D array/list of values
@@ -2157,10 +2157,10 @@ def sparse_inputTensor(idxs, values, shape, batched=False, defval=0,device=""):
         batched(bool): Whether to use the last dimension as a batch dimension (default: False). For example if :code:`shape=(3, 3, 3)` and :code:`batched=True` the resulting expression will be a batch of 3 3x3 matrices
         defval(number): The default value for all non specified coordinates (default: 0)
         device(string): Optional, device on which to create the expression.
-    
+
     Returns:
         _vecInputExpression: Input expression
-    
+
     Raises:
         TypeError: If the type is not respected
         ValueError: If the number of dimensions don't match
@@ -2182,7 +2182,7 @@ def sparse_inputTensor(idxs, values, shape, batched=False, defval=0,device=""):
 
 cdef class _lookupExpression(Expression):
     """Expression corresponding to a lookup from lookup parameter
-    
+
     """
     cdef UnsignedValue val
     def __cinit__(self, ComputationGraph g, LookupParameters p, unsigned index=0, update=True):
@@ -2198,10 +2198,10 @@ cdef class _lookupExpression(Expression):
         g._inputs.append(self)
     def set(self,i):
         """Change the lookup index
-        
+
         This is useful if you want to to change the input and recompute the graph without needing to re-create it. Don't forget to use :code:`recalculate=True` when calling :code:`.value()` on the output.
         This allows you to use dynet as a static framework.
-        
+
         Args:
             i(number): New lookup index
         """
@@ -2210,7 +2210,7 @@ cdef class _lookupExpression(Expression):
 
 cdef class _lookupBatchExpression(Expression):
     """Expression corresponding to batched lookups from a lookup parameter
-    
+
     """
     cdef UnsignedVectorValue val
     def __cinit__(self, ComputationGraph g, LookupParameters p, vector[unsigned] indices, update=True):
@@ -2225,10 +2225,10 @@ cdef class _lookupBatchExpression(Expression):
         g._inputs.append(self)
     def set(self,i):
         """Change the lookup index
-        
+
         This is useful if you want to to change the input and recompute the graph without needing to re-create it. Don't forget to use :code:`recalculate=True` when calling :code:`.value()` on the output.
         This allows you to use dynet as a static framework.
-        
+
         Args:
             i(list(int)): New indices
         """
@@ -2240,11 +2240,11 @@ def lookup(LookupParameters p, unsigned index=0, update=True):
 
         :param p: Lookup parameter to pick from
         :type p: LookupParameters
-    
+
     Keyword Args:
         index(number): Lookup index (default: 0)
         update(bool): Whether to update the lookup parameter [(default: True)
-    
+
     Returns:
         _lookupExpression: Expression for the embedding
     """
@@ -2254,14 +2254,14 @@ def lookup_batch(LookupParameters p, vector[unsigned] indices, update=True):
     """Look up parameters.
 
     The mini-batched version of lookup. The resulting expression will be a mini-batch of parameters, where the "i"th element of the batch corresponds to the parameters at the position specified by the "i"th element of "indices"
-    
+
     Args:
         p(LookupParameters): Lookup parameter to pick from
         indices(list(int)): Indices to look up for each batch element
-    
+
     Keyword Args:
         update(bool): Whether to update the lookup parameter (default: True)
-    
+
     Returns:
         _lookupBatchExpression: Expression for the batched embeddings
     """
@@ -2269,7 +2269,7 @@ def lookup_batch(LookupParameters p, vector[unsigned] indices, update=True):
 
 cdef class _pickerExpression(Expression):
     """Expression corresponding to a row picked from a bigger expression
-    
+
     """
     cdef UnsignedValue val
     cdef unsigned dim
@@ -2284,10 +2284,10 @@ cdef class _pickerExpression(Expression):
         g._inputs.append(self)
     def set_index(self,i):
         """Change the pick index
-        
+
         This is useful if you want to to change the input and recompute the graph without needing to re-create it. Don't forget to use :code:`recalculate=True` when calling :code:`.value()` on the output.
         This allows you to use dynet as a static framework.
-        
+
         Args:
             i(number): New index
         """
@@ -2298,14 +2298,14 @@ def pick(Expression e, unsigned index=0, unsigned dim=0):
     """Pick element.
 
     Pick a single element/row/column/sub-tensor from an expression. This will result in the dimension of the tensor being reduced by 1.
-    
+
     Args:
         e(Expression): Expression to pick from
-    
+
     Keyword Args:
         index(number): Index to pick (default: 0)
         dim(number): Dimension to pick from (default: 0)
-    
+
     Returns:
         _pickerExpression: Picked expression
     """
@@ -2313,7 +2313,7 @@ def pick(Expression e, unsigned index=0, unsigned dim=0):
 
 cdef class _pickerBatchExpression(Expression):
     """Batched version of :code:`_pickerExpression`
-    
+
     """
     cdef UnsignedVectorValue val
     cdef unsigned dim
@@ -2327,10 +2327,10 @@ cdef class _pickerBatchExpression(Expression):
         g._inputs.append(self)
     def set_index(self,i):
         """Change the pick indices
-        
+
         This is useful if you want to to change the input and recompute the graph without needing to re-create it. Don't forget to use :code::code:`recalculate=True` when calling :code:`.value()` on the output.
         This allows you to use dynet as a static framework.
-        
+
         Args:
             i(list): New list of indices
         """
@@ -2341,12 +2341,12 @@ def pick_batch(Expression e, vector[unsigned] indices, unsigned dim=0):
     """Batched pick.
 
     Pick elements from multiple batches.
-    
+
     Args:
         e(Expression): Expression to pick from
         indices(list): Indices to pick
         dim(number): Dimension to pick from (default: 0)
-    
+
     Returns:
         _pickerBatchExpression: Picked expression
     """
@@ -2354,17 +2354,17 @@ def pick_batch(Expression e, vector[unsigned] indices, unsigned dim=0):
 
 # }}}
 
-cpdef Expression zeros(dim, int batch_size=1): 
+cpdef Expression zeros(dim, int batch_size=1):
     """Create an input full of zeros
-    
+
     Create an input full of zeros, sized according to dimensions :code:`dim`
-    
+
     Args:
         dim (tuple, int): Dimension of the tensor
-    
+
     Keyword Arguments:
         batch_size (number): Batch size of the tensor (default: (1))
-    
+
     Returns:
         dynet.Expression: A :code:`d` dimensioned zero tensor
     """
@@ -2373,101 +2373,101 @@ cpdef Expression zeros(dim, int batch_size=1):
 cpdef Expression zeroes(dim, int batch_size=1):
     return zeros(dim, batch_size)
 
-cpdef Expression ones(dim, int batch_size=1): 
+cpdef Expression ones(dim, int batch_size=1):
     """Create an input full of ones
-    
+
     Create an input full of ones, sized according to dimensions :code:`dim`
-    
+
     Args:
         dim (tuple, int): Dimension of the tensor
-    
+
     Keyword Arguments:
         batch_size (number): Batch size of the tensor (default: (1))
-    
+
     Returns:
         dynet.Expression: A :code:`d` dimensioned zero tensor
     """
     return Expression.from_cexpr(_cg.version(), c_ones(_cg.thisptr[0], Dim(dim, batch_size)))
 
-cpdef Expression constant(dim, float val, int batch_size=1): 
+cpdef Expression constant(dim, float val, int batch_size=1):
     """Create an input full of :code:`val`
-    
+
     Create an input full of :code:`val`, sized according to dimensions :code:`dim`
-    
+
     Args:
         dim (tuple, int): Dimension of the tensor
         val (number): Value
-    
+
     Keyword Arguments:
         batch_size (number): Batch size of the tensor (default: (1))
-    
+
     Returns:
         dynet.Expression: A :code:`d` dimensioned tensor filled with value :code:`val`
     """
     return Expression.from_cexpr(_cg.version(), c_constant(_cg.thisptr[0], Dim(dim, batch_size), val))
 
-cpdef Expression random_normal(dim, int batch_size=1): 
+cpdef Expression random_normal(dim, int batch_size=1):
     """Create a random normal vector
-    
+
     Create a vector distributed according to normal distribution with mean 0, variance 1.
-    
+
     Args:
         dim (tuple, int): Dimension of the tensor
-    
+
     Keyword Arguments:
         batch_size (number): Batch size of the tensor  (default: (1))
-    
+
     Returns:
         dynet.Expression: A "d" dimensioned normally distributed tensor
     """
     return Expression.from_cexpr(_cg.version(), c_random_normal(_cg.thisptr[0], Dim(dim, batch_size)))
 cpdef Expression random_bernoulli(dim, float p, float scale=1.0, int batch_size=1):
     """Create a random bernoulli tensor
-    
+
     Create a tensor distributed according to bernoulli distribution with parameter :math:`p`.
-    
+
     Args:
         dim (tuple, int): Dimension of the tensor
         p (number): Parameter of the bernoulli distribution
-    
+
     Keyword Arguments:
         scale (number): Scaling factor to apply to the sampled tensor (default: (1.0))
         batch_size (number): Batch size of the tensor (default: (1))
-    
+
     Returns:
         dynet.Expression: A "d" dimensioned bernoulli distributed tensor
     """
     return Expression.from_cexpr(_cg.version(), c_random_bernoulli(_cg.thisptr[0], Dim(dim, batch_size), p, scale))
 cpdef Expression random_uniform(dim, float left, float right, int batch_size=1):
     """Create a random uniform tensor
-    
+
     Create a tensor distributed according to uniform distribution with boundaries left and right.
 
     Args:
         dim (tuple, int): Dimension of the tensor
         left (number): Lower bound of the uniform distribution
         right (number): Upper bound of the uniform distribution
-    
+
     Keyword Arguments:
         batch_size (number): Batch size of the tensor (default: (1))
-    
+
     Returns:
         dynet.Expression: A "d" dimensioned uniform distributed tensor
     """
     return Expression.from_cexpr(_cg.version(), c_random_uniform(_cg.thisptr[0], Dim(dim, batch_size), left, right))
 cpdef Expression random_gumbel(dim, float mu = 0.0, float beta = 1.0, int batch_size=1):
     """Create a random Gumbel sampled vector
-    
+
     Create a vector distributed according to a Gumbel distribution with the specified parameters. (Currently only the defaults of mu=0.0 and beta=1.0 supported.
-    
+
     Args:
         dim (tuple, int): Dimension of the tensor
-    
+
     Keyword Arguments:
         mu (number): The :math:`\mu` parameter (default: (0.0))
         beta (number): The :math:`\\beta` parameter (default: (1.0))
         batch_size (number): Batch size of the tensor (default: (1))
-    
+
     Returns:
         dynet.Expression:  "d" dimensioned Gumbel distributed tensor
     """
@@ -2475,24 +2475,24 @@ cpdef Expression random_gumbel(dim, float mu = 0.0, float beta = 1.0, int batch_
 
 cpdef Expression nobackprop(Expression x):
     """Prevent backprop
-    
+
     This node has no effect on the forward pass, but prevents gradients from flowing backward during the backward pass. This is useful when there's a subgraph for which you don't want loss passed back to the parameters.
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: An output expression containing the same as input (only effects on backprop process)
     """
     return Expression.from_cexpr(x.cg_version, c_nobackprop(x.c()))
 cpdef Expression flip_gradient(Expression x):
     """Negative backprop
-    
+
     This node has no effect on the forward pass, but takes negative on backprop process. This operation is widely used in adversarial networks.
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: An output expression containing the same as input (only effects on backprop process)
     """
@@ -2501,13 +2501,13 @@ cpdef Expression flip_gradient(Expression x):
 # binary-exp
 cpdef Expression cdiv(Expression x, Expression y):
     """Componentwise division
-    
+
     Divide an expressions component-wise by another, broadcasting dimensions (currently only of the second expression!) if necessary as follows:
           - When number of dimensions differ, we add dimensions of size 1 to make the number of dimensions match
           - Now, every dimensions is required to have matching size, or the dim size of the right expression must equal 1 (in which case it will be broadcasted)
           - In the same way, the batch sizes must match, or the batch size of the right expression must equal 1 in which case it will be broadcasted
           - The resulting tensor's dimensionality is thus determined as the max of both inputs at every position
-    
+
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
@@ -2519,13 +2519,13 @@ cpdef Expression cdiv(Expression x, Expression y):
     return Expression.from_cexpr(x.cg_version, c_cdiv(x.c(), y.c()))
 cpdef Expression cmult(Expression x, Expression y):
     """Componentwise multiplication
-    
+
     Multiply two expressions component-wise, broadcasting dimensions if necessary as follows:
           - When number of dimensions differ, we add dimensions of size 1 to make the number of dimensions match
           - Now, every dimensions is required to have matching size, or one of the dimensions must equal 1 (in which case it will be broadcasted)
           - In the same way, the batch dimension must match, or equal 1 in which case it will be broadcasted
           - The resulting tensor's dimensionality is thus determined as the max of both inputs at every position
-    
+
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
@@ -2537,39 +2537,39 @@ cpdef Expression cmult(Expression x, Expression y):
     return Expression.from_cexpr(x.cg_version, c_cmult(x.c(), y.c()))
 cpdef Expression colwise_add(Expression x, Expression y):
     """Columnwise addition
-    
+
     Add vector :math:`y` to each column of matrix :math:`x`
-    
+
     Args:
         x (dynet.Expression): An MxN matrix
         y (dynet.Expression): A length M vector
-    
+
     Returns:
         dynet.Expression: An expression where :math:`y` is added to each column of :math:`x`
     """
     ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_colwise_add(x.c(), y.c()))
 
-cpdef Expression inverse(Expression x): 
+cpdef Expression inverse(Expression x):
     """Matrix Inverse
-    
+
     Takes the inverse of a matrix (not implemented on GPU yet, although contributions are welcome: `issue <https://github.com/clab/dynet/issues/158>`_). Note that back-propagating through an inverted matrix can also be the source of stability problems sometimes.
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: Inverse of x
     """
     return Expression.from_cexpr(x.cg_version, c_inverse(x.c()))
-cpdef Expression logdet(Expression x): 
+cpdef Expression logdet(Expression x):
     """Log determinant
 
     Takes the log of the determinant of a matrix. (not implemented on GPU yet, although contributions are welcome: `issue <https://github.com/clab/dynet/issues/158>`_).
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`\log(\\vert x\\vert)`
     """
@@ -2578,11 +2578,11 @@ cpdef Expression trace_of_product(Expression x, Expression y):
     """Trace of Matrix Product
 
     Takes the trace of the product of matrices. (not implemented on GPU yet, although contributions are welcome: `issue <https://github.com/clab/dynet/issues/158>`_).
-    
+
     Args:
         x (dynet.Expression): The first input expression
         Expression y (dynet.Expression): The second input expression
-    
+
     Returns:
         dynet.Expression: :math:`\\text{Tr}(xy)`
     """
@@ -2590,26 +2590,26 @@ cpdef Expression trace_of_product(Expression x, Expression y):
     return Expression.from_cexpr(x.cg_version, c_trace_of_product(x.c(), y.c()))
 cpdef Expression dot_product(Expression x, Expression y):
     """Dot Product
-    
+
     Calculate the dot product :math:`x^Ty=\sum_i x_iy_i`
-    
+
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Returns:
         dynet.Expression: :math:`x^Ty=\sum_i x_iy_i`
     """
-    ensure_freshness(y); 
+    ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_dot_product(x.c(), y.c()))
 cpdef Expression squared_norm(Expression x):
     """Squared norm
-    
+
     The squared norm of the values of :code:`x`: :math:`\Vert x\Vert_2^2=\sum_i x_i^2`.
 
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`\Vert x\Vert_2^2=\sum_i x_i^2`
     """
@@ -2628,53 +2628,53 @@ cpdef Expression l2_norm(Expression x):
     return Expression.from_cexpr(x.cg_version, c_l2_norm(x.c()))
 cpdef Expression squared_distance(Expression x, Expression y):
     """Squared distance
-    
+
     The squared distance between values of :code:`x` and :code:`y`: :math:`\Vert x-y\Vert_2^2=\sum_i (x_i-y_i)^2`.
-    
+
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Returns:
         dynet.Expression: :math:`\Vert x-y\Vert_2^2=\sum_i (x_i-y_i)^2`
     """
-    ensure_freshness(y); 
+    ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_squared_distance(x.c(), y.c()))
 cpdef Expression l1_distance(Expression x, Expression y):
     """L1 distance
-    
+
     L1 distance between values of :code:`x` and :code:`y`: :math:`\Vert x-y\Vert_1=\sum_i \\vert x_i-y_i\\vert`.
-    
+
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Returns:
         dynet.Expression: :math:`\Vert x-y\Vert_1=\sum_i \\vert x_i-y_i\\vert`.
     """
-    ensure_freshness(y); 
+    ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_l1_distance(x.c(), y.c()))
 cpdef Expression binary_log_loss(Expression x, Expression y):
     """Binary log loss
-    
+
     The log loss of a binary decision according to the sigmoid sigmoid function :math:`- \sum_i (y_i  \ln(x_i) + (1-y_i)  \ln(1-x_i))`
-    
+
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Returns:
         dynet.Expression: :math:`- \sum_i (y_i  \ln(x_i) + (1-y_i)  \ln(1-x_i))`
     """
-    ensure_freshness(y); 
+    ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_binary_log_loss(x.c(), y.c()))
 #cpdef Expression conv1d_narrow(Expression x, Expression y): ensure_freshness(y); return Expression.from_cexpr(x.cg_version, c_conv1d_narrow(x.c(), y.c()))
 #cpdef Expression conv1d_wide(Expression x, Expression y): ensure_freshness(y); return Expression.from_cexpr(x.cg_version, c_conv1d_wide(x.c(), y.c()))
-cpdef Expression filter1d_narrow(Expression x, Expression y): 
+cpdef Expression filter1d_narrow(Expression x, Expression y):
     """[summary]
-    
+
     [description]
-    
+
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
@@ -2682,107 +2682,107 @@ cpdef Expression filter1d_narrow(Expression x, Expression y):
     Returns:
         dynet.Expression: TODO
     """
-    ensure_freshness(y); 
+    ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_filter1d_narrow(x.c(), y.c()))
-cpdef Expression conv2d(Expression x, Expression f, vector[unsigned] stride, bool is_valid = True): 
+cpdef Expression conv2d(Expression x, Expression f, vector[unsigned] stride, bool is_valid = True):
     """2D convolution without bias
-    
+
     2D convolution operator without bias parameters.
     :code:`VALID` and :code:`SAME` convolutions are supported.
-    
+
     Think about when stride is 1, the distinction:
-    
+
     - :code:`SAME`: output size is the same with input size. To do so, one needs to pad the input so the filter can sweep outside of the input maps.
     - :code:`VALID`: output size shrinks by :code:`filter_size - 1`, and the filters always sweep at valid positions inside the input maps. No padding needed.
 
     In detail, assume
-    
+
     - Input feature maps: :code:`XH x XW x XC x N`
     - Filters: :code:`FH x FW x XC x FC`
     - Strides: :code:`strides[0]` and :code:`strides[1]` are row (:code:`h`) and col (:code:`w`) stride, respectively.
- 
+
     For the :code:`SAME` convolution: the output height (:code:`YH`) and width (:code:`YW`) are computed as:
-    
+
     - :code:`YH = ceil(float(XH) / float(strides[0]))`
     - :code:`YW = ceil(float(XW) / float(strides[1]))`
-    
+
     and the paddings are computed as:
-    
+
     - :code:`pad_along_height = max((YH - 1) * strides[0] + FH - XH, 0)`
     - :code:`pad_along_width = max((YW - 1) * strides[1] + FW - XW, 0)`
     - :code:`pad_top = pad_along_height / 2`
     - :code:`pad_bottom = pad_along_height - pad_top`
     - :code:`pad_left = pad_along_width / 2`
     - :code:`pad_right = pad_along_width - pad_left`
- 
+
     For the :code:`VALID` convolution: the output height (:code`YH`) and width (:code:`YW`) are computed as:
-    
+
     - :code:`YH = ceil(float(XH - FH + 1) / float(strides[0]))`
     - :code:`YW = ceil(float(XW - FW + 1) / float(strides[1]))`
-    
+
     and the paddings are always zeros.
-    
+
     Args:
         x (dynet.Expression): The input feature maps: (H x W x Ci) x N (ColMaj), 3D tensor with an optional batch dimension
         f (dynet.Expression): 2D convolution filters: H x W x Ci x Co (ColMaj), 4D tensor
         stride (list): the row and column strides
-    
+
     Keyword Arguments:
         is_valid (bool): 'VALID' convolution or 'SAME' convolution, default is True ('VALID') (default: (True))
-    
+
     Returns:
         dynet.Expression: The output feature maps (H x W x Co) x N, 3D tensor with an optional batch dimension
     """
-    ensure_freshness(f); 
+    ensure_freshness(f);
     return Expression.from_cexpr(x.cg_version, c_conv2d(x.c(), f.c(), stride, is_valid))
 
 cpdef Expression conv2d_bias(Expression x, Expression f, Expression b, vector[unsigned] stride, bool is_valid = True):
     """2D convolution with bias
-    
+
     2D convolution operator with bias parameters.
     :code:`VALID` and :code:`SAME` convolutions are supported.
-    
+
     Think about when stride is 1, the distinction:
-    
+
     - :code:`SAME`: output size is the same with input size. To do so, one needs to pad the input so the filter can sweep outside of the input maps.
     - :code:`VALID`: output size shrinks by :code:`filter_size - 1`, and the filters always sweep at valid positions inside the input maps. No padding needed.
 
     In detail, assume
-    
+
     - Input feature maps: :code:`XH x XW x XC x N`
     - Filters: :code:`FH x FW x XC x FC`
     - Strides: :code:`strides[0]` and :code:`strides[1]` are row (:code:`h`) and col (:code:`w`) stride, respectively.
- 
+
     For the :code:`SAME` convolution: the output height (:code:`YH`) and width (:code:`YW`) are computed as:
-    
+
     - :code:`YH = ceil(float(XH) / float(strides[0]))`
     - :code:`YW = ceil(float(XW) / float(strides[1]))`
-    
+
     and the paddings are computed as:
-    
+
     - :code:`pad_along_height = max((YH - 1) * strides[0] + FH - XH, 0)`
     - :code:`pad_along_width = max((YW - 1) * strides[1] + FW - XW, 0)`
     - :code:`pad_top = pad_along_height / 2`
     - :code:`pad_bottom = pad_along_height - pad_top`
     - :code:`pad_left = pad_along_width / 2`
     - :code:`pad_right = pad_along_width - pad_left`
- 
+
     For the :code:`VALID` convolution: the output height (:code`YH`) and width (:code:`YW`) are computed as:
-    
+
     - :code:`YH = ceil(float(XH - FH + 1) / float(strides[0]))`
     - :code:`YW = ceil(float(XW - FW + 1) / float(strides[1]))`
-    
+
     and the paddings are always zeros.
-    
+
     Args:
         x (dynet.Expression): The input feature maps: (H x W x Ci) x N (ColMaj), 3D tensor with an optional batch dimension
         f (dynet.Expression): 2D convolution filters: H x W x Ci x Co (ColMaj), 4D tensor
         b (dynet.Expression): The bias (1D: Ci)
         stride (list): the row and column strides
-    
+
     Keyword Arguments:
         is_valid (bool): 'VALID' convolution or 'SAME' convolution, default is True ('VALID') (default: (True))
-    
+
     Returns:
         dynet.Expression: The output feature maps (H x W x Co) x N, 3D tensor with an optional batch dimension
     """
@@ -2790,188 +2790,188 @@ cpdef Expression conv2d_bias(Expression x, Expression f, Expression b, vector[un
     ensure_freshness(b)
     return Expression.from_cexpr(x.cg_version, c_conv2d(x.c(), f.c(), b.c(), stride, is_valid))
 
-cpdef Expression maxpooling2d(Expression x, vector[unsigned] ksize, vector[unsigned] stride, bool is_valid = True): 
+cpdef Expression maxpooling2d(Expression x, vector[unsigned] ksize, vector[unsigned] stride, bool is_valid = True):
     """2D maxpooling
-    
+
     2D maxpooling operator.
     :code:`VALID` and :code:`SAME` maxpooling are supported.
-    
+
     Args:
         x (dynet.Expression): The input feature maps: (H x W x Ci) x N (ColMaj), 3D tensor with an optional batch dimension
-        ksize (list): the max pooling 2d window size 
+        ksize (list): the max pooling 2d window size
         stride (list): the row and column strides
-    
+
     Keyword Arguments:
         is_valid (bool): 'VALID' or 'SAME', default is True ('VALID') (default: (True))
-    
+
     Returns:
         dynet.Expression: The output feature maps (H x W x Co) x N, 3D tensor with an optional batch dimension
     """
     return Expression.from_cexpr(x.cg_version, c_maxpooling2d(x.c(), ksize, stride, is_valid))
 
 # unary-exp
-cpdef Expression tanh(Expression x): 
+cpdef Expression tanh(Expression x):
     """Hyperbolic tangent
-    
+
     Elementwise calculation of the hyperbolic tangent
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`\\tanh(x)`
     """
     return Expression.from_cexpr(x.cg_version, c_tanh(x.c()))
-cpdef Expression exp(Expression x): 
+cpdef Expression exp(Expression x):
     """Natural exponent
-    
+
     Calculate elementwise :math:`y_i = e^{x_i}`
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`e^{x}`
     """
     return Expression.from_cexpr(x.cg_version, c_exp(x.c()))
-cpdef Expression square(Expression x): 
+cpdef Expression square(Expression x):
     """Square
-    
+
     Calculate elementwise :math:`y_i = x_i^2`
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y = x^2`
     """
     return Expression.from_cexpr(x.cg_version, c_square(x.c()))
-cpdef Expression sqrt(Expression x): 
+cpdef Expression sqrt(Expression x):
     """Square root
-    
+
     Calculate elementwise :math:`y_i = \sqrt{x_i}`
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y = \sqrt{x}`
     """
     return Expression.from_cexpr(x.cg_version, c_sqrt(x.c()))
 
-cpdef Expression abs(Expression x): 
+cpdef Expression abs(Expression x):
     """Absolute value
-    
+
     Calculate elementwise :math:`y_i = \\vert x_i\\vert`
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y = \\vert x\\vert`
     """
     return Expression.from_cexpr(x.cg_version, c_abs(x.c()))
 
-cpdef Expression erf(Expression x): 
+cpdef Expression erf(Expression x):
     """Gaussian error function
 
     Elementwise calculation of the Gaussian error function :math:`y_i = \\text{erf}(x_i)=\\frac {1}{\sqrt{\pi}}\int_{-x_i}^{x_i}e^{-t^2}\mathrm{d}t`
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y_i = \\text{erf}(x_i)`
     """
     return Expression.from_cexpr(x.cg_version, c_erf(x.c()))
-cpdef Expression cube(Expression x): 
+cpdef Expression cube(Expression x):
     """cube
-    
+
     Calculate elementwise :math:`y_i = x_i^3`
 
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y = x^3`
     """
     return Expression.from_cexpr(x.cg_version, c_cube(x.c()))
-cpdef Expression log(Expression x): 
+cpdef Expression log(Expression x):
     """Natural logarithm
-    
+
     Elementwise calculation of the natural logarithm :math:`y_i = \ln(x_i)`
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y_i = \ln(x_i)`
     """
     return Expression.from_cexpr(x.cg_version, c_log(x.c()))
-cpdef Expression lgamma(Expression x): 
+cpdef Expression lgamma(Expression x):
     """Log gamma
-    
+
     Calculate elementwise log gamma function :math:`y_i = \ln(\Gamma(x_i))`
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y_i = \ln(\Gamma(x_i))`
     """
     return Expression.from_cexpr(x.cg_version, c_lgamma(x.c()))
-cpdef Expression logistic(Expression x): 
+cpdef Expression logistic(Expression x):
     """Logistic sigmoid function
-    
+
     Calculate elementwise :math:`y_i = \\frac{1}{1+e^{-x_i}}`
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y_i = \\frac{1}{1+e^{-x_i}}`
     """
     return Expression.from_cexpr(x.cg_version, c_logistic(x.c()))
 
-cpdef Expression rectify(Expression x): 
+cpdef Expression rectify(Expression x):
     """Rectifier (or ReLU, Rectified Linear Unit)
-    
+
     Calculate elementwise recitifer (ReLU) function :math:`y_i = \max(x_i,0)`
 
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y_i = \max(x_i,0)`
     """
     return Expression.from_cexpr(x.cg_version, c_rectify(x.c()))
 
-cpdef Expression elu(Expression x, float alpha=1.0): 
+cpdef Expression elu(Expression x, float alpha=1.0):
     """Exponential Linear Unit (ELU)
 
-    Calculate elementwise the function 
+    Calculate elementwise the function
 
     .. math::
         y_i = \left\{\\begin{array}{lr}
                    x_i, & \\text{if } x>0\\\\
                    \\alpha\\times(e^{x_i} - 1), & \\text{if }x\leqslant 0
                  \end{array}\\right.
-        
+
     Reference: `Clevert et al., 2015 <https://arxiv.org/abs/1511.07289v5>`_
- 
+
     Args:
         x (dynet.Expression): Input expression
         alpha (number): :math:`\\alpha` parameter
-    
+
     Returns:
         dynet.Expression: :math:`\\text{ELU}(x_i, \\alpha)`
     """
     return Expression.from_cexpr(x.cg_version, c_elu(x.c(), alpha))
 
-cpdef Expression selu(Expression x): 
+cpdef Expression selu(Expression x):
     """Scaled Exponential Linear Unit (SELU)
 
-    Calculate elementwise the function 
+    Calculate elementwise the function
 
     .. math::
         y_i = \lambda\\times\left\{
@@ -2989,26 +2989,26 @@ cpdef Expression selu(Expression x):
         \end{split}
 
     Reference: `Klambaouer et al., 2017 <https://arxiv.org/abs/1706.02515>`_
- 
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`\\text{SELU}(x_i)`
     """
     return Expression.from_cexpr(x.cg_version, c_selu(x.c()))
 
-cpdef Expression silu(Expression x, float beta=1.0): 
+cpdef Expression silu(Expression x, float beta=1.0):
     """SILU / SiL / Swish
 
     Calculate elementwise :math:`y_i = \\frac{x_i}{1+e^{-beta * x_i}}`
-        
+
     Reference: `Hendrycks and Gimpel, 2016 <https://openreview.net/pdf?id=Bk0MRI5lg>`_, `Elfwing et al, 2017 <https://arxiv.org/pdf/1702.03118.pdf>`, and `Ramachandran et al., 2017 <https://arxiv.org/pdf/1710.05941>`_,
- 
+
     Args:
         x (dynet.Expression): Input expression
         beta (number): :math:`\\beta` parameter
-    
+
     Returns:
         dynet.Expression: :math:`\\text{silu}(x_i, \\beta)`
     """
@@ -3016,15 +3016,15 @@ cpdef Expression silu(Expression x, float beta=1.0):
 
 cpdef Expression log_softmax(Expression x, list restrict=None):
     """Restricted log softmax
-    
+
     The log softmax function calculated over only a subset of the vector elements. The elements to be included are set by the :code:`restriction` variable. All elements not included in :code:`restriction` are set to negative infinity.
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Keyword Arguments:
         restrict (list): List of log softmax to compute (default: (None))
-    
+
     Returns:
         dynet.Expression: A vector with the log softmax over the specified elements
     """
@@ -3035,13 +3035,13 @@ cpdef Expression log_softmax(Expression x, list restrict=None):
 
 cpdef Expression softmax(Expression x, unsigned d=0):
     """Softmax
-    
+
     The softmax function normalizes each column to ensure that all values are between 0 and 1 and add to one by applying the :math:`\\frac{e^{x_i}}{sum_j e^{x_j}}`.
-    
+
     Args:
         x (dynet.Expression): Input expression
         d (int): Dimension to normalize over
-    
+
     Returns:
         dynet.Expression: :math:`\\frac{e^{x_i}}{\sum_j e^{x_j}}`
     """
@@ -3049,12 +3049,12 @@ cpdef Expression softmax(Expression x, unsigned d=0):
 
 cpdef Expression sparsemax(Expression x):
     """Sparsemax
-    
+
     The sparsemax function (Martins et al. 2016), which is similar to softmax, but induces sparse solutions where most of the vector elements are zero. **Note:** This function is not yet implemented on GPU.
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: The sparsemax of the scores
     """
@@ -3067,7 +3067,7 @@ cpdef Expression softsign(Expression x):
 
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: :math:`y_i = \\frac{x_i}{1+\\vert x_i\\vert}`
     """
@@ -3075,60 +3075,60 @@ cpdef Expression softsign(Expression x):
 
 cpdef Expression pow(Expression x, Expression y):
     """Power function
-    
+
     Calculate an output where the ith element is equal to :math:`x_i^{y_i}`
 
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Returns:
         dynet.Expression: :math:`x_i^{y_i}`
     """
-    ensure_freshness(y); 
+    ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_pow(x.c(), y.c()))
 
 cpdef Expression bmin(Expression x, Expression y):
     """Minimum
-    
+
     Calculate an output where the ith element is :math:`\min(x_i,y_i)`
 
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Returns:
         dynet.Expression: :math:`\min(x_i,y_i)`
     """
-    ensure_freshness(y); 
+    ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_bmin(x.c(), y.c()))
 
 cpdef Expression bmax(Expression x, Expression y):
     """Maximum
-    
+
     Calculate an output where the ith element is :math:`\max(x_i,y_i)`
 
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Returns:
         dynet.Expression: :math:`\max(x_i,y_i)`
     """
-    ensure_freshness(y); 
+    ensure_freshness(y);
     return Expression.from_cexpr(x.cg_version, c_bmax(x.c(), y.c()))
 
 cpdef Expression transpose(Expression x, list dims=[1, 0]):
     """Transpose a matrix
-    
+
     Get the transpose of the matrix, or if dims is specified shuffle the dimensions arbitrarily.
 
     **Note:** This is O(1) if either the row or column dimension is 1, and O(n) otherwise.
-    
+
     Args:
         x (dynet.Expression): Input expression
         dims (list): The dimensions to swap. The ith dimension of the output will be equal to the dims[i] dimension of the input. dims must have the same number of dimensions as x.
-    
+
     Returns:
         dynet.Expression: :math:`x^T` / the shuffled expression
     """
@@ -3142,8 +3142,8 @@ cpdef Expression select_rows(Expression x, vector[unsigned] rs):
 
     Args:
         x (dynet.Expression): Input expression
-        rs (list): The rows to extract 
-    
+        rs (list): The rows to extract
+
     Returns:
         dynet.Expression: An expression containing the selected rows
     """
@@ -3156,8 +3156,8 @@ cpdef Expression select_cols(Expression x, vector[unsigned] cs):
 
     Args:
         x (dynet.Expression): Input expression
-        cs (list): The columns to extract 
-    
+        cs (list): The columns to extract
+
     Returns:
         dynet.Expression: An expression containing the selected columns
     """
@@ -3165,12 +3165,12 @@ cpdef Expression select_cols(Expression x, vector[unsigned] cs):
 
 cpdef Expression sum_elems(Expression x):
     """Sum all elements
-    
+
     Sum all the elements in an expression.
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: The sum of all of its elements
     """
@@ -3178,7 +3178,7 @@ cpdef Expression sum_elems(Expression x):
 
 cpdef Expression sum_dim(Expression x, list d, bool b=False, unsigned n=0):
     """Mean along an arbitrary dimension
-    
+
     Computes the sum :math:`\sum_ix_i`  along an arbitrary dimension or dimensions.
 
 
@@ -3186,7 +3186,7 @@ cpdef Expression sum_dim(Expression x, list d, bool b=False, unsigned n=0):
         x (dynet.Expression): Input expression
         d (list): Dimensions along which to reduce
         b (bool): Whether to include batch dimension
-    
+
     Returns:
         dynet.Expression: An expression with |d| less dimensions and possibly dropped batch dimension
     """
@@ -3194,12 +3194,12 @@ cpdef Expression sum_dim(Expression x, list d, bool b=False, unsigned n=0):
 
 cpdef Expression sum_batches(Expression x):
     """Sum over minibatches
-    
+
     Sum an expression that consists of multiple minibatches into one of equal dimension but with only a single minibatch. This is useful for summing loss functions at the end of minibatch training.
 
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: An expression with a single batch
     """
@@ -3207,11 +3207,11 @@ cpdef Expression sum_batches(Expression x):
 
 cpdef Expression mean_elems(Expression x):
     """Mean of elements of the tensor
-    
+
     Computes the mean :math:`\\frac 1 n \sum_ix_i` of all the elements of each minibatch.
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: A scalar expression (minibatched)
     """
@@ -3219,7 +3219,7 @@ cpdef Expression mean_elems(Expression x):
 
 cpdef Expression mean_dim(Expression x, list d, bool b, unsigned n=0):
     """Mean along an arbitrary dimension
-    
+
     Computes the mean :math:`\\frac 1 n \sum_ix_i`  along an arbitrary dimension.
 
 
@@ -3228,7 +3228,7 @@ cpdef Expression mean_dim(Expression x, list d, bool b, unsigned n=0):
         d (list): Dimensions along which to reduce
         b (bool): Whether to include batch dimension
         n (int): If > 0, overwrite the n in the equation by this value, useful for masking
-    
+
     Returns:
         dynet.Expression: An expression with |d| less dimensions and possibly dropped batch dimension
     """
@@ -3236,11 +3236,11 @@ cpdef Expression mean_dim(Expression x, list d, bool b, unsigned n=0):
 
 cpdef Expression mean_batches(Expression x):
     """Mean along the batch dimension
-    
+
     Computes the mean :math:`\\frac 1 n \sum_ix_i`  along the batch dimension.
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: An expression with a single batch
     """
@@ -3248,11 +3248,11 @@ cpdef Expression mean_batches(Expression x):
 
 cpdef Expression std_elems(Expression x):
     """Standard deviation of elements of the tensor
-    
+
     Computes the standard deviation :math:`\sigma=\sqrt{\\frac 1 n \sum_i(x_i-\mu)^2}` of all the elements of each minibatch.
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: A scalar expression (minibatched)
     """
@@ -3260,7 +3260,7 @@ cpdef Expression std_elems(Expression x):
 
 cpdef Expression std_dim(Expression x, list d, bool b, unsigned n=0):
     """Standard deviation along an arbitrary dimension
-    
+
     Computes the standard deviation :math:`\sigma=\sqrt{\\frac 1 n \sum_i(x_i-\mu)^2}` along arbitrary dimensions.
 
     Args:
@@ -3268,7 +3268,7 @@ cpdef Expression std_dim(Expression x, list d, bool b, unsigned n=0):
         d (int): Dimensions along which to reduce
         b (bool): Whether to include batch dimension
         n (int): If > 0, overwrite the n in the equation by this value, useful for masking
-    
+
     Returns:
         dynet.Expression: An expression with |d| less dimensions and possibly dropped batch dimension
     """
@@ -3276,11 +3276,11 @@ cpdef Expression std_dim(Expression x, list d, bool b, unsigned n=0):
 
 cpdef Expression std_batches(Expression x):
     """Standard deviation along the batch dimension
-    
+
     Computes the standard deviation :math:`\sigma=\sqrt{\\frac 1 n \sum_i(x_i-\mu)^2}`  along the batch dimension.
     Args:
         x (dynet.Expression): Input expression
-    
+
     Returns:
         dynet.Expression: An expression with a single batch
     """
@@ -3288,12 +3288,12 @@ cpdef Expression std_batches(Expression x):
 
 cpdef Expression moment_elems(Expression x, unsigned r):
     """Statistical moment of elements of the tensor
-    
+
     Computes the statistical moment of order :math:`r`, :math:`\\frac 1 n \sum_ix_i^r` of all the elements of each minibatch.
     Args:
         x (dynet.Expression): Input expression
         r (int): Moment order
-    
+
     Returns:
         dynet.Expression: A scalar expression (minibatched)
     """
@@ -3301,7 +3301,7 @@ cpdef Expression moment_elems(Expression x, unsigned r):
 
 cpdef Expression moment_dim(Expression x, list d, unsigned r, bool b, unsigned n=0):
     """Statistical moment along an arbitrary dimension
-    
+
     Computes the statistical moment of order :math:`r`, :math:`\\frac 1 n \sum_ix_i^r`  along an arbitrary dimension.
 
 
@@ -3311,7 +3311,7 @@ cpdef Expression moment_dim(Expression x, list d, unsigned r, bool b, unsigned n
         r (int): Moment order
         b (bool): Whether to include batch dimension
         n (int): If > 0, overwrite the n in the equation by this value, useful for masking
-    
+
     Returns:
         dynet.Expression: An expression with |d| less dimensions and possibly dropped batch dimension
     """
@@ -3319,12 +3319,12 @@ cpdef Expression moment_dim(Expression x, list d, unsigned r, bool b, unsigned n
 
 cpdef Expression moment_batches(Expression x, unsigned r):
     """Statistical moment along the batch dimension
-    
+
     Computes the statistical moment of order :math:`r`, :math:`\\frac 1 n \sum_ix_i^r`  along the batch dimension.
     Args:
         x (dynet.Expression): Input expression
         r (int): Moment order
-    
+
     Returns:
         dynet.Expression: An expression with a single batch
     """
@@ -3333,17 +3333,17 @@ cpdef Expression moment_batches(Expression x, unsigned r):
 #expr-opt
 cpdef Expression fold_rows(Expression x, unsigned nrows=2):
     """[summary]
-    
+
     [description]
-    
+
     Args:
-        x (dynet.Expression): 
-    
+        x (dynet.Expression):
+
     Keyword Arguments:
         unsigned nrows {number}:  (default: (2))
-    
+
     Returns:
-        dynet.Expression: 
+        dynet.Expression:
     """
     return Expression.from_cexpr(x.cg_version, c_fold_rows(x.c(),nrows))
 #expr-expr-opt
@@ -3352,16 +3352,16 @@ cpdef Expression fold_rows(Expression x, unsigned nrows=2):
 # res = max(0, m - x + y)
 cpdef Expression pairwise_rank_loss(Expression x, Expression y, float m=1.0):
     """Pairwise rank loss
-    
+
     A margin-based loss, where every margin violation for each pair of values is penalized: :math:`\sum_i \max(m - x_i + y_i, 0)`
-    
+
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Keyword Arguments:
         m (number): The margin (default: (1.0))
-    
+
     Returns:
         dynet.Expression: The pairwise rank loss
     """
@@ -3369,20 +3369,20 @@ cpdef Expression pairwise_rank_loss(Expression x, Expression y, float m=1.0):
     return Expression.from_cexpr(x.cg_version, c_pairwise_rank_loss(x.c(), y.c(), m))
 cpdef Expression poisson_loss(Expression log_lambda, unsigned x):
     """Poisson loss
-    
+
     The negative log probability of :code:`x` according to a Poisson distribution with parameter :math:`\exp` :code:`log_lambda`. Useful in Poisson regression where, we try to predict the parameters of a Possion distribution to maximize the probability of data :code:`x`.
-    
+
     Args:
         log_lambda (dynet.Expression): The log of the Poisson distribution's lambda
         x (int): The target value
-    
+
     Returns:
         dynet.Expression: The Poisson loss
     """
     return Expression.from_cexpr(log_lambda.cg_version, c_poisson_loss(log_lambda.c(), x))
 cpdef Expression huber_distance(Expression x, Expression y, float c=1.345):
     """Huber distance
-    
+
     The huber distance between values of :code:`x` and :code:`y` parameterized by :code:`c`, :math:`\sum_i L_c(x_i, y_i)` where:
 
     .. math::
@@ -3395,10 +3395,10 @@ cpdef Expression huber_distance(Expression x, Expression y, float c=1.345):
     Args:
         x (dynet.Expression): The first input expression
         y (dynet.Expression): The second input expression
-    
+
     Keyword Arguments:
         c (number): The parameter of the huber distance parameterizing the cuttoff (default: (1.345))
-    
+
     Returns:
         dynet.Expression: The huber distance
     """
@@ -3407,77 +3407,77 @@ cpdef Expression huber_distance(Expression x, Expression y, float c=1.345):
 #expr-unsigned
 cpdef Expression kmax_pooling(Expression x, unsigned k, unsigned d=1):
     """Kmax-pooling operation
-    
+
     Select out k maximum values along a given dimension, in the same order as they appear. This will result in the size of the given dimension being changed to k.
-    
+
     Args:
-        x (dynet.Expression): 
+        x (dynet.Expression):
         unsigned k (dynet.Expression): Number of maximum values to retrieve along the given dimension
 
     Keyword Arguments:
         unsigned d (int): Dimension on which to perform kmax-pooling (default: (1))
-    
+
     Returns:
-        dynet.Expression: 
+        dynet.Expression:
     """
     return Expression.from_cexpr(x.cg_version, c_kmax_pooling(x.c(), k, d))
 cpdef Expression pickneglogsoftmax(Expression x, unsigned v):
     """Negative softmax log likelihood
-    
+
     This function takes in a vector of scores  :code:`x`, and performs a log softmax, takes the negative, and selects the likelihood corresponding to the element :code:`v`. This is perhaps the most standard loss function for training neural networks to predict one out of a set of elements.
 
     Args:
         x (dynet.Expression): Input scores
         v (int): True class
-    
+
     Returns:
         dynet.Expression: :math:`-\log\left(\\frac{e^{x_v}}{\sum_j e^{x_j}}\\right)`
     """
     return Expression.from_cexpr(x.cg_version, c_pickneglogsoftmax(x.c(), v))
 cpdef Expression pickneglogsoftmax_batch(Expression x, vector[unsigned] vs):
     """Negative softmax log likelihood on a batch
-    
+
     This function takes in a batched vector of scores :code:`x`, and performs a log softmax, takes the negative, and selects the likelihood corresponding to the elements :code:`vs`. This is perhaps the most standard loss function for training neural networks to predict one out of a set of elements.
-    
+
     Args:
         x (dynet.Expression): Input scores
         v (list): True classes
-    
+
     Returns:
         dynet.Expression: :math:`-\sum_{v\in \\texttt{vs}}\log\left(\\frac{e^{x_v}}{\sum_j e^{x_j}}\\right)`
     """
     return Expression.from_cexpr(x.cg_version, c_pickneglogsoftmax(x.c(), vs))
 cpdef Expression hinge(Expression x, unsigned v, float m=1.0):
     """Hinge loss
-    
+
     This function takes in a vector of scores  :code:`x`, and calculates a hinge loss such that the element :code:`v` must be greater than all other elements by at least :code:`m`, otherwise a loss is incurred.
 
     Args:
         x (dynet.Expression): Input scores
         v (int): True class
         m (float): The margin
-    
+
     Returns:
         dynet.Expression: :math:`\\sum_{\\tilde{v} != v} max(x_{\\tilde{v}} - x_v + m, 0)`
     """
     return Expression.from_cexpr(x.cg_version, c_hinge(x.c(), v, m))
 cpdef Expression hinge_batch(Expression x, vector[unsigned] vs, float m=1.0):
     """Hinge loss on a batch
-    
+
     This function takes in a batched vector of scores  :code:`xs`, and calculates a hinge loss such that the elements :code:`vs` must be greater than all other elements by at least :code:`m`, otherwise a loss is incurred.
-    
+
     Args:
         x (dynet.Expression): Input scores
         v (list): True classes
         m (float): The margin
-    
+
     Returns:
         dynet.Expression: The batched hinge loss function
     """
     return Expression.from_cexpr(x.cg_version, c_hinge(x.c(), vs, m))
 cpdef Expression hinge_dim(Expression x, vector[unsigned] v, unsigned d=0, float m=1.0):
     """Dimensionwise hinge loss
-    
+
     This function takes in a matrix of scores  :code:`x`, and calculates a hinge loss such that the elements :code:`v` must be greater than all other elements in dimension :code:`d` by at least :code:`m`, otherwise a loss is incurred.
 
     Args:
@@ -3485,22 +3485,22 @@ cpdef Expression hinge_dim(Expression x, vector[unsigned] v, unsigned d=0, float
         v (list): True classes (size of the non-:code:`d` dimension)
         d (int): Dimension over which to perform the hinge loss
         m (float): The margin
-    
+
     Returns:
         dynet.Expression: Containing a vector of losses the size of the non-:code:`d` dimension
     """
     return Expression.from_cexpr(x.cg_version, c_hinge_dim(x.c(), v, d, m))
 # cpdef Expression hinge_dim_batch(Expression x, vector[vector[unsigned]] vs, unsigned d=0, float m=1.0):
 #     """Dimensionwise hinge loss on a batch
-#     
+#
 #     The batched version of :code:`hinge_dim`, where we pass in a list of lists of IDs :code:`v`, where each list corresponds to the IDs for one batch.
-#     
+#
 #     Args:
 #         x (dynet.Expression): Input scores
 #         v (list[list]): True classes
 #         d (int): Dimension over which to perform the hinge loss
 #         m (float): The margin
-#     
+#
 #     Returns:
 #         dynet.Expression: The batched hinge_dim loss function
 #     """
@@ -3509,28 +3509,28 @@ cpdef Expression hinge_dim(Expression x, vector[unsigned] v, unsigned d=0, float
 
 cpdef Expression kmh_ngram(Expression x, unsigned v):
     """[summary]
-    
+
     [description]
-    
+
     Args:
-        x (dynet.Expression): 
-        v (dynet.Expression): 
-    
+        x (dynet.Expression):
+        v (dynet.Expression):
+
     Returns:
-        dynet.Expression: 
+        dynet.Expression:
     """
     return Expression.from_cexpr(x.cg_version, c_kmh_ngram(x.c(), v))
 cpdef Expression pick_range(Expression x, unsigned s, unsigned e, unsigned d = 0):
     """Pick range of elements
-    
+
     Pick a range of elements from an expression.
-    
+
     Args:
         x (dynet.Expression): input expression
         s (int): Start index
         e (int): End index
         d (int): Dimension along which to pick
-    
+
     Returns:
         dynet.Expression: The value of {x[v],...,x[u]} along the dimension
     """
@@ -3566,11 +3566,11 @@ cpdef Expression pick_batch_elem(Expression x, unsigned v):
             x_{2,1,1} & x_{2,1,2} \\\\
             x_{2,2,1} & x_{2,2,2} \\\\
         \end{pmatrix}
-    
+
     Args:
         x (dynet.Expression): Input expression
         v (int): The index of the batch element to be picked.
-    
+
     Returns:
         dynet.Expression: The expression of picked batch element. The picked element is a tensor whose batch dimension equals to one.
     """
@@ -3607,12 +3607,12 @@ cpdef Expression pick_batch_elems(Expression x, vector[unsigned] vs):
             x_{3,1,1} & x_{3,1,2} \\\\
             x_{3,2,1} & x_{3,2,2} \\\\
         \end{pmatrix}
-    
-    
+
+
     Args:
         x (dynet.Expression): Input expression
         vs (list): A list of indices of the batch elements to be picked.
-    
+
     Returns:
         dynet.Expression: The expression of picked batch elements. The batch elements is a tensor whose batch dimension equals to the size of list `v`.
     """
@@ -3620,13 +3620,13 @@ cpdef Expression pick_batch_elems(Expression x, vector[unsigned] vs):
 #expr-float
 cpdef Expression noise(Expression x, float stddev):
     """Additive gaussian noise
-    
+
     Add gaussian noise to an expression.
-    
+
     Args:
         x (dynet.Expression): Input expression
         stddev (number): The standard deviation of the gaussian
-    
+
     Returns:
         dynet.Expression: :math:`y\sim\mathcal N(x,\\texttt{stddev})`
     """
@@ -3634,33 +3634,33 @@ cpdef Expression noise(Expression x, float stddev):
 
 cpdef Expression dropout(Expression x, float p):
     """Dropout
-    
-    With a fixed probability, drop out (set to zero) nodes in the input expression, and **scale** the remaining nodes by 1/p. Note that there are `two kinds of dropout <http://cs231n.github.io/neural-networks-2/#reg>`_: 
 
-    - *Regular dropout:* where we perform dropout at training time and then scale outputs by p at test time. 
-    - *Inverted dropout:* where we perform dropout and scaling at training time, and do not need to do anything at test time. 
+    With a fixed probability, drop out (set to zero) nodes in the input expression, and **scale** the remaining nodes by 1/p. Note that there are `two kinds of dropout <http://cs231n.github.io/neural-networks-2/#reg>`_:
+
+    - *Regular dropout:* where we perform dropout at training time and then scale outputs by p at test time.
+    - *Inverted dropout:* where we perform dropout and scaling at training time, and do not need to do anything at test time.
 
     DyNet implements the latter, so you only need to apply dropout at training time, and do not need to perform scaling and test time.
-    
+
     Args:
         x (dynet.Expression): Input expression
         p (number): The dropout probability
-    
+
     Returns:
         dynet.Expression: The dropped out expression :math:`y=\\frac{1}{1-\\texttt{p}}x\circ z, z\sim\\text{Bernoulli}(1-\\texttt{p})`
     """
     return Expression.from_cexpr(x.cg_version, c_dropout(x.c(), p))
 
-    
+
 cpdef Expression dropout_batch(Expression x, float p):
     """Dropout entire elements of a minibatch
-    
+
     Identical to the dropout operation except entire batch elements are dropped
 
     Args:
         x (dynet.Expression): Input expression
         p (number): The dropout probability
-    
+
     Returns:
         dynet.Expression: The dropped expression
     """
@@ -3668,8 +3668,8 @@ cpdef Expression dropout_batch(Expression x, float p):
 
 cpdef Expression dropout_dim(Expression x, unsigned d, float p):
     """Dropout along one dimension
-    
-    Identical to the dropout operation except the dropout mask is the same across one dimension. Use this if you want to drop columns or lines in a matrix for example 
+
+    Identical to the dropout operation except the dropout mask is the same across one dimension. Use this if you want to drop columns or lines in a matrix for example
 
     For now this only supports tensors of order <= 3 (with or without batch dimension)
 
@@ -3677,7 +3677,7 @@ cpdef Expression dropout_dim(Expression x, unsigned d, float p):
         x (dynet.Expression): Input expression
         d (int): Dimension along which to drop
         p (number): The dropout probability
-    
+
     Returns:
         dynet.Expression: The dropped expression
     """
@@ -3685,13 +3685,13 @@ cpdef Expression dropout_dim(Expression x, unsigned d, float p):
 
 cpdef Expression block_dropout(Expression x, float p):
     """Block dropout
-    
+
     Identical to the dropout operation, but either drops out *all* or *no* values in the expression, as opposed to making a decision about each value individually.
-    
+
     Args:
         x (dynet.Expression): Input expression
         p (number): The dropout probability
-    
+
     Returns:
         dynet.Expression: The block dropout expression
     """
@@ -3699,7 +3699,7 @@ cpdef Expression block_dropout(Expression x, float p):
 #expr-dim
 cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1):
     """Reshape to another size
-    
+
     This node reshapes a tensor to another size, without changing the underlying layout of the data. The layout of the data in DyNet is column-major, so if we have a 3x4 matrix :
 
     .. math::
@@ -3720,14 +3720,14 @@ cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1):
         \end{pmatrix}
 
     **Note:** This is O(1) for forward, and O(n) for backward.
-    
+
     Args:
         x (dynet.Expression): Input expression
         d (tuple): New dimension
-    
+
     Keyword Arguments:
         batch_size (int): New batch size (default: (1))
-    
+
     Returns:
         dynet.Expression: The reshaped expression
     """
@@ -3735,30 +3735,30 @@ cpdef Expression reshape(Expression x, tuple d, unsigned int batch_size=1):
 
 cpdef Expression max_dim(Expression x, unsigned d=0):
     """Max out through a dimension
-    
+
     Select out a element/row/column/sub-tensor from an expression, with maximum value along a given dimension. This will result in the dimension of the expression being reduced by 1.
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Keyword Arguments:
         d (int): Dimension on which to perform the maxout (default: (0))
-    
+
     Returns:
         dynet.Expression: An expression of sub-tensor with max value along dimension :code:`d`
     """
     return Expression.from_cexpr(x.cg_version, c_max_dim(x.c(), d))
 cpdef Expression min_dim(Expression x, unsigned d=0):
     """Min out through a dimension
-    
+
     Select out a element/row/column/sub-tensor from an expression, with minimum value along a given dimension. This will result in the dimension of the expression being reduced by 1.
-    
+
     Args:
         x (dynet.Expression): Input expression
-    
+
     Keyword Arguments:
         d (int): Dimension on which to perform the minout (default: (0))
-    
+
     Returns:
         dynet.Expression: An expression of sub-tensor with min value along dimension :code:`d`
     """
@@ -3766,13 +3766,13 @@ cpdef Expression min_dim(Expression x, unsigned d=0):
 
 cpdef Expression contract3d_1d(Expression x, Expression y):
     """Contracts a rank 3 tensor and a rank 1 tensor into a rank 2 tensor
-    
+
     The resulting tensor :math:`z` has coordinates :math:`z_ij = \sum_k x_{ijk} y_k`
-    
+
     Args:
         x (dynet.Expression): Rank 3 tensor
         y (dynet.Expression): Vector
-    
+
     Returns:
         Matrix
         dynet.Expression
@@ -3789,7 +3789,7 @@ cpdef Expression contract3d_1d_bias(Expression x, Expression y, Expression b):
         x (dynet.Expression): Rank 3 tensor
         y (dynet.Expression): Vector
         b (dynet.Expression): Bias vector
-    
+
     Returns:
         Matrix
         dynet.Expression
@@ -3804,12 +3804,12 @@ cpdef Expression contract3d_1d_1d(Expression x, Expression y, Expression z):
     This is the equivalent of calling :code:`contract3d_1d` and then performing a matrix vector multiplication.
 
     The resulting tensor :math:`t` has coordinates :math:`t_i = \sum_{j,k} x_{ijk} y_k z_j`
-    
+
     Args:
         x (dynet.Expression): Rank 3 tensor
         y (dynet.Expression): Vector
         z (dynet.Expression): Vector
-    
+
     Returns:
         Vector
         dynet.Expression
@@ -3820,7 +3820,7 @@ cpdef Expression contract3d_1d_1d(Expression x, Expression y, Expression z):
 
 cpdef Expression contract3d_1d_1d_bias(Expression x, Expression y, Expression z, Expression b):
     """Same as :code:`contract3d_1d_1d` with an additional bias parameter
- 
+
     This is the equivalent of calling :code:`contract3d_1d` and then performing an affine transform.
 
     The resulting tensor :math:`t` has coordinates :math:`t_i = b_i + \sum_{j,k} x_{ijk} y_k z_j`
@@ -3830,7 +3830,7 @@ cpdef Expression contract3d_1d_1d_bias(Expression x, Expression y, Expression z,
         y (dynet.Expression): Vector
         z (dynet.Expression): Vector
         b (dynet.Expression): Bias vector
-    
+
     Returns:
         Vector
         dynet.Expression
@@ -3843,12 +3843,12 @@ cpdef Expression contract3d_1d_1d_bias(Expression x, Expression y, Expression z,
 
 cpdef Expression esum(list xs):
     """Sum
-    
+
     This performs an elementwise sum over all the expressions in :code:`xs`
-    
+
     Args:
         xs (list): A list of expression of same dimension
-    
+
     Returns:
         dynet.Expression: An expression where the ith element is equal to :math:`\sum_{j=0}\\texttt{xs[}j\\texttt{][}i\\texttt{]}`
     """
@@ -3864,9 +3864,9 @@ cpdef Expression esum(list xs):
 
 cpdef Expression logsumexp(list xs):
     """Log, sum, exp
-    
+
     The elementwise "logsumexp" function that calculates :math:`\ln(\sum_i e^{xs_i})`, used in adding probabilities in the log domain.
-    
+
     Args:
         xs (list): A list of expression of same dimension
 
@@ -3885,14 +3885,14 @@ cpdef Expression logsumexp(list xs):
 
 cpdef Expression logsumexp_dim(Expression x, unsigned d=0):
     """Logsumexp along an arbitrary dimension
-    
+
     The "logsumexp" function that calculates :math:`\ln(\sum_i e^{xs_i})`, used in adding probabilities in the log domain.
     This is performed along a certain dimension.
 
     Args:
         x (dynet.Expression): Input expression
         d (unsigned): Dimensions along which to reduce
-    
+
     Returns:
         dynet.Expression: An expression with one less dimension representing the result
     """
@@ -3900,31 +3900,31 @@ cpdef Expression logsumexp_dim(Expression x, unsigned d=0):
 
 cpdef Expression average(list xs):
     """Average
-    
+
     This performs an elementwise average over all the expressions in :code:`xs`
-    
+
     Args:
         xs (list): A list of expression of same dimension
-    
+
     Returns:
         dynet.Expression: An expression where the ith element is equal to :math:`\\frac{1}{\\texttt{len(xs)}}\sum_{j=0}\\texttt{xs[}j\\texttt{][}i\\texttt{]}`
     """
     assert xs, 'List is empty, nothing to average.'
     cdef vector[CExpression] cvec
     cdef Expression x
-    for x in xs: 
-        ensure_freshness(x) 
+    for x in xs:
+        ensure_freshness(x)
         cvec.push_back(x.c())
     return Expression.from_cexpr(x.cg_version, c_average(cvec))
 
 cpdef Expression emax(list xs):
     """Max
-    
+
     This performs an elementwise max over all the expressions in :code:`xs`
 
     Args:
         xs (list): A list of expression of same dimension
-    
+
     Returns:
         dynet.Expression: An expression where the ith element is equal to :math:`\max_j\\texttt{xs[}j\\texttt{][}i\\texttt{]}`
     """
@@ -3932,21 +3932,21 @@ cpdef Expression emax(list xs):
     cdef Expression c
     cdef Expression x
     c = xs[0]
-    ensure_freshness(c) 
-    for x in xs: 
-        ensure_freshness(x) 
+    ensure_freshness(c)
+    for x in xs:
+        ensure_freshness(x)
         c = Expression.from_cexpr(x.cg_version, c_bmax(x.c(),c.c()))
     return c
     #return Expression.from_cexpr(x.cg_version, c_max(cvec))
 
 cpdef Expression concatenate_cols(list xs):
     """Concatenate columns
-    
+
     Perform a concatenation of the columns in multiple expressions. All expressions must have the same number of rows.
-    
+
     Args:
         xs (list): A list of expressions
-    
+
     Returns:
         dynet.Expression: The expression with the columns concatenated
     """
@@ -3954,20 +3954,20 @@ cpdef Expression concatenate_cols(list xs):
     cdef vector[CExpression] cvec
     cdef Expression x
     for x in xs:
-        ensure_freshness(x) 
+        ensure_freshness(x)
         cvec.push_back(x.c())
     return Expression.from_cexpr(x.cg_version, c_concat_cols(cvec))
 
 cpdef Expression concatenate(list xs, unsigned d=0):
     """Concatenate
-    
+
      Perform a concatenation of multiple expressions along a particular dimension.
      All expressions must have the same dimensions except for the dimension to be concatenated (rows by default).
-    
+
     Args:
         xs (list): A list of expressions
         d: The dimension along with to perform concatenation
-    
+
     Returns:
         dynet.Expression: The expression concatenated along the particular dimension
     """
@@ -3975,18 +3975,18 @@ cpdef Expression concatenate(list xs, unsigned d=0):
     cdef vector[CExpression] cvec
     cdef Expression x
     for x in xs:
-        ensure_freshness(x) 
+        ensure_freshness(x)
         cvec.push_back(x.c())
     return Expression.from_cexpr(x.cg_version, c_concat(cvec, d))
 
 cpdef Expression concatenate_to_batch(list xs):
     """Concatenate list of expressions to a single batched expression
-    
+
     Perform a concatenation of several expressions along the batch dimension. All expressions must have the same shape except for the batch dimension.
 
     Args:
         xs (list): A list of expressions of same dimension (except batch size)
-    
+
     Returns:
         dynet.Expression: The expression with the batch dimensions concatenated
     """
@@ -3994,18 +3994,18 @@ cpdef Expression concatenate_to_batch(list xs):
     cdef vector[CExpression] cvec
     cdef Expression x
     for x in xs:
-        ensure_freshness(x) 
+        ensure_freshness(x)
         cvec.push_back(x.c())
     return Expression.from_cexpr(x.cg_version, c_concat_to_batch(cvec))
 
 cpdef Expression affine_transform(list exprs):
     """Affine transform
-    
+
     This performs an affine transform over an arbitrary (odd) number of expressions held in the input initializer list xs. The first expression is the "bias," which is added to the expression as-is. The remaining expressions are multiplied together in pairs, then added. A very common usage case is the calculation of the score for a neural network layer (e.g. :math:`b + Wz`) where b is the bias, W is the weight matrix, and z is the input. In this case :code:`xs[0] = b`, :code:`xs[1] = W`, and :code:`xs[2] = z`.
-     
+
     Args:
         exprs (list): A list containing an odd number of expressions
-    
+
     Returns:
         dynet.Expression: An expression equal to: :code:`xs[0] + xs[1]*xs[2] + xs[3]*xs[4] + ...`
     """
@@ -4013,14 +4013,14 @@ cpdef Expression affine_transform(list exprs):
     cdef Expression e
     cdef vector[CExpression] ves
     for e in exprs:
-        ensure_freshness(e) 
+        ensure_freshness(e)
         ves.push_back(e.c())
     return Expression.from_cexpr(e.cg_version, c_affine_transform(ves))
 
 cpdef Expression layer_norm(Expression x, Expression g, Expression b):
     """Layer normalization
 
-    Performs layer normalization : 
+    Performs layer normalization :
 
     .. math::
 
@@ -4029,15 +4029,15 @@ cpdef Expression layer_norm(Expression x, Expression g, Expression b):
            \sigma &= \sqrt{\\frac 1 n \sum_{i=1}^n (x_i-\mu)^2}\\\\
            y&=\\frac {\\boldsymbol{g}} \sigma \circ (\\boldsymbol{x}-\mu) + \\boldsymbol{b}\\\\
         \end{split}
- 
-        
+
+
     Reference : `Ba et al., 2016 <http://arxiv.org/abs/1607.06450>`_
-        
+
     Args:
         x (dynet.Expression): Input expression (possibly batched)
         g (dynet.Expression): Gain (same dimension as x, no batch dimension)
         b (dynet.Expression): Bias (same dimension as x, no batch dimension)
-    
+
     Returns:
         An expression of the same dimension as :code:`x`
         dynet.Expression
@@ -4049,21 +4049,21 @@ cpdef Expression layer_norm(Expression x, Expression g, Expression b):
 cpdef Expression weight_norm(Expression w, Expression g):
     """Weight normalization
 
-    Performs weight normalization : 
+    Performs weight normalization :
 
     .. math::
 
         \\begin{split}
            \hat{w} &= g\\frac{w}{\Vert w\Vert}\\\\
         \end{split}
- 
-        
+
+
     Reference : `Salimans, Kingma 2016 <https://arxiv.org/abs/1602.07868>`_
-        
+
     Args:
         w (dynet.Expression): Input expression (weight parameter)
         g (dynet.Expression): Gain (scalar expression, usually also a parameter)
-    
+
     Returns:
         An expression of the same dimension as :code:`w`
         dynet.Expression
@@ -4075,14 +4075,14 @@ cpdef Expression weight_norm(Expression w, Expression g):
 
 cpdef Expression vanilla_lstm_gates_dropout_concat(list x_t, Expression h_tm1, Expression Wx, Expression Wh, Expression b, Expression dropout_mask_x, Expression dropout_mask_h, float weightnoise_std=0.0):
     """Computes LSTM gates (matrix multiply + nonlinearities):
-    
+
        gates_i = sigmoid ((Wx_i * x_t) . dropout_mask_x + (Wh_i * h_tm1) . dropout_mask_h + b_i)
        gates_f = sigmoid ((Wx_f * x_t) . dropout_mask_x + (Wh_f * h_tm1) . dropout_mask_h + b_f + 1)
        gates_o = sigmoid ((Wx_o * x_t) . dropout_mask_x + (Wh_o * h_tm1) . dropout_mask_h + b_o)
        gates_g =   tanh  ((Wx_g * x_t) . dropout_mask_x + (Wh_g * h_tm1) . dropout_mask_h + b_g)
-       
-       Where optionally gaussian noise with the given standard deviation is applied to Wx, Wh, b parameters. 
-       
+
+       Where optionally gaussian noise with the given standard deviation is applied to Wx, Wh, b parameters.
+
        returns [gates_i]
                [gates_f]
                [gates_o]
@@ -4095,7 +4095,7 @@ cpdef Expression vanilla_lstm_gates_dropout_concat(list x_t, Expression h_tm1, E
         Wh (dynet.Expression): Parameter matrix size 4H x H
         b (dynet.Expression): Bias parameter size 4H
         weightnoise_std (real): apply gaussian noise to weights (Wx, Wh, b); requires only temporary additional memory
-    
+
     Returns:
         Vector size 4H
         dynet.Expression
@@ -4104,7 +4104,7 @@ cpdef Expression vanilla_lstm_gates_dropout_concat(list x_t, Expression h_tm1, E
     cdef Expression e
     cdef vector[CExpression] ves
     for e in x_t:
-        ensure_freshness(e) 
+        ensure_freshness(e)
         ves.push_back(e.c())
     return Expression.from_cexpr(h_tm1.cg_version, c_vanilla_lstm_gates_dropout_concat(ves,h_tm1.c(),Wx.c(),Wh.c(),b.c(), dropout_mask_x.c(), dropout_mask_h.c(), weightnoise_std))
 
@@ -4113,7 +4113,7 @@ cpdef Expression vanilla_lstm_gates_concat(list x_t, Expression h_tm1, Expressio
     cdef Expression e
     cdef vector[CExpression] ves
     for e in x_t:
-        ensure_freshness(e) 
+        ensure_freshness(e)
         ves.push_back(e.c())
     return Expression.from_cexpr(h_tm1.cg_version, c_vanilla_lstm_gates_concat(ves,h_tm1.c(),Wx.c(),Wh.c(),b.c(), weightnoise_std))
 
@@ -4134,7 +4134,7 @@ cpdef Expression vanilla_lstm_c(Expression c_tm1, Expression gates_t):
     Args:
         c_tm1 (dynet.Expression): Cell at previous timestep (vector size H)
         gates_t (dynet.Expression): Gates at current timestep as computed by vanilla_lstm_gates (vector size 4H)
-    
+
     Returns:
         Vector size H
         dynet.Expression
@@ -4149,7 +4149,7 @@ cpdef Expression vanilla_lstm_h(Expression c_t, Expression gates_t):
     Args:
         c_t (dynet.Expression): Cell at current timestep (vector size H)
         gates_t (dynet.Expression): Gates at current timestep as computed by vanilla_lstm_gates (vector size 4H)
-    
+
     Returns:
         Vector size H
         dynet.Expression
@@ -4165,7 +4165,7 @@ cpdef Expression to_device(Expression e, device_str):
     Args:
         e (dynet.Expression): Expression
         device_str (string): a device name
-    
+
     Returns:
         dynet.Expression
     """
@@ -4175,7 +4175,7 @@ cpdef Expression to_device(Expression e, device_str):
     return Expression.from_cexpr(e.cg_version, c_to_device(e.c(), dev))
 
 # }}}
-    
+
 # {{{ RNNS / Builders
 # TODO: unify these with inheritance
 
@@ -4184,23 +4184,23 @@ cdef class _RNNBuilder: # {{{
     """
     cdef CRNNBuilder *thisptr
     cdef RNNState _init_state
-    cdef int cg_version 
+    cdef int cg_version
 
     def __dealloc__(self):
         del self.thisptr
 
     cpdef set_dropout(self, float f):
         """[summary]
-        
+
         [description]
-        
+
         Args:
             float f: [description]
         """
         self.thisptr.set_dropout(f)
     cpdef disable_dropout(self):
         """[summary]
-        
+
         [description]
         """
         self.thisptr.disable_dropout()
@@ -4295,13 +4295,13 @@ cdef class _RNNBuilder: # {{{
 
     cpdef RNNState initial_state(self,vecs=None,update=True):
         """Get a :code:`dynet.RNNState`
-        
+
         This initializes a :code:`dynet.RNNState` by loading the parameters in the computation graph
-        
+
         Args:
             vecs (list): Initial hidden state for each layer as a list of :code:`dynet.Expression` s  (default: {None})
             update (bool): trainer updates internal parameters (default: {True})
-        
+
         Returns:
             :code:`dynet.RNNState` used to feed inputs/transduces sequences, etc...
             dynet.RNNState
@@ -4317,15 +4317,15 @@ cdef class _RNNBuilder: # {{{
 
     cpdef RNNState initial_state_from_raw_vectors(self,vecs=None, update=True):
         """Get a :code:`dynet.RNNState`
-        
+
         This initializes a :code:`dynet.RNNState` by loading the parameters in the computation graph
 
         Use this if you want to initialize the hidden states with values directly rather than expressions.
-        
+
         Args:
             vecs (list): Initial hidden state for each layer as a list of numpy arrays  (default: {None})
             update (bool): trainer updates internal parameters (default: {True})
-        
+
         Returns:
             :code:`dynet.RNNState` used to feed inputs/transduces sequences, etc...
             dynet.RNNState
@@ -4350,7 +4350,7 @@ cdef class _RNNBuilder: # {{{
 
 cdef class SimpleRNNBuilder(_RNNBuilder): # {{{
     """[summary]
-    
+
     [description]
     """
     cdef CSimpleRNNBuilder* thissimpleptr
@@ -4372,9 +4372,9 @@ cdef class SimpleRNNBuilder(_RNNBuilder): # {{{
 # TODO rename to parameters()?
     cpdef get_parameters(self):
         """Retrieve the internal parameters of the RNN
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_{hx},W_{hh},b_h`
-        
+
         Returns:
             List of parameters for each layer
             list
@@ -4390,9 +4390,9 @@ cdef class SimpleRNNBuilder(_RNNBuilder): # {{{
 # TODO rename to parameter_expressions()?
     cpdef get_parameter_expressions(self):
         """Retrieve the internal parameters expressions of the RNN
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_{hx},W_{hh},b_h`
-        
+
         Returns:
             List of parameter expressions for each layer
             list
@@ -4413,10 +4413,10 @@ cdef class SimpleRNNBuilder(_RNNBuilder): # {{{
 
     def whoami(self): return "SimpleRNNBuilder"
 # SimpleRNNBuilder }}}
-    
+
 cdef class GRUBuilder(_RNNBuilder): # {{{
     """[summary]
-    
+
     [description]
     """
     cdef CGRUBuilder* thisgruptr
@@ -4438,9 +4438,9 @@ cdef class GRUBuilder(_RNNBuilder): # {{{
 # TODO rename to parameters()?
     cpdef get_parameters(self):
         """Retrieve the internal parameters of the GRU
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_{zx},W_{zh},b_z,W_{rx},W_{rh},b_r,W_{hx},W_{hh},b_h`
-        
+
         Returns:
             List of parameters for each layer
             list
@@ -4456,9 +4456,9 @@ cdef class GRUBuilder(_RNNBuilder): # {{{
 # TODO rename to parameter_expressions()?
     cpdef get_parameter_expressions(self):
         """Retrieve the internal parameters expressions of the GRU
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_{zx},W_{zh},b_z,W_{rx},W_{rh},b_r,W_{hx},W_{hh},b_h`
-        
+
         Returns:
             List of parameter expressions for each layer
             list
@@ -4515,9 +4515,9 @@ cdef class CoupledLSTMBuilder(_RNNBuilder): # {{{
 # TODO rename to parameters()?
     cpdef get_parameters(self):
         """Retrieve the internal parameters of the LSTM
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_{ix},W_{ih},W_{ic},b_i,W_{ox},W_{oh},W_{oc},b_o,W_{cx},W_{ch},b_c`
-        
+
         Returns:
             List of parameters for each layer
             list
@@ -4534,9 +4534,9 @@ cdef class CoupledLSTMBuilder(_RNNBuilder): # {{{
 # TODO rename to parameter_expressions()?
     cpdef get_parameter_expressions(self):
         """Retrieve the internal parameters expressions of the LSTM
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_{ix},W_{ih},W_{ic},b_i,W_{ox},W_{oh},W_{oc},b_o,W_{cx},W_{ch},b_c`
-        
+
         Returns:
             List of parameter expressions for each layer
             list
@@ -4560,7 +4560,7 @@ cdef class CoupledLSTMBuilder(_RNNBuilder): # {{{
 
 cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
     """VanillaLSTM allows to create an "standard" LSTM, ie with decoupled input and forget gate and no peepholes connections
-    
+
     This cell runs according to the following dynamics :
 
     .. math::
@@ -4580,14 +4580,15 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
         hidden_dim (int): Dimension of the recurrent units
         model (dynet.ParameterCollection): ParameterCollection to hold the parameters
         ln_lstm (bool): Whether to use layer normalization
+        forget_bias (bool): Whether to use forget gate bias
 
     """
     cdef CVanillaLSTMBuilder* thisvanillaptr
     cdef tuple _spec
-    def __init__(self, unsigned layers, unsigned input_dim, unsigned hidden_dim, ParameterCollection model, ln_lstm=False):
-        self._spec = (layers, input_dim, hidden_dim, ln_lstm)
+    def __init__(self, unsigned layers, unsigned input_dim, unsigned hidden_dim, ParameterCollection model, ln_lstm=False, forget_bias=True):
+        self._spec = (layers, input_dim, hidden_dim, ln_lstm, forget_bias)
         if layers > 0:
-            self.thisvanillaptr = self.thisptr = new CVanillaLSTMBuilder(layers, input_dim, hidden_dim, model.thisptr, ln_lstm)
+            self.thisvanillaptr = self.thisptr = new CVanillaLSTMBuilder(layers, input_dim, hidden_dim, model.thisptr, ln_lstm, forget_bias)
         else:
             self.thisvanillaptr = self.thisptr = new CVanillaLSTMBuilder()
         self.cg_version = -1
@@ -4597,18 +4598,18 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
 
     @classmethod
     def from_spec(cls, spec, model):
-        layers, input_dim, hidden_dim, ln_lstm = spec
-        return VanillaLSTMBuilder(layers, input_dim, hidden_dim, model, ln_lstm)
+        layers, input_dim, hidden_dim, ln_lstm, forget_bias = spec
+        return VanillaLSTMBuilder(layers, input_dim, hidden_dim, model, ln_lstm, forget_bias)
 
 # TODO rename to parameters()?
     cpdef get_parameters(self):
         """Retrieve the internal parameters of the VanillaLSTM
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_x,W_h,b` where :math:`W_x,W_h` are stacked version of the individual gates matrices:
 
         .. code-block:: text
 
-                  h/x   
+                  h/x
                 +------+
                 |      |
             i   |      |
@@ -4638,12 +4639,12 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
 # TODO rename to parameter_expressions()?
     cpdef get_parameter_expressions(self):
         """Retrieve the internal parameters expressions of the VanillaLSTM
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_x,W_h,b` where :math:`W_x,W_h` are stacked version of the individual gates matrices:
 
         .. code-block:: text
 
-                  h/x   
+                  h/x
                 +------+
                 |      |
             i   |      |
@@ -4657,7 +4658,7 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
                 |      |
             c   |      |
                 +------+
-        
+
         Returns:
             List of parameter expressions for each layer
             list
@@ -4679,7 +4680,7 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
 
     cpdef void set_dropouts(self, float d, float d_r):
         """Set the dropout rates
-        
+
         The dropout implemented here is the variational dropout with tied weights introduced in `Gal, 2016 <http://papers.nips.cc/paper/6241-a-theoretically-grounded-application-of-dropout-in-recurrent-neural-networks>`_
 
         More specifically, dropout masks :math:`\mathbf{z_x}\sim \\text(1-d_x)`, :math:`\mathbf{z_h}\sim \\text{Bernoulli}(1-d_h)` are sampled at the start of each sequence.
@@ -4707,11 +4708,11 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
 
     cpdef void set_dropout_masks(self, unsigned batch_size=1):
         """Set dropout masks at the beginning of a sequence for a specific batch size
-        
+
         If this function is not called on batched input, the same mask will be applied across all batch elements. Use this to apply different masks to each batch element
 
         You need to call this __AFTER__ calling `initial_state`
-        
+
         Args:
             batch_size (int): Batch size (default: {1})
         """
@@ -4727,7 +4728,7 @@ LSTMBuilder = VanillaLSTMBuilder
 
 cdef class CompactVanillaLSTMBuilder(_RNNBuilder): # {{{
     """CompactVanillaLSTM allows to create an "standard" LSTM, ie with decoupled input and forget gate and no peepholes connections
-    
+
     This cell runs according to the following dynamics :
 
     .. math::
@@ -4769,12 +4770,12 @@ cdef class CompactVanillaLSTMBuilder(_RNNBuilder): # {{{
 # TODO rename to parameters()?
     cpdef get_parameters(self):
         """Retrieve the internal parameters of the CompactVanillaLSTM
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_x,W_h,b` where :math:`W_x,W_h` are stacked version of the individual gates matrices:
 
         .. code-block:: text
 
-                  h/x   
+                  h/x
                 +------+
                 |      |
             i   |      |
@@ -4804,12 +4805,12 @@ cdef class CompactVanillaLSTMBuilder(_RNNBuilder): # {{{
 # TODO rename to parameter_expressions()?
     cpdef get_parameter_expressions(self):
         """Retrieve the internal parameters expressions of the CompactVanillaLSTM
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_x,W_h,b` where :math:`W_x,W_h` are stacked version of the individual gates matrices:
 
         .. code-block:: text
 
-                  h/x   
+                  h/x
                 +------+
                 |      |
             i   |      |
@@ -4823,7 +4824,7 @@ cdef class CompactVanillaLSTMBuilder(_RNNBuilder): # {{{
                 |      |
             c   |      |
                 +------+
-        
+
         Returns:
             List of parameter expressions for each layer
             list
@@ -4845,7 +4846,7 @@ cdef class CompactVanillaLSTMBuilder(_RNNBuilder): # {{{
 
     cpdef void set_dropouts(self, float d, float d_r):
         """Set the dropout rates
-        
+
         The dropout implemented here is the variational dropout with tied weights introduced in `Gal, 2016 <http://papers.nips.cc/paper/6241-a-theoretically-grounded-application-of-dropout-in-recurrent-neural-networks>`_
 
         More specifically, dropout masks :math:`\mathbf{z_x}\sim \\text(1-d_x)`, :math:`\mathbf{z_h}\sim \\text{Bernoulli}(1-d_h)` are sampled at the start of each sequence.
@@ -4873,11 +4874,11 @@ cdef class CompactVanillaLSTMBuilder(_RNNBuilder): # {{{
 
     cpdef void set_dropout_masks(self, unsigned batch_size=1):
         """Set dropout masks at the beginning of a sequence for a specific batch size
-        
+
         If this function is not called on batched input, the same mask will be applied across all batch elements. Use this to apply different masks to each batch element
 
         You need to call this __AFTER__ calling `initial_state`
-        
+
         Args:
             batch_size (int): Batch size (default: {1})
         """
@@ -4899,7 +4900,7 @@ cdef class CompactVanillaLSTMBuilder(_RNNBuilder): # {{{
 
 cdef class FastLSTMBuilder(_RNNBuilder): # {{{
     """[summary]
-    
+
     [description]
     """
     cdef CFastLSTMBuilder* thisfastptr
@@ -4910,9 +4911,9 @@ cdef class FastLSTMBuilder(_RNNBuilder): # {{{
 # TODO rename to parameters()?
     cpdef get_parameters(self):
         """Retrieve the internal parameters of the FastLSTM
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_{ix},W_{ih},W_{ic},b_i,W_{ox},W_{oh},W_{oc},b_o,W_{cx},W_{ch},b_c`
-        
+
         Returns:
             List of parameters for each layer
             list
@@ -4928,9 +4929,9 @@ cdef class FastLSTMBuilder(_RNNBuilder): # {{{
 # TODO rename to parameter_expressions()?
     cpdef get_parameter_expressions(self):
         """Retrieve the internal parameters expressions of the FastLSTM
-        
+
         The output is a list with one item per layer. Each item is a list containing :math:`W_{ix},W_{ih},W_{ic},b_i,W_{ox},W_{oh},W_{oc},b_o,W_{cx},W_{ch},b_c`
-       
+
         Returns:
             List of parameter expressions for each layer
             list
@@ -4954,8 +4955,8 @@ cdef class FastLSTMBuilder(_RNNBuilder): # {{{
 
 class BiRNNBuilder(object): # {{{
     """
-    Builder for BiRNNs that delegates to regular RNNs and wires them together.  
-    
+    Builder for BiRNNs that delegates to regular RNNs and wires them together.
+
         builder = BiRNNBuilder(1, 128, 100, model, LSTMBuilder)
         [o1,o2,o3] = builder.transduce([i1,i2,i3])
     """
@@ -4963,7 +4964,7 @@ class BiRNNBuilder(object): # {{{
         """Args:
             num_layers: depth of the BiRNN
             input_dim: size of the inputs
-            hidden_dim: size of the outputs (and intermediate layer representations.) This hidden dim is split evenly between the two constituent RNNs, and thus must be even. 
+            hidden_dim: size of the outputs (and intermediate layer representations.) This hidden dim is split evenly between the two constituent RNNs, and thus must be even.
             model
             rnn_builder_factory: RNNBuilder subclass, e.g. LSTMBuilder
             builder_layers: list of (forward, backward) pairs of RNNBuilder instances to directly initialize layers
@@ -5036,9 +5037,9 @@ class BiRNNBuilder(object): # {{{
     def transduce(self, es):
         """
         returns the list of output Expressions obtained by adding the given inputs
-        to the current state, one by one, to both the forward and backward RNNs, 
+        to the current state, one by one, to both the forward and backward RNNs,
         and concatenating.
-        
+
         @param es: a list of Expression
 
         see also add_inputs(xs)
@@ -5050,8 +5051,8 @@ class BiRNNBuilder(object): # {{{
              state, as well as to the state-vectors (h() and s() )
 
             .transduce(xs) returns a list of Expression. These are just the output
-             expressions. For many cases, this suffices. 
-             transduce is much more memory efficient than add_inputs. 
+             expressions. For many cases, this suffices.
+             transduce is much more memory efficient than add_inputs.
         """
         for e in es:
             ensure_freshness(e)
@@ -5080,10 +5081,10 @@ cdef class RNNState: # {{{
 
     cpdef RNNState set_h(self, es=None):
         """Manually set the output :math:`h_t`
-        
+
         Args:
             es (list): List of expressions, one for each layer (default: {None})
-        
+
         Returns:
             New RNNState
             dynet.RNNState
@@ -5094,12 +5095,12 @@ cdef class RNNState: # {{{
 
     cpdef RNNState set_s(self, es=None):
         """Manually set the hidden states
-        
+
         This is different from :code:`set_h` because, for LSTMs for instance this also sets the cell state. The format is :code:`[new_c[0],...,new_c[n],new_h[0],...,new_h[n]]`
-        
+
         Args:
             es (list): List of expressions, in this format : :code:`[new_c[0],...,new_c[n],new_h[0],...,new_h[n]]` (default: {None})
-        
+
         Returns:
             New RNNState
             dynet.RNNState
@@ -5110,10 +5111,10 @@ cdef class RNNState: # {{{
 
     cpdef RNNState add_input(self, Expression x):
         """This computes :math:`h_t = \\text{RNN}(x_t)`
-        
+
         Args:
             x (dynet.Expression): Input expression
-        
+
         Returns:
             New RNNState
             dynet.RNNState
@@ -5134,8 +5135,8 @@ cdef class RNNState: # {{{
              state, as well as to the state-vectors (:code:`h()` and :code:`s()` )
 
         - :code:`.transduce(xs)` returns a list of Expression. These are just the output
-             expressions. For many cases, this suffices. 
-        
+             expressions. For many cases, this suffices.
+
         :code:`transduce` is much more memory efficient than :code:`add_inputs`.
 
         Args:
@@ -5151,12 +5152,12 @@ cdef class RNNState: # {{{
             cur = cur.add_input(x)
             states.append(cur)
         return states
-    
+
     cpdef transduce(self, xs):
         """
         returns the list of output Expressions obtained by adding the given inputs
         to the current state, one by one.
-        
+
         see also :code:`add_inputs(xs)`
 
         :code:`.transduce(xs)` is different from :code:`.add_inputs(xs)` in the following way:
@@ -5166,8 +5167,8 @@ cdef class RNNState: # {{{
              state, as well as to the state-vectors (:code:`h()` and :code:`s()` )
 
         - :code:`.transduce(xs)` returns a list of Expression. These are just the output
-             expressions. For many cases, this suffices. 
-        
+             expressions. For many cases, this suffices.
+
         :code:`transduce` is much more memory efficient than :code:`add_inputs`.
 
         Args:
@@ -5222,9 +5223,9 @@ cdef class RNNState: # {{{
 
     def b(self):
         """Get the underlying RNNBuilder
-        
+
         In case you need to set dropout or other stuff.
-        
+
         Returns:
             Underlying RNNBuilder
             dynet.RNNBuilder
@@ -5275,23 +5276,23 @@ cdef class Trainer:
     Generic trainer
 
     Attributes:
-        learning_rate(number): Global learning rate for all parameters 
+        learning_rate(number): Global learning rate for all parameters
     """
     cdef CTrainer *thisptr
     def __dealloc__(self):
         del self.thisptr
     cpdef update(self):
         """Update the parameters
-        
+
         The update equation is different for each trainer, check the online c++ documentation for more details on what each trainer does
         """
         self.thisptr.update()
 
     cpdef update_subset(self, updated_params, updated_lookups):
         """Update a subset of parameters
-        
+
         Only use this in last resort, a more elegant way to update only a subset of parameters is to use the "update" keyword in dy.parameter or Parameter.expr() to specify which parameters need to be updated __during the creation of the computation graph__
-        
+
         Args:
             updated_params(list): Indices of parameters to update
             updated_lookups(list): Indices of lookup parameters to update
@@ -5310,7 +5311,7 @@ cdef class Trainer:
 
     cpdef restart(self, learning_rate=None):
         """Restarts the optimizer
-        
+
         Clears all momentum values and assimilate (if applicable)
 
         Args:
@@ -5322,8 +5323,8 @@ cdef class Trainer:
             self.thisptr.restart(learning_rate)
 
     cpdef status(self):
-        """Outputs information about the trainer in the stderr 
-        
+        """Outputs information about the trainer in the stderr
+
         (number of updates since last call, number of clipped gradients, learning rate, etc...)
         """
         self.thisptr.status()
@@ -5338,9 +5339,9 @@ cdef class Trainer:
         self.thisptr.sparse_updates_enabled = su
     cpdef set_clip_threshold(self,float thr):
         """Set clipping thershold
-        
+
         To deactivate clipping, set the threshold to be <=0
-        
+
         Args:
             thr(number): Clipping threshold
         """
@@ -5352,7 +5353,7 @@ cdef class Trainer:
             self.thisptr.clip_threshold = thr
     cpdef get_clip_threshold(self):
         """Get clipping threshold
-        
+
         Returns:
             number: Gradient clipping threshold
         """
@@ -5368,12 +5369,12 @@ cdef class Trainer:
 
 cdef class SimpleSGDTrainer(Trainer):
     """Stochastic gradient descent trainer
-    
+
     This trainer performs stochastic gradient descent, the goto optimization procedure for neural networks.
-    
+
     Args:
         m(dynet.ParameterCollection): ParameterCollection to be trained
-    
+
     Keyword Args:
         learning_rate(number): Initial learning rate (default: 0.1)
     """
@@ -5396,10 +5397,10 @@ cdef class CyclicalSGDTrainer(Trainer):
        x &= \left\\vert \\frac{\\texttt{it}}{\\texttt{step_size}} - 2 \\times \\text{cycle} + 1\\right\\vert\\\\
        \eta &= \eta_{\\text{min}} + (\eta_{\\text{max}} - \eta_{\\text{min}}) \\times \max(0, 1 - x) \\times \gamma^{\\texttt{it}}\\\\
        \end{split}
-    
+
     Args:
         m(dynet.ParameterCollection): ParameterCollection to be trained
-    
+
     Keyword Args:
         learning_rate_min (number): Lower learning rate (default: {0.01})
         learning_rate_max (number): Upper learning rate (default: {0.1})
@@ -5416,12 +5417,12 @@ cdef class CyclicalSGDTrainer(Trainer):
 
 cdef class MomentumSGDTrainer(Trainer):
     """Stochastic gradient descent with momentum
-    
-    This is a modified version of the SGD algorithm with momentum to stablize the gradient trajectory. 
-    
+
+    This is a modified version of the SGD algorithm with momentum to stablize the gradient trajectory.
+
     Args:
         m(dynet.ParameterCollection): ParameterCollection to be trained
-    
+
     Keyword Args:
         learning_rate(number): Initial learning rate (default: 0.1)
         mom(number): Momentum (default: 0.9)
@@ -5435,12 +5436,12 @@ cdef class MomentumSGDTrainer(Trainer):
 
 cdef class AdagradTrainer(Trainer):
     """Adagrad optimizer
-    
+
     The adagrad algorithm assigns a different learning rate to each parameter.
-    
+
     Args:
         m(dynet.ParameterCollection): ParameterCollection to be trained
-    
+
     Keyword Args:
         learning_rate(number): Initial learning rate (default: 0.1)
         eps(number): Epsilon parameter to prevent numerical instability (default: 1e-20)
@@ -5453,12 +5454,12 @@ cdef class AdagradTrainer(Trainer):
 
 cdef class AdadeltaTrainer(Trainer):
     """AdaDelta optimizer
-    
+
     The AdaDelta optimizer is a variant of Adagrad aiming to prevent vanishing learning rates.
-    
+
     Args:
         m(dynet.ParameterCollection): ParameterCollection to be trained
-    
+
     Keyword Args:
         eps(number): Epsilon parameter to prevent numerical instability (default: 1e-6)
         rho(number): Update parameter for the moving average of updates in the numerator (default: 0.95)
@@ -5470,12 +5471,12 @@ cdef class AdadeltaTrainer(Trainer):
 
 cdef class RMSPropTrainer(Trainer):
     """RMSProp optimizer
-    
+
     The RMSProp optimizer is a variant of Adagrad where the squared sum of previous gradients is replaced with a moving average with parameter rho.
-    
+
     Args:
         m(dynet.ParameterCollection): ParameterCollection to be trained
-    
+
     Keyword Args:
         learning_rate(number): Initial learning rate (default: 0.001)
         eps(number): Epsilon parameter to prevent numerical instability (default: 1e-8)
@@ -5488,12 +5489,12 @@ cdef class RMSPropTrainer(Trainer):
 
 cdef class AdamTrainer(Trainer):
     """Adam optimizer
-    
+
     The Adam optimizer is similar to RMSProp but uses unbiased estimates of the first and second moments of the gradient
-    
+
     Args:
         m(dynet.ParameterCollection): ParameterCollection to be trained
-    
+
     Keyword Args:
         alpha(number): Initial learning rate (default: 0.001)
         beta_1(number): Moving average parameter for the mean (default: 0.9)
@@ -5538,14 +5539,14 @@ cdef class SoftmaxBuilder:
 
     cpdef neg_log_softmax(self, Expression x, unsigned c, bool update=True):
         """Negative log probability of a class
-        
+
         Given class :math:`c` and vector :math:`x`, this returns :math:`-\log(p(c \mid x))`
-        
+
         Args:
             x(dynet.Expression): Input vector
             c(unsigned): Class id
             update(bool): Whether to update the parameters or not (default: {True})
-        
+
         Returns:
             Log probability of given class
             dynet.Expression
@@ -5555,12 +5556,12 @@ cdef class SoftmaxBuilder:
 
     cpdef neg_log_softmax_batch(self, Expression x, vector[unsigned] c, bool update=True):
         """Batched version of :code:`neg_log_softmax`
-        
+
         Args:
             x(dynet.Expression): Input vector (batched)
             c(list): list of class ids (one per batch element)
             update(bool): Whether to update the parameters or not (default: {True})
-        
+
         Returns:
             Log probability of given class
             dynet.Expression
@@ -5570,10 +5571,10 @@ cdef class SoftmaxBuilder:
 
     cpdef sample(self, Expression x):
         """Sample from the softmax distribution
-        
+
         Args:
             x(dynet.Expression): Input vector
-        
+
         Returns:
             Sampled class
             int
@@ -5583,13 +5584,13 @@ cdef class SoftmaxBuilder:
 
     cpdef full_log_distribution(self, Expression x, bool update=True):
         """Returns an Expression representing a vector the size of the number of classes.
-        
+
         The ith dimension gives :math:`\log p(c_i | x)`. This function may be SLOW. Avoid if possible.
-        
+
         Args:
             x(dynet.Expression): Input vector
             update(bool): Whether to update the parameters or not (default: {True})
-        
+
         Returns:
             Vector of :math:`\log(p(c\mid x)`
             dynet.Expression
@@ -5599,13 +5600,13 @@ cdef class SoftmaxBuilder:
 
     cpdef full_logits(self, Expression x, bool update=True):
         """Returns the logits (before application of the softmax)
-        
+
         The ith dimension gives :math:`W_i^Tx + b_i`
-        
+
         Args:
             x(dynet.Expression): Input vector
             update(bool): Whether to update the parameters or not (default: {True})
-        
+
         Returns:
             Expression for the logits
             dynet.Expression
@@ -5615,9 +5616,9 @@ cdef class SoftmaxBuilder:
 
     cpdef ParameterCollection param_collection(self):
         """Returns the ParameterCollection containing the softmax parameters
-        
+
         The first parameter in the parametercollection is the weight matrix, the second is the biases (if any)
-        
+
         Returns:
             Subcollection holding the parameters
             ParameterCollection
@@ -5685,11 +5686,11 @@ cdef class ClassFactoredSoftmaxBuilder(SoftmaxBuilder):
 
     cpdef class_log_distribution(self, Expression x, bool update=True):
         """Get log distribution over classes
-        
+
         Args:
             x(dynet.Expression): Input vector
             update(bool): Whether to update the parameters or not (default: {True})
-        
+
         Returns:
             Vector of :math:`\log(p(c\mid x)`
             dynet.Expression
@@ -5699,11 +5700,11 @@ cdef class ClassFactoredSoftmaxBuilder(SoftmaxBuilder):
 
     cpdef class_logits(self, Expression x, bool update=True):
         """Returns the logits over classes
-        
+
         Args:
             x(dynet.Expression): Input vector
             update(bool): Whether to update the parameters or not (default: {True})
-        
+
         Returns:
             Expression for the logits
             dynet.Expression
@@ -5713,12 +5714,12 @@ cdef class ClassFactoredSoftmaxBuilder(SoftmaxBuilder):
 
     cpdef subclass_log_distribution(self, Expression x, unsigned classid, bool update=True):
         """ Get log distribution over subclasses of class
-        
+
         Args:
             x(dynet.Expression): Input vector
             classid(int): class index
             update(bool): Whether to update the parameters or not (default: {True})
-        
+
         Returns:
             Vector of :math:`\log(p(i\mid x, \\texttt{classid})`
             dynet.Expression
@@ -5728,12 +5729,12 @@ cdef class ClassFactoredSoftmaxBuilder(SoftmaxBuilder):
 
     cpdef subclass_logits(self, Expression x, unsigned classid, bool update=True):
         """Logits over subclasses of class
-        
+
         Args:
             x(dynet.Expression): Input vector
             classid(int): class index
             update(bool): Whether to update the parameters or not (default: {True})
-        
+
         Returns:
             Expression for the logits
             dynet.Expression


### PR DESCRIPTION
Based on this paper  http://proceedings.mlr.press/v37/jozefowicz15.pdf by Jozefowicz et al. adding a bias of 1 to the  LSTM's forget gate improves the performance. On the other hand Dozat et al.(https://web.stanford.edu/~tdozat/files/TDozat-CoNLL2017-Presentation.pdf) found that adding the aforementioned bias to the forget gate hurts the performance of their SOTA  POS tagging & Dependency parsing models. 
I have made some minor modifications in order to let the user to decide if forget bias should be used or not.