### PR TITLE
Fixed pernicious bug in autobatching

### DIFF
--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -322,10 +322,10 @@ void BatchedExecutionEngine::combine_tensors(
     float** srcs = static_cast<float**>(basemem);
     float** trgs = static_cast<float**>(basemem) + TRG;
     std::size_t* lens = static_cast<std::size_t*>(basemem) + LEN;
-    CUDA_CHECK(cudaMemcpyAsync(basemem,
-                               &(locs)[0],
-                               locs.size() * sizeof(CopyArgs),
-                               cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(basemem,
+                          &(locs)[0],
+                          locs.size() * sizeof(CopyArgs),
+                          cudaMemcpyHostToDevice));
     gpu::parallel_memcpy(batch_ids.size(), max_length, srcs, trgs, lens);
 #endif
   } else if (tout.device->type == DeviceType::CPU) {
@@ -373,10 +373,10 @@ void BatchedExecutionEngine::accumulate_tensors(
     float** srcs = static_cast<float**>(basemem);
     float** trgs = static_cast<float**>(basemem) + TRG;
     std::size_t* lens = static_cast<std::size_t*>(basemem) + LEN;
-    CUDA_CHECK(cudaMemcpyAsync(basemem,
-                               &(locs)[0],
-                               locs.size() * sizeof(CopyArgs),
-                               cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaMemcpy(basemem,
+                          &(locs)[0],
+                          locs.size() * sizeof(CopyArgs),
+                          cudaMemcpyHostToDevice));
     gpu::parallel_accumulate(batch_ids.size(), max_length, srcs, trgs, lens);
 #endif
   }

--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -322,10 +322,11 @@ void BatchedExecutionEngine::combine_tensors(
     float** srcs = static_cast<float**>(basemem);
     float** trgs = static_cast<float**>(basemem) + TRG;
     std::size_t* lens = static_cast<std::size_t*>(basemem) + LEN;
-    CUDA_CHECK(cudaMemcpy(basemem,
+    CUDA_CHECK(cudaMemcpyAsync(basemem,
                           &(locs)[0],
                           locs.size() * sizeof(CopyArgs),
-                          cudaMemcpyHostToDevice));
+                          cudaMemcpyHostToDevice,
+                          static_cast<Device_GPU*>(tout.device)->estream->stream()));
     gpu::parallel_memcpy(batch_ids.size(), max_length, srcs, trgs, lens);
 #endif
   } else if (tout.device->type == DeviceType::CPU) {
@@ -373,10 +374,11 @@ void BatchedExecutionEngine::accumulate_tensors(
     float** srcs = static_cast<float**>(basemem);
     float** trgs = static_cast<float**>(basemem) + TRG;
     std::size_t* lens = static_cast<std::size_t*>(basemem) + LEN;
-    CUDA_CHECK(cudaMemcpy(basemem,
+    CUDA_CHECK(cudaMemcpyAsync(basemem,
                           &(locs)[0],
                           locs.size() * sizeof(CopyArgs),
-                          cudaMemcpyHostToDevice));
+                          cudaMemcpyHostToDevice,
+                          static_cast<Device_GPU*>(tin.device)->estream->stream()));
     gpu::parallel_accumulate(batch_ids.size(), max_length, srcs, trgs, lens);
 #endif
   }


### PR DESCRIPTION
OK, it took me literally all day to find a bug that can be fixed in 10 characters of code.

Basically, parallel memcpy (used in autobatching) requires memory to be transferred to the GPU, but this was being done in an asynchronous fashion, and as a result the memory wasn't necessarily arriving at the GPU before the memcpy kernel started executing.

This probably fixes https://github.com/clab/dynet/issues/1057