### PR TITLE
Added constrained softmax operator.

### DIFF
--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -97,6 +97,7 @@ Expression sparsemax(const Expression& x) { return Expression(x.pg, x.pg->add_fu
 Expression sparsemax_loss(const Expression& x, const vector<unsigned>& target_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, target_support)); }
 Expression sparsemax_loss(const Expression& x, const vector<unsigned>* ptarget_support) { return Expression(x.pg, x.pg->add_function<SparsemaxLoss>({x.i}, ptarget_support)); }
 Expression softmax(const Expression& x, unsigned d) { return Expression(x.pg, x.pg->add_function<Softmax>({x.i}, d)); }
+Expression constrained_softmax(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<ConstrainedSoftmax>({x.i, y.i})); }
 Expression softsign(const Expression& x) { return Expression(x.pg, x.pg->add_function<SoftSign>({x.i})); }
 Expression pow(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Pow>({x.i, y.i})); }
 Expression min(const Expression& x, const Expression& y) { return Expression(x.pg, x.pg->add_function<Min>({x.i, y.i})); }

--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1569,6 +1569,19 @@ Expression sparsemax_loss(const Expression& x, const std::vector<unsigned>* ptar
 
 /**
  * \ingroup lossoperations
+ * \brief Constrained softmax
+ * \details The constrained softmax function.
+ *          **Note:** This function is not yet implemented on GPU.
+ *
+ * \param x A vector of scores
+ * \param y A vector of upper bound constraints on probabilities
+ *
+ * \return The constrained softmax of the scores.
+ */
+Expression constrained_softmax(const Expression& x, const Expression& y);
+
+/**
+ * \ingroup lossoperations
  * \brief Squared norm
  * \details The squared L2 norm of the values of x: \f$\sum_i x_i^2\f$.
  *

--- a/dynet/nodes-softmaxes.h
+++ b/dynet/nodes-softmaxes.h
@@ -78,6 +78,17 @@ struct SparsemaxLoss : public Node {
   const std::vector<unsigned>* pq;
 };
 
+// y = constrained_softmax(x, u)
+// y = arg min_{y<=u} KL(y || x)
+struct ConstrainedSoftmax : public Node {
+  explicit ConstrainedSoftmax(const std::initializer_list<VariableIndex>& a)
+      : Node(a) {
+    this->has_cuda_implemented = false;
+  }
+  DYNET_NODE_DEFINE_DEV_IMPL()
+  size_t aux_storage_size() const override;
+};
+
 }  // namespace dynet
 
 #endif

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -329,6 +329,7 @@ cdef extern from "dynet/expr.h" namespace "dynet":
     CExpression c_softmax "dynet::softmax" (CExpression& x, unsigned d) except + #
     CExpression c_sparsemax "dynet::sparsemax" (CExpression& x) except + #
     CExpression c_softsign "dynet::softsign" (CExpression& x) except + #
+    CExpression c_constrained_softmax "dynet::constrained_softmax" (CExpression& x, CExpression &y) except + #
     CExpression c_pow "dynet::pow" (CExpression& x, CExpression& y) except + #
     CExpression c_bmin "dynet::min" (CExpression& x, CExpression& y) except + #
     CExpression c_bmax "dynet::max" (CExpression& x, CExpression& y) except + #

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3238,6 +3238,23 @@ cpdef Expression softsign(Expression x):
     """
     return Expression.from_cexpr(x.cg_version, c_softsign(x.c()))
 
+cpdef Expression constrained_softmax(Expression x, Expression y):
+    """Constrained softmax function
+
+    The constrained softmax function (Martins and Kreutzer, 2017) is similar to softmax, but defines upper bounds for the resulting probabilities. **Note:** This function is not yet implemented on GPU.
+    
+    Args:
+        x (dynet.Expression): Input expression (scores)
+        y (dynet.Expression): Input expression (upper bounds)
+    
+    Returns:
+        dynet.Expression: The constrained softmax of the scores, satisfying the upper bound constraints
+
+    """
+    ensure_freshness(y);
+    return Expression.from_cexpr(x.cg_version,
+                                 c_constrained_softmax(x.c(), y.c()))
+
 cpdef Expression pow(Expression x, Expression y):
     """Power function
     


### PR DESCRIPTION
Implementation of a ConstrainedSoftmax node as described in this paper:

André F. T. Martins and Julia Kreutzer.
"Learning What’s Easy: Fully Differentiable Neural Easy-First Taggers."
Conference on Empirical Methods in Natural Language Processing (EMNLP'17), Copenhagen, Denmark, September 2017.
https://aclanthology.info/pdf/D/D17/D17-1036.pdf

The function implemented in this node is similar to Softmax, but it allows upper bound constraints on the resulting probabilities. It's differentiable both with respect to both the scores and the constraints. Currently CPU-only.