### PR TITLE
scala: Add implicit conversions from seq to vector

### DIFF
--- a/contrib/swig/src/main/scala/edu/cmu/dynet/RNNBuilder.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/RNNBuilder.scala
@@ -23,7 +23,7 @@ abstract class RnnBuilder(private[dynet] val _builder: internal.RNNBuilder) {
     new Expression(expr)
   }
 
-  def addInput(prev: Int, x: Expression) = {
+  def addInput(prev: Int, x: Expression): Expression = {
     val expr = _builder.add_input(prev, x.expr)
     new Expression(expr)
   }

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Vector.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Vector.scala
@@ -8,6 +8,11 @@ package edu.cmu.dynet
 import scala.language.implicitConversions
 import scala.collection.JavaConverters._
 
+object IntVector {
+  implicit def Seq2IntVector(x: Seq[Int]) =
+    new IntVector(x)
+}
+
 class IntVector private[dynet] (private[dynet] val vector: internal.IntVector)
     extends scala.collection.mutable.IndexedSeq[Int] {
   def this(size: Long) { this(new internal.IntVector(size)) }
@@ -20,6 +25,11 @@ class IntVector private[dynet] (private[dynet] val vector: internal.IntVector)
   override def apply(idx: Int): Int = vector.get(idx)
   override def length: Int = vector.size.toInt
   override def update(idx: Int, elem: Int): Unit = vector.set(idx, elem)
+}
+
+object UnsignedVector {
+  implicit def Seq2UnsignedVector(x: Seq[Long]) =
+    new UnsignedVector(x)
 }
 
 /** SWIG converts C++ `unsigned` to Scala `Long` */
@@ -36,6 +46,11 @@ class UnsignedVector private[dynet] (private[dynet] val vector: internal.Unsigne
   override def update(idx: Int, elem: Long): Unit = vector.set(idx, elem)
 }
 
+object FloatVector {
+  implicit def Seq2FloatVector(x: Seq[Float]) =
+    new FloatVector(x)
+}
+
 class FloatVector private[dynet] (private[dynet] val vector: internal.FloatVector)
     extends scala.collection.mutable.IndexedSeq[Float] {
   def this(size: Long) { this(new internal.FloatVector(size)) }
@@ -47,6 +62,11 @@ class FloatVector private[dynet] (private[dynet] val vector: internal.FloatVecto
   override def apply(idx: Int): Float = vector.get(idx)
   override def length: Int = vector.size.toInt
   override def update(idx: Int, elem: Float): Unit = vector.set(idx, elem)
+}
+
+object ExpressionVector {
+  implicit def Seq2ExpressionVector(x: Seq[Expression]) =
+    new ExpressionVector(x)
 }
 
 class ExpressionVector private[dynet] (
@@ -79,6 +99,11 @@ class ExpressionVector private[dynet] (
     elem.ensureFresh()
     vector.set(idx, elem.expr)
   }
+}
+
+object UnsignedVectorVector {
+  implicit def Seq2UnsignedVectorVector(x: Seq[UnsignedVector]) =
+    new UnsignedVectorVector(x)
 }
 
 class UnsignedVectorVector private[dynet] (private[dynet] val vector: internal.UnsignedVectorVector)


### PR DESCRIPTION
To non-scala people: These definition allow to pass e.g. a Seq[Int] to a method
expecting an IntVector and and the compiler will automatically call the conversion
method constructing an IntVector from the sequence.
 - pro: less Code to write, easier interaction with scala-native data structures
 - con: conversion cost is hidden istead of explicit

This is a matter of style and maybe others don't like implicit conversions?
@shuheik and @joelgrus might have an opinion.

For me it is quite handy.  Alternatively, I would add it to a separate package
(e.g. edu.cmu.dynet.implicitConversions) which can be imported if needed.