### PR TITLE
Run Travis CI on release tags

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,7 +35,7 @@ install:
   - conda create -q -n test-env python=%PYTHON_VERSION% cython numpy pypandoc
   - activate test-env
   - cinst pandoc
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq $True) { (gc setup.py) -replace '. (version=.)0.0.0', '${1}' + "$env:APPVEYOR_REPO_TAG_NAME" | Out-File -encoding 'UTF8' setup.py }
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $True) { (gc setup.py) -replace '. (version=.)0.0.0', "`${1}$env:APPVEYOR_REPO_TAG_NAME" | Out-File -encoding 'UTF8' setup.py }
 
 before_build:
   - cmd: md build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 branches:
   only:
     - master
+    - /^[0-9.]*$/
 stages:
   - test
   - name: test_pip

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -2,7 +2,4 @@
 set -xe
 
 cd "$TRAVIS_BUILD_DIR"
-if [[ "$TRAVIS_OS_NAME" == linux ]]; then
-  python setup.py sdist  # Build sdist
-fi
 twine upload --skip-existing dist/*  # Upload to PyPI

--- a/.travis/install_dependencies.sh
+++ b/.travis/install_dependencies.sh
@@ -46,6 +46,10 @@ if [[ "$BACKEND" == cuda ]]; then
   sudo ln -s /usr/local/cuda-${CUDA_VERSION_MAJOR}.${CUDA_VERSION_MINOR} /usr/local/cuda
 fi
 
+if [[ "$TRAVIS_OS_NAME" == linux ]]; then
+  python setup.py sdist  # Build sdist
+fi
+
 # Eigen
 hg clone https://bitbucket.org/eigen/eigen/ -r 699b659
 cd eigen


### PR DESCRIPTION
Release 2.0.2 didn't trigger a deployment to PyPI because it didn't trigger a build at all, due to restriction to run builds only for `master`. Now they'll run for tags like "2.0.2" too.

For this one, I manually triggered a build here: https://travis-ci.org/danielhers/dynet/builds/319905996