### PR TITLE
Save/load with generators in Python API

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -649,7 +649,8 @@ cdef class Parameters: # {{{
             arr = np.asarray(arr)
         shape = arr.shape
         if self.shape() != shape:
-            raise ValueError("Shape of values and parameter don't match in Parameters.set_value")
+            raise ValueError("Shape of values and parameter don't match in Parameters.set_value: "
+                             "%s != %s" % (shape, self.shape()))
         arr = arr.flatten(order='F')
         self.thisptr.set_value(arr)
 
@@ -1190,7 +1191,7 @@ cdef class ParameterCollection: # {{{
         Returns:
             (dynet.Parameters): Created Parameter
         """
-        assert(isinstance(dim,(tuple,int)))
+        assert isinstance(dim,(tuple,int)), "Parameter dimension must be tuple or int: %s" % dim
         cdef CParameters p
         cdef CParameterInit *initializer
         cdef CDevice *dev
@@ -1220,7 +1221,7 @@ cdef class ParameterCollection: # {{{
         Returns:
             (dynet.LookupParameters): Created LookupParameter
         """
-        assert(isinstance(dim, tuple))
+        assert isinstance(dim, tuple), "Lookup parameter dimension must be tuple: %s" % dim
         cdef CDevice *dev
         cdef CLookupParameters p
         cdef int nids = dim[0]
@@ -1272,7 +1273,7 @@ cdef class ParameterCollection: # {{{
         Args:
             lam (float): Weight decay coefficient
         """
-        assert(isinstance(lam,float))
+        assert isinstance(lam,float), "Weight decay lambda must be float: %s" % lam
         self.thisptr.set_weight_decay_lambda(lam)
 
     cpdef name(self):
@@ -1695,7 +1696,7 @@ cdef class Expression: #{{{
             IndexError: If the indices are too large
             ValueError: In case of improper slice or if step is used
         """
-        assert isinstance(index, (int, slice))
+        assert isinstance(index, (int, slice)), "Expression key must be int or slice: %s" % index
         cdef int rows = self.c().dim().rows()
         cdef int i, j
         if isinstance(index, int):
@@ -5274,8 +5275,8 @@ class BiRNNBuilder(object): # {{{
         self.spec = num_layers, input_dim, hidden_dim, rnn_builder_factory, builder_layers
         model = self.model = model.add_subcollection("birnn")
         if builder_layers is None:
-            assert num_layers > 0
-            assert hidden_dim % 2 == 0, "BiRNN hidden dimension must be even."
+            assert num_layers > 0, "BiRNN number of layers must be positive: %d" % num_layers
+            assert hidden_dim % 2 == 0, "BiRNN hidden dimension must be even: %d" % hidden_dim
             self.builder_layers = []
             f = rnn_builder_factory(1, input_dim, hidden_dim/2, model)
             b = rnn_builder_factory(1, input_dim, hidden_dim/2, model)

--- a/tests/python/test.py
+++ b/tests/python/test.py
@@ -341,6 +341,10 @@ class TestIOHighLevelAPI(unittest.TestCase):
         dy.save(self.file, [self.b])
         [b] = dy.load(self.file, self.m2)
 
+    def test_save_load_generator(self):
+        dy.save(self.file, (x for x in [self.b]))
+        [b] = list(dy.load_generator(self.file, self.m2))
+
 
 class TestExpression(unittest.TestCase):
 


### PR DESCRIPTION
This allows saving memory or even showing a progress bar while loading the parameters (using `tqdm`, for example). This helps when waiting for a model to be saved/loaded, as it gives an idea for how far along it has got.
`load` has the same behavior as before. Added `load_generator`, which yields parameters rather than returning a list.
`save` didn't need to change at all, since it already supported generators. I only generalized the documentation.
Also used `with` syntactic sugar for opening files, and added informative messages to assertions.