### PR TITLE
add __gitversion__ info to python build

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -71,6 +71,13 @@ if(PYTHON)
   add_dependencies(pydynet pydynet_precopy)
   add_dependencies(pydynet_precopy dynet)
 
+  execute_process(
+      COMMAND git describe --tags --always
+      WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+      OUTPUT_VARIABLE GIT_DESCRIBE
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+      )
+
 endif()
 
 if (WITH_CUDA_BACKEND)

--- a/python/dynet.py.in
+++ b/python/dynet.py.in
@@ -16,6 +16,8 @@ else:
 
 __version__ = 2.0
 
+__gitversion__ = "${GIT_DESCRIBE}"
+
 # check HAVE_CUDA
 if not HAVE_CUDA:
     ERRMSG = 'DyNet was not installed with GPU support. Please see the installation instructions for how to make it possible to use GPUs.'

--- a/setup.py
+++ b/setup.py
@@ -346,7 +346,10 @@ class build_ext(_build_ext):
             for d in os.listdir("build"):
                 target_dir = os.path.join(SCRIPT_DIR, "build", d)
                 rmtree(target_dir, ignore_errors=True)
-                copytree(os.path.join("build", d), target_dir)
+                try:
+                    copytree(os.path.join("build", d), target_dir)
+                except OSError as e:
+                    log.info("Cannot copy %s %s" % (os.path.join("build",d), e))
 
 
 try:


### PR DESCRIPTION
This should allow:
```
import dynet
print dynet.__gitversion__
```
to get the exact version this module is based on.

It also fixes a build problem on my local machine, where automatic files prevented copytree from working.