### PR TITLE
[WIP] Python wheel for any commit

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,8 @@ environment:
     TWINE_USERNAME: danielh
     TWINE_PASSWORD:
       secure: cpMn69tLzuhwO7EPhhiVwA==
+    TWINE_PASSWORD_TEST:
+      secure: PgevW/oQiBa2F4u+FciQBA==
   matrix:
     - PYTHON_VERSION: 3.5
     - PYTHON_VERSION: 3.6
@@ -35,7 +37,15 @@ install:
   - conda create -q -n test-env python=%PYTHON_VERSION% cython numpy pypandoc
   - activate test-env
   - cinst pandoc
-  - ps: if ($env:APPVEYOR_REPO_TAG -eq $True) { (gc setup.py) -replace '. (version=.)0.0.0', "`${1}$env:APPVEYOR_REPO_TAG_NAME" | Out-File -encoding 'UTF8' setup.py }
+  - ps: >-
+      if ($env:APPVEYOR_REPO_TAG -eq $True) {
+        $VERSION = $env:APPVEYOR_REPO_TAG_NAME
+        $env:TWINE_SERVER = "pypi"
+      } else {
+        $VERSION = "0.0.0+git." + (git describe --tags --always)
+        $env:TWINE_SERVER = "testpypi"
+      }
+      (gc setup.py) -replace '. (version=.)0.0.0', "`${1}$VERSION" | Out-File -encoding 'UTF8' setup.py
 
 before_build:
   - cmd: md build
@@ -67,8 +77,13 @@ deploy_script:
   - echo [distutils]                                  > %USERPROFILE%\\.pypirc
   - echo index-servers =                             >> %USERPROFILE%\\.pypirc
   - echo     pypi                                    >> %USERPROFILE%\\.pypirc
+  - echo     testpypi                                >> %USERPROFILE%\\.pypirc
   - echo [pypi]                                      >> %USERPROFILE%\\.pypirc
-  - echo username=%PYPI_USERNAME%                    >> %USERPROFILE%\\.pypirc
-  - echo password=%PYPI_PASSWORD%                    >> %USERPROFILE%\\.pypirc
+  - echo username=%TWINE_USERNAME%                   >> %USERPROFILE%\\.pypirc
+  - echo password=%TWINE_PASSWORD%                   >> %USERPROFILE%\\.pypirc
+  - echo [testpypi]                                  >> %USERPROFILE%\\.pypirc
+  - echo username=%TWINE_USERNAME%                   >> %USERPROFILE%\\.pypirc
+  - echo password=%TWINE_PASSWORD_TEST%              >> %USERPROFILE%\\.pypirc
   - python -m pip install twine
-  - if "%APPVEYOR_REPO_TAG%"=="true" ( python -m twine upload --skip-existing dist/* build/python/dist/* )
+  - python -m twine upload --repository %TWINE_SERVER% --skip-existing dist/* build/python/dist/*
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - PYTHON=python TWINE_USERNAME=danielh
     - secure: "j8Ro21/7h5FKuJHPJRHYfOiZHMoAfD/dfpqXZreGrl79jVSEdPZmmOdvFH++CqrRdttpxOf2Lg5qOfpXfziC5ecJx1USslBSo2qwAG9JwPkwjCK7MhouM64yhVedj9Es/H635aufbyRsDIhKr5poPrrH+UebEq/63QpEdDWIWq8="
+    - secure: "F115kko2LxjQGU/hRzN7iBVh80DbfsKVpSq2clBfTBu5aKAYroPEhQunf4o5uECN71kyP/qld9JUtEbFySsRYYMtTGRAcexg2C935Ax65mLYDLvpZjQf7xpLjAEwkUYZp1prlrJi4E/pDofsGy4NP9QbarQveuaFzFAG4tJKkkU="
 branches:
   only:
     - master
@@ -187,5 +188,4 @@ deploy:
     - .travis/deploy.sh
   on:
     repo: clab/dynet
-    tags: true
     condition: "$PYTHON_INSTALL = pip"

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -2,4 +2,10 @@
 set -xe
 
 cd "$TRAVIS_BUILD_DIR"
-twine upload --skip-existing dist/*  # Upload to PyPI
+if [[ -n "$TRAVIS_TAG" ]]; then
+  REPO=  # Upload to PyPI
+else
+  REPO="--repository-url https://test.pypi.org/legacy/"  # Upload to TestPyPI
+fi
+twine upload $REPO --skip-existing dist/*
+

--- a/.travis/fix_version.sh
+++ b/.travis/fix_version.sh
@@ -3,7 +3,10 @@ set -xe
 
 cd "$TRAVIS_BUILD_DIR"
 if [[ -n "$TRAVIS_TAG" ]]; then
-  sed -i.bak "s/# version=.*/version=\"$TRAVIS_TAG\",/" setup.py
-  sed -i.bak "s/ -march=native//" CMakeLists.txt
+  VERSION="$TRAVIS_TAG"
+else
+  VERSION="0.0.0+git.$(git describe --tags --always)"
 fi
+sed -i.bak "s/# version=.*/version=\"$VERSION\",/" setup.py
+sed -i.bak "s/ -march=native//" CMakeLists.txt
 


### PR DESCRIPTION
This PR adds a unique identifier to the Python wheel (binary distribution) created for any commit on Travis CI and AppVeyor. The identifier is "git." + the commit hash. When uploaded to a cloud storage, this will allow easily testing any commit or PR without having to build DyNet yourself - just install from the wheel in a few seconds.
The problem is that PyPI (even TestPyPI) doesn't allow uploading distributions with "PEP 440 local versions", that is, with the "git." + commit suffix, as it's only intended for release distributions, so we can't use it to store the builds.
Can someone suggest another cloud storage to store these? I can configure Travis CI and AppVeyor to upload there, but I don't have the resources to maintain the storage.