### PR TITLE
Exposing weight-decay-lambda through parameter collection.

### DIFF
--- a/dynet/globals.cc
+++ b/dynet/globals.cc
@@ -10,7 +10,7 @@ namespace dynet {
 
 std::mt19937* rndeng = nullptr;
 Device* default_device = nullptr;
-float weight_decay_lambda;
+float default_weight_decay_lambda;
 int autobatch_flag; 
 int profiling_flag = 0;
 NamedTimer timer;

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -251,7 +251,7 @@ void initialize(DynetParams& params) {
   // Set weight decay rate
   if (params.weight_decay < 0 || params.weight_decay >= 1)
     throw std::invalid_argument("[dynet] weight decay parameter must be between 0 and 1 (probably very small like 1e-6)\n");
-  weight_decay_lambda = params.weight_decay;
+  default_weight_decay_lambda = params.weight_decay;
 
   // Set autobatch
   if(params.autobatch)

--- a/dynet/init.h
+++ b/dynet/init.h
@@ -6,7 +6,7 @@
 
 namespace dynet {
 
-extern float weight_decay_lambda;
+extern float default_weight_decay_lambda;
 extern int autobatch_flag;
 extern int profiling_flag;
 

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -462,7 +462,7 @@ struct LookupParameter {
 // This is an internal class to store parameters in the collection
 struct ParameterCollectionStorage {
 
-  ParameterCollectionStorage();
+  ParameterCollectionStorage(float weight_decay_lambda);
 
   ~ParameterCollectionStorage();
 
@@ -500,10 +500,17 @@ public:
   friend struct LookupParameter;
 
   /**
-   * \brief Constructor
+   * \brief Constructor.
+   * \details Weight-decay value is taken from commandline option.
    */
   ParameterCollection();
   ~ParameterCollection();
+
+  /**
+   * \brief Constructor.
+   * \param weight_decay_lambda Default weight-decay value for this collection.
+   */
+  ParameterCollection(float weight_decay_lambda);
   /**
    * \brief Returns the l2 of your gradient
    * \details Use this to look for gradient vanishing/exploding
@@ -699,9 +706,11 @@ public:
    *          (possibly named) subset of the original collection. This is
    *          useful if you want to save/load/update only part of the
    *          parameters in the model.
+   * \param name 
+   * \param weight_decay_lambda if negative/omitted, inherit from parent.
    * \return The subcollection
    */
-  ParameterCollection add_subcollection(const std::string& name = "");
+  ParameterCollection add_subcollection(const std::string& name = "", float weight_decay_lambda = -1);
 
   /**
    * \brief Get size
@@ -732,7 +741,7 @@ protected:
   void add_lookup_parameters_to_storage(std::shared_ptr<LookupParameterStorage> p);
 
 private:
-  ParameterCollection(const std::string & name, ParameterCollection* parent);
+  ParameterCollection(const std::string & name, ParameterCollection* parent, float weight_decay_lambda);
   std::string name;
   std::unordered_map<std::string,int> name_cntr, collec_name_cntr;
   ParameterCollectionStorage * storage;

--- a/dynet/model.h
+++ b/dynet/model.h
@@ -719,6 +719,11 @@ public:
    */
   L2WeightDecay& get_weight_decay() { return get_storage().weight_decay; }
 
+  /**
+   * \brief Get the weight decay lambda value.
+   */
+  float get_weight_decay_lambda() { return get_weight_decay().get_lambda(); }
+
   ParameterCollectionStorage& get_storage();
   const ParameterCollectionStorage& get_storage() const;
 

--- a/dynet/weight-decay.h
+++ b/dynet/weight-decay.h
@@ -19,6 +19,7 @@ struct L2WeightDecay {
     if (lam < 0) throw std::domain_error("Bad value of lambda in set_lambda");
     lambda = lam;
   }
+  float get_lambda() { return lambda; }
   void update_weight_decay(unsigned num_updates = 1) {
     if (num_updates == 0) return;
     if (num_updates == 1)

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -105,6 +105,7 @@ cdef extern from "dynet/model.h" namespace "dynet":
         #float gradient_l2_norm() const
         CParameters add_parameters(CDim& d)
         CParameters set_weight_decay_lambda(float lam)
+        float get_weight_decay_lambda()
         CParameters add_parameters(CDim& d, CParameterInit initializer, string name) except +
         CParameters add_parameters(CDim& d, CParameterInit initializer, string name, CDevice *device) except +
         #CLookupParameters add_lookup_parameters(unsigned n, const CDim& d)

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -1279,9 +1279,23 @@ cdef class ParameterCollection: # {{{
         """
         return ParameterCollection.wrap(self.thisptr.add_subcollection((name or "").encode()), self)
 
-    cpdef set_weight_decay_lambda(self, lam):
+    cpdef float get_weight_decay(self):
+        """Get the weight decay lambda value.
+        """
+        return self.thisptr.get_weight_decay_lambda()
+
+    cpdef set_weight_decay(self, float lam):
         """Set the weight decay coefficient.
         
+        Args:
+            lam (float): Weight decay coefficient
+        """
+        assert isinstance(lam,float), "Weight decay lambda must be float: %s" % lam
+        self.thisptr.set_weight_decay_lambda(lam)
+
+    cpdef set_weight_decay_lambda(self, lam):
+        """Set the weight decay coefficient. (alias to set_weight_decay)
+
         Args:
             lam (float): Weight decay coefficient
         """


### PR DESCRIPTION
Adding access to the weight-decay lambda value (both setting and getting) from python and cpp.

The second commit also fixes the issue in #1243 .