### PR TITLE
Fixed corner case causing incorrect values in autobatching

### DIFF
--- a/dynet/exec.cc
+++ b/dynet/exec.cc
@@ -841,7 +841,7 @@ const Tensor& BatchedExecutionEngine::incremental_forward_no_update(
         for(size_t i = 0; i < arity; ++i) {
           // 1) the inputs don't need to be concatenated. Just use the tensor
           if(!my_batch.concat[i]) {
-            my_batch.arg_nfxs[i] = &batches[node2batch[node->args[i]]].nfx;
+            my_batch.arg_nfxs[i] = &get_nfx(node->args[i]);
           // 2) the inputs need to be concatenated
           } else {
             // 2.a) the inputs need to be concatenated, but are already in the


### PR DESCRIPTION
This PR fixes a corner case that caused autobatching to give incorrect results. Specifically it happens when there is a node that:
1. Is autobatched together
2. Takes an input that is not batched (e.g. the left side of a matrix multiply, which is usually a parameter matrix)
3. That input was calculated in an autobatched manner
4. That input was not the first element of the batch when it was calculated

I believe this is a pretty rare case, so most programs that ran using autobatched results will never encounter this. That being said, we did encounter it in the wild, so anyone who is using autobatching should probably upgrade to the latest version once this PR is merged.