### PR TITLE
dynet-1298. Add ** support for pow op.

### DIFF
--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1131,12 +1131,12 @@ Expression softsign(const Expression& x);
 /**
  * \ingroup arithmeticoperations
  * \brief Power function
- * \details Calculate an output where the ith element is equal to x_i^y_i
+ * \details Calculate an output where the ith element is equal to x_i^y
  *
  * \param x The input expression
- * \param y The exponent expression
+ * \param y The exponent expression(scalar expression)
  *
- * \return An expression where the ith element is equal to x_i^y_i
+ * \return An expression where the ith element is equal to x_i^y
  */
 Expression pow(const Expression& x, const Expression& y);
 

--- a/dynet/nodes-arith-cwise.h
+++ b/dynet/nodes-arith-cwise.h
@@ -55,6 +55,7 @@ struct CwiseQuotient : public Node {
 
 // y = pow(x_1, x_2)
 // x_2 raise every element in x_1 to the power of scalar x_2
+// TODO: coefficient-wise support from Eigen::TensorMap
 struct Pow : public Node {
   explicit Pow(const std::initializer_list<VariableIndex>& a) : Node(a) {}
   DYNET_NODE_DEFINE_DEV_IMPL()

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -859,6 +859,12 @@ cdef class Expression: #{{{
         elif isinstance(self,Expression) and isinstance(other,(int, float)):
             return _neg(_scalarsub(other, self))
         else: raise NotImplementedError()
+    def __pow__(self, other, _):
+        if isinstance(self, Expression) and isinstance(other, Expression):
+            return pow(self, other)
+        elif isinstance(self, Expression) and isinstance(other, (int, float)):
+            return pow(self, scalarInput(other))
+        else: raise NotImplementedError()
 #}}}
 
 

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3606,14 +3606,14 @@ cpdef Expression constrained_softmax(Expression x, Expression y):
 cpdef Expression pow(Expression x, Expression y):
     """Power function
     
-    Calculate an output where the ith element is equal to :math:`x_i^{y_i}`
+    Calculate an output where the ith element is equal to :math:`x_i^{y}`
 
     Args:
         x (dynet.Expression): The first input expression
-        y (dynet.Expression): The second input expression
+        y (dynet.Expression): The second input expression(scalar expression)
     
     Returns:
-        dynet.Expression: :math:`x_i^{y_i}`
+        dynet.Expression: :math:`x_i^{y}`
     """
     ensure_freshness(y); 
     return Expression.from_cexpr(x.cg_version, c_pow(x.c(), y.c()))

--- a/tests/test-dim.cc
+++ b/tests/test-dim.cc
@@ -36,5 +36,11 @@ BOOST_AUTO_TEST_CASE( test_dim_truncate_multiple_one ) {
     BOOST_CHECK_EQUAL(t1.nd, 1);
 }
 
+BOOST_AUTO_TEST_CASE( test_dim_truncate_a_one ) {
+    Dim d1({1});
+    Dim t1 = d1.truncate();
+    BOOST_CHECK_EQUAL(t1.nd, 1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 


### PR DESCRIPTION
Address https://github.com/clab/dynet/issues/1298.

Before:
```
t = dy.inputVector([1,2,3])
l = dy.pow(t, dy.scalarInput(2)).value() # works: [1., 4., 9.]
l = dy.pow(t, dy.inputVector([2]).value() # works: [1., 4., 9.]
l = dy.pow(t, dy.inputVector([2, 2, 2]))  # don't support
l = dy.pow(t, 2) # don't support
l = t ** 2 # don't support
```

After:
```
t = dy.inputVector([1,2,3])
l = dy.pow(t, dy.scalarInput(2)).value() # works: [1., 4., 9.]
l = dy.pow(t, dy.inputVector([2]).value() # works: [1., 4., 9.]
l = dy.pow(t, dy.inputVector([2, 2, 2]))  # don't support, waiting for Eigen::Tensor cwise pow impl
l = dy.pow(t, 2) # don't support since we should be consistent with the params of dynet operators
l = (t ** 2).value() # works: [1., 4., 9.]
l = (t ** dy.scalarInput(2)).value() # works: [1., 4., 9.]
```