### PR TITLE
Adding TensorTools::topk.

### DIFF
--- a/dynet/tensor.h
+++ b/dynet/tensor.h
@@ -349,6 +349,18 @@ struct TensorTools {
    */
   static IndexTensor categorical_sample_log_prob(const Tensor& v, unsigned dim = 0, unsigned num = 1);
 
+  /**
+  * \brief Calculate the k-max values and their indexes
+  *
+  * \param v A tensor where each row represents a probability distribution
+  * \param dim Which dimension to take the kmax over
+  * \param num The number of kmax values
+  *
+  * \returns A newly allocated pair<Tensor, LongTensor> consisting of argmax Vals/IDs. The length of the
+  *          dimension "dim" will be "num", consisting of the appropriate Vals/IDs.
+  */
+  static std::pair<Tensor, IndexTensor> topk(const Tensor& v, unsigned dim = 0, unsigned num = 1);
+
   // Device functions that can be called directly if the device is already known
   template<class MyDevice>
   static void clip_dev(const MyDevice & dev, Tensor& d, float left, float right);
@@ -366,6 +378,8 @@ struct TensorTools {
   static IndexTensor categorical_sample_log_prob_dev(const MyDevice & dev, const Tensor& v, unsigned dim = 0, unsigned num = 1);
   template <class MyDevice>
   static void logsumexp_dev(const MyDevice & dev, const Tensor& x, Tensor &m, Tensor &z, unsigned d = 0);
+  template <class MyDevice>
+  static std::pair<Tensor, IndexTensor> topk_dev(const MyDevice & dev, const Tensor& v, unsigned dim = 0, unsigned num = 1);
 
 };
 

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -2,6 +2,7 @@ from libcpp.memory cimport shared_ptr
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libcpp cimport bool
+from libcpp.pair cimport pair
 
 ctypedef float real
 
@@ -58,6 +59,8 @@ cdef extern from "dynet/index-tensor.h" namespace "dynet":
         CIndexTensor argmax(CTensor& t, unsigned dim, unsigned num) 
         @staticmethod
         CIndexTensor categorical_sample_log_prob(CTensor& t, unsigned dim, unsigned num) 
+        @staticmethod
+        pair[CTensor, CIndexTensor] topk(CTensor& t, unsigned dim, unsigned num)
 
 cdef extern from "dynet/model.h" namespace "dynet":
     cdef cppclass CParameterStorage "dynet::ParameterStorage":

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -2075,6 +2075,19 @@ cdef class Tensor: #{{{
             dimension "dim" will be "num", consisting of the appropriate IDs.
         """
         return Tensor.wrap_cindextensor(CTensorTools.categorical_sample_log_prob(self.t, dim, num))
+
+    cpdef topk(self, unsigned dim=0, unsigned num=1):
+        """Calculate the index of the topk value.
+
+        Keyword Args:
+            dim(integer): which dimension to take the topk over
+            num(integer): the number of topk values
+        
+        Returns:
+            A pair of newly allocated Tensor/IndexTensor consisting of values/indexes.
+        """
+        cdef pair[CTensor, CIndexTensor] res = CTensorTools.topk(self.t, dim, num)
+        return (Tensor.wrap_ctensor(res.first), Tensor.wrap_cindextensor(res.second))
 # Tensor }}}
 
 #{{{ Expressions

--- a/tests/test-tensor.cc
+++ b/tests/test-tensor.cc
@@ -60,6 +60,23 @@ BOOST_AUTO_TEST_CASE( argmax ) {
                                 idx_act.begin(), idx_act.end());
 }
 
+// test whether topk is working properly
+BOOST_AUTO_TEST_CASE(topk) {
+  dynet::ComputationGraph cg;
+  Expression x1 = input(cg, Dim({3}, 2), batch_vals);
+  std::pair<Tensor, IndexTensor> rets = TensorTools::topk(x1.value());
+  // idx
+  vector<Eigen::DenseIndex> idx_act = as_vector(rets.second);
+  vector<Eigen::DenseIndex> idx_exp = {1, 2};
+  BOOST_CHECK_EQUAL_COLLECTIONS(idx_exp.begin(), idx_exp.end(),
+    idx_act.begin(), idx_act.end());
+  // val
+  vector<float> val_act = as_vector(rets.first);
+  vector<float> val_exp = {2.f, 6.f};
+  BOOST_CHECK_EQUAL_COLLECTIONS(val_act.begin(), val_act.end(),
+    val_exp.begin(), val_exp.end());
+}
+
 // for now, just make sure that things don't die
 BOOST_AUTO_TEST_CASE( categorical_sample_log_prob ) {
   dynet::ComputationGraph cg;

--- a/third_party/topk.h
+++ b/third_party/topk.h
@@ -1,0 +1,119 @@
+#ifndef _H_TOPK
+#define _H_TOPK
+
+//#define HAVE_CUDA 1
+
+#ifdef __CUDACC__
+
+#include <Eigen/Eigen>
+#include <unsupported/Eigen/CXX11/Tensor>
+
+// using eigen, but only one-argmax
+namespace impl_eigen{
+  template<typename T, typename IndexType, bool IsMax=true>
+  cudaError topk(T* input, T* ouput_val, IndexType* ouput_idx,
+    IndexType outer_size, IndexType inner_size, IndexType cur_size, IndexType k,
+    Eigen::GpuDevice& my_device){
+    throw std::runtime_error("Not implemented topk-EIGEN for IndexType != Eigen::DenseIndex.");
+  }
+
+  template<typename T, bool IsMax=true>
+  cudaError topk(T* input, T* ouput_val, Eigen::DenseIndex* ouput_idx,
+    Eigen::DenseIndex outer_size, Eigen::DenseIndex inner_size, Eigen::DenseIndex cur_size, Eigen::DenseIndex k,
+    Eigen::GpuDevice& my_device){
+    // only argmax
+    if(k != 1)
+      throw std::runtime_error("Not implemented topk-EIGEN for k != 1.");
+    const Eigen::array<Eigen::DenseIndex, 1> reduction_axis = {1};
+    if(IsMax){
+      (Eigen::TensorMap<Eigen::Tensor<Eigen::DenseIndex, 2>>(ouput_idx, inner_size, outer_size)).device(my_device)
+        = (Eigen::TensorMap<Eigen::Tensor<T, 3>>(input, inner_size, cur_size, outer_size)).argmax(1);
+      (Eigen::TensorMap<Eigen::Tensor<T, 2>>(ouput_val, inner_size, outer_size)).device(my_device)
+        = (Eigen::TensorMap<Eigen::Tensor<T, 3>>(input, inner_size, cur_size, outer_size)).maximum(reduction_axis);
+    }
+    else{
+      (Eigen::TensorMap<Eigen::Tensor<Eigen::DenseIndex, 2>>(ouput_idx, inner_size, outer_size)).device(my_device)
+        = (Eigen::TensorMap<Eigen::Tensor<T, 3>>(input, inner_size, cur_size, outer_size)).argmin(1);
+      (Eigen::TensorMap<Eigen::Tensor<T, 2>>(ouput_val, inner_size, outer_size)).device(my_device)
+        = (Eigen::TensorMap<Eigen::Tensor<T, 3>>(input, inner_size, cur_size, outer_size)).minimum(reduction_axis);
+    }
+    return cudaGetLastError();
+  }
+};
+
+#include "topk_tf.h"
+#include "topk_tr.h"
+
+namespace topk_gpu{
+
+  enum TopK_Gpu_Strategy { TOPK_AUTO=0, TOPK_TF, TOPK_TR, TOPK_EIGEN };
+
+  template<typename T, typename IndexType, bool IsMax, int Strategy>
+  cudaError topk(T* input, T* output_val, IndexType* output_idx,
+    IndexType outer_size, IndexType inner_size, IndexType cur_size, IndexType k, Eigen::GpuDevice* dev=nullptr){
+    // auto mode depending on k
+    auto strat = Strategy;
+    if(Strategy == TOPK_AUTO){
+      // TODO: simple rule based (can be further extended)
+      strat = ((k<=16) ? TOPK_TF : TOPK_TR);
+    }
+    if(strat == TOPK_TF)   // max-shards
+      return impl_tf::topk<T, IndexType, IsMax>(input, output_val, output_idx, outer_size, inner_size, cur_size, k, 0);
+    else if(strat == TOPK_TR)
+      return impl_tr::topk<T, IndexType, IsMax>(input, output_val, output_idx, outer_size, inner_size, cur_size, k);
+    else if(strat == TOPK_EIGEN)
+      return impl_eigen::topk<T, IndexType, IsMax>(input, output_val, output_idx, outer_size, inner_size, cur_size, k, *dev);
+    else
+      throw std::runtime_error("Unknown topk strategy.");
+  }
+}
+
+#endif
+
+#include <algorithm>
+#include <vector>
+
+// simple loop with nth-element
+namespace topk_cpu{
+  template<typename T>
+  bool gt(const T& a, const T& b){ return a.value > b.value;}
+
+  template<typename T>
+  bool lt(const T& a, const T& b){ return a.value < b.value; }
+
+  template <typename T, typename IndexType>
+  struct Entry {
+    IndexType index;
+    T value;
+  };
+
+  template<typename T, typename IndexType, bool IsMax>
+  void topk(T* input, T* ouput_val, IndexType* ouput_idx,
+    IndexType outer_size, IndexType inner_size, IndexType cur_size, IndexType k){
+    using std::vector;
+    for(IndexType i = 0; i < outer_size*inner_size; i++){
+      IndexType slice = i;
+      T* input_start = input + slice/inner_size*inner_size*cur_size + slice%inner_size;
+      T* output_val_start = ouput_val + slice/inner_size*inner_size*k + slice%inner_size;
+      IndexType* ouput_idx_start = ouput_idx + slice/inner_size*inner_size*k + slice%inner_size;
+      // copy into a vector
+      vector<Entry<T, IndexType>> entries;
+      for(IndexType step = 0; step < cur_size; step++)
+        entries.push_back({step, input_start[step*inner_size]});
+      // split
+      if(IsMax)
+        std::nth_element(entries.begin(), entries.begin()+k-1, entries.end(), gt<Entry<T, IndexType>>);
+      else
+        std::nth_element(entries.begin(), entries.begin()+k-1, entries.end(), lt<Entry<T, IndexType>>);
+      // assign
+      for(IndexType step = 0; step < k; step++){
+        const auto& one = entries[step];
+        output_val_start[step*inner_size] = one.value;
+        ouput_idx_start[step*inner_size] = one.index;
+      }
+    }
+  }
+}
+
+#endif // !_H_TOPK
+

--- a/third_party/topk_tf.h
+++ b/third_party/topk_tf.h
@@ -1,0 +1,409 @@
+/* Copyright 2017 The TensorFlow Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// modified version of heap-based topk from tensorflow
+// https://github.com/tensorflow/tensorflow/tree/6bcc00668094be8daf8465b8689bbed5ab285b2d/tensorflow/core/kernels/topk_op_gpu.cu.cc
+
+#ifndef _TOPK_TF
+#define _TOPK_TF
+
+#include <stdexcept>
+#include <sstream>
+#include <cstdlib>
+#include <assert.h>
+
+// tensorflow's implementation using max/min-heap
+// - from tensorflow/tensorflow/core/kernels/topk_op_gpu.cu.cc
+namespace impl_tf {
+
+  enum class HeapType { kMinHeap, kMaxHeap };
+  enum class PreferIndices { kLower, kHigher };   // prefer which index if equal
+
+  template <typename T, typename IndexType>
+  struct Entry {
+    IndexType index;
+    T value;
+  };
+
+  template <typename T, typename IndexType>
+  struct LinearData {
+    typedef impl_tf::Entry<T, IndexType> Entry;
+    __device__ Entry& operator[](IndexType index) const { return data[index]; }
+    __device__ IndexType get_index(IndexType i) const { return data[i].index; }
+    __device__ T get_value(IndexType i) const { return data[i].value; }
+    Entry* const data;
+  };
+
+  template <typename T, typename IndexType>
+  struct IndirectLinearData {
+    typedef impl_tf::Entry<T, IndexType> Entry;
+    __device__ Entry& operator[](IndexType index) const { return data[index]; }
+    __device__ IndexType get_index(IndexType i) const { return backing_data[data[i].index].index; }
+    __device__ T get_value(IndexType i) const { return data[i].value; }
+    Entry* const data;
+    Entry* const backing_data;
+  };
+
+  template <typename T, typename IndexType>
+  struct StridedData {
+    typedef impl_tf::Entry<T, IndexType> Entry;
+    // Here distributing among the different threads (shards)
+    __device__ Entry& operator[](IndexType index) const { return data[index * blockDim.x + threadIdx.x]; }
+    __device__ IndexType get_index(IndexType i) const { return (*this)[i].index; }
+    __device__ T get_value(IndexType i) const { return (*this)[i].value; }
+    Entry* const data;
+  };
+
+
+  // A heap of Entry<T> that can either work as a min-heap or as a max-heap.
+  template <HeapType heapType, PreferIndices preferIndices, template <typename, typename> class Data, typename T, typename IndexType>
+  struct IndexedHeap {
+    typedef typename Data<T, IndexType>::Entry Entry;
+    const Data<T, IndexType> data;
+
+    // indicating whether left should be prior to right
+    __device__ bool is_above(IndexType left, IndexType right) {
+      T left_value = data.get_value(left);
+      T right_value = data.get_value(right);
+      if(left_value == right_value) {
+        if(preferIndices == PreferIndices::kLower) {
+          return data.get_index(left) < data.get_index(right);
+        }
+        else {
+          return data.get_index(left) > data.get_index(right);
+        }
+      }
+      if(heapType == HeapType::kMinHeap) {
+        return left_value < right_value;
+      }
+      else {
+        return left_value > right_value;
+      }
+    }
+
+    // assign one entry
+    __device__ void assign(IndexType i, const Entry& entry) { data[i] = entry; }
+
+    // swap
+    __device__ void swap(IndexType a, IndexType b) {
+      auto tmp = data[b];
+      data[b] = data[a];
+      data[a] = tmp;
+    }
+
+    // upward from i
+    __device__ void push_up(IndexType i) {
+      IndexType child = i;
+      IndexType parent;
+      for(; child > 0; child = parent) {
+        parent = (child - 1) / 2;
+        if(!is_above(child, parent)) {
+          // Heap property satisfied.
+          break;
+        }
+        swap(child, parent);
+      }
+    }
+
+    __device__ void push_root_down(IndexType k) { push_down(0, k); }
+
+    // MAX-HEAPIFY in Cormen, k is the range
+    __device__ void push_down(IndexType node, IndexType k) {
+      while(true) {
+        const IndexType left = 2 * node + 1;
+        const IndexType right = left + 1;
+        IndexType smallest = node;
+        if(left < k && is_above(left, smallest)) {
+          smallest = left;
+        }
+        if(right < k && is_above(right, smallest)) {
+          smallest = right;
+        }
+        if(smallest == node) {
+          break;
+        }
+        swap(smallest, node);
+        node = smallest;
+      }
+    }
+
+    // BUILD-MAX-HEAPIFY in Cormen
+    __device__ void build(IndexType k) {
+      for(IndexType node = (k - 1) / 2; node >= 0; node--) {
+        push_down(node, k);
+      }
+    }
+
+    // HEAP-EXTRACT-MAX in Cormen
+    __device__ void remove_root(IndexType k) {
+      data[0] = data[k - 1];
+      push_root_down(k - 1);
+    }
+
+    // in-place HEAPSORT in Cormen (turn minHeap to max-sorting)
+    // This method destroys the heap property.
+    __device__ void sort(IndexType k) {
+      for(IndexType slot = k - 1; slot > 0; slot--) {
+        // This is like remove_root but we insert the element at the end.
+        swap(slot, 0);
+        // Heap is now an element smaller.
+        push_root_down(/*k=*/slot);
+      }
+    }
+
+    __device__ void replace_root(const Entry& entry, IndexType k) {
+      data[0] = entry;
+      push_root_down(k);
+    }
+
+    __device__ const Entry& root() { return data[0]; }
+  };
+
+  template <HeapType heapType, PreferIndices preferIndices, template <typename, typename> class Data, typename T, typename IndexType>
+  __device__ IndexedHeap<heapType, preferIndices, Data, T, IndexType> make_indexed_heap(
+    typename Data<T, IndexType>::Entry* data) {
+    return IndexedHeap<heapType, preferIndices, Data, T, IndexType>{Data<T, IndexType>{data}};
+  }
+
+  // heapTopK walks over [input, input+length) with `step_size` stride starting at
+  // `start_index`.
+  // It builds a top-`k` heap that is stored in `heap_entries` using `Accessor` to
+  // access elements in `heap_entries`. If sorted=true, the elements will be
+  // sorted at the end.
+  // -- start_index and step_size are at cur_size-level, which is over another level stride of inner_size
+  // -- only consider the inner_size (inner_stride) when reading the real value from input
+  template <typename T, typename IndexType, template <typename, typename> class Data, bool IsMax>
+  __device__ void heapTopK(const T* __restrict__ input, IndexType length, IndexType k, Entry<T, IndexType>* __restrict__ heap_entries,
+    bool sorted, IndexType start_index, IndexType step_size, IndexType inner_size) {
+    // this should be restricted previously
+    //assert(k <= (length-start_index+step_size-1)/step_size);
+    // the min value as the threshold
+    // -- with kHigher preference means prefer lower-indexed top values
+    constexpr auto HeapType = IsMax ? HeapType::kMinHeap : HeapType::kMaxHeap;
+    auto heap = make_indexed_heap<HeapType, PreferIndices::kHigher, Data, T, IndexType>(heap_entries);
+
+    IndexType heap_end_index = start_index + k * step_size;
+    if(heap_end_index > length) {
+      heap_end_index = length;
+    }
+    // Initialize the min-heap with the first k ones.
+    for(IndexType index = start_index, slot = 0; index < heap_end_index; index += step_size, slot++) {
+      heap.assign(slot, {index, input[index*inner_size]});
+    }
+    heap.build(k);
+    // Now iterate over the remaining items.
+    // If an item is smaller than the min element, it is not amongst the top k.
+    // Otherwise, replace the min element with it and push upwards.
+    for(IndexType index = heap_end_index; index < length; index += step_size) {
+      // We prefer elements with lower indices. This is given here.
+      // Later elements automatically have higher indices, so can be discarded.
+      auto this_value = input[index*inner_size];
+      bool to_replace;
+      if(IsMax)   // if kmax, ignore values that are smaller than the smallest value in minHeap
+        to_replace = (this_value > heap.root().value);
+      else
+        to_replace = (this_value < heap.root().value);
+      if(to_replace) {
+        // This element should replace the min.
+        heap.replace_root({index, this_value}, k);
+      }
+    }
+    // Sort if wanted.
+    if(sorted) {
+      heap.sort(k);
+    }
+  }
+
+  // mergeShards performs a top-k merge on `num_shards` many sorted streams that
+  // are sorted and stored in `entries` in a strided way:
+  // |s_1 1st|s_2 1st|...s_{num_shards} 1st|s_1 2nd|s_2 2nd|...
+  // The overall top k elements are written to `top_k_values` and their indices
+  // to top_k_indices.
+  // `top_k_heap` is used as temporary storage for the merge heap.
+  template <typename T, typename IndexType, bool IsMax>
+  __device__ void mergeShards(IndexType num_shards, IndexType k,
+    Entry<T, IndexType>* __restrict__ entries, Entry<T, IndexType>* __restrict__ top_k_heap,
+    T* top_k_values, IndexType* top_k_indices, IndexType inner_size) {
+    // If k < num_shards, we can use a min-heap with k elements to get the top k
+    // of the sorted blocks.
+    // If k > num_shards, we can initialize a min-heap with the top element from
+    // each sorted block.
+    const IndexType heap_size = k < num_shards ? k : num_shards;
+
+    // TODO: the heaps could have garbage if too many shards or too few length
+    // Min-heap part.
+    {
+      constexpr auto HeapType = IsMax ? HeapType::kMinHeap : HeapType::kMaxHeap;
+      auto min_heap = IndexedHeap<HeapType, PreferIndices::kHigher,
+        IndirectLinearData, T, IndexType>{IndirectLinearData<T, IndexType>{top_k_heap, entries}};
+      // Initialize the heap as a min-heap.
+      for(IndexType slot = 0; slot < heap_size; slot++) {
+        min_heap.assign(slot, {slot, entries[slot].value});
+      }
+      min_heap.build(heap_size);
+
+      // Now perform top k with the remaining shards (if num_shards > heap_size).
+      for(IndexType shard = heap_size; shard < num_shards; shard++) {
+        const auto entry = entries[shard];
+        const auto root = min_heap.root();
+        //
+        if(IsMax){
+          if(entry.value < root.value) continue;
+        }
+        else{
+          if(entry.value > root.value) continue;
+        }
+        // prefer lower index
+        if(entry.value == root.value &&
+          entry.index > entries[root.index].index) {
+          continue;
+        }
+        // This element should replace the min.
+        min_heap.replace_root({shard, entry.value}, heap_size);
+      }
+    }
+
+    // Max-part.
+    {
+      // Turn the min-heap into a max-heap in-place.
+      constexpr auto HeapType = (!IsMax) ? HeapType::kMinHeap : HeapType::kMaxHeap;
+      auto max_heap = IndexedHeap<HeapType, PreferIndices::kLower,
+        IndirectLinearData, T, IndexType>{IndirectLinearData<T, IndexType>{top_k_heap, entries}};
+
+      // Heapify into a max heap.
+      max_heap.build(heap_size);
+
+      // Now extract the minimum k-1 times.
+      // k is treated specially.
+      const IndexType last_k = k - 1;
+      for(IndexType rank = 0; rank < last_k; rank++) {
+        const Entry<T, IndexType>& max_element = max_heap.root();
+        top_k_values[rank*inner_size] = max_element.value;
+        IndexType shard_index = max_element.index;
+        top_k_indices[rank*inner_size] = entries[shard_index].index;
+        IndexType next_shard_index = shard_index + num_shards;
+        // For rank < k-1, each top k heap still contains at least 1 element,
+        // so we can draw a replacement.
+        max_heap.replace_root({next_shard_index, entries[next_shard_index].value}, heap_size);
+      }
+
+      // rank == last_k.
+      const Entry<T, IndexType>& max_element = max_heap.root();
+      top_k_values[last_k*inner_size] = max_element.value;
+      IndexType shard_index = max_element.index;
+      top_k_indices[last_k*inner_size] = entries[shard_index].index;
+    }
+  }
+
+  extern __shared__ char shared_memory[];
+
+  template <typename T, typename IndexType, bool IsMax>
+  __global__ void TopKKernel(T* input, T* ouput_val, IndexType* ouput_idx,
+    IndexType outer_size, IndexType inner_size, IndexType cur_size, IndexType k) {
+    // 
+    IndexType slice = blockIdx.x;
+    if(slice >= outer_size*inner_size) {
+      return;
+    }
+    // prepare data
+    T* input_start = input + slice/inner_size*inner_size*cur_size + slice%inner_size;
+    T* output_val_start = ouput_val + slice/inner_size*inner_size*k + slice%inner_size;
+    IndexType* ouput_idx_start = ouput_idx + slice/inner_size*inner_size*k + slice%inner_size;
+
+    // heap-select with strided elements
+    const IndexType thread_index = threadIdx.x;   // index of the shards
+    const IndexType thread_count = blockDim.x;    // how many shards
+    Entry<T, IndexType>* shared_entries = (Entry<T, IndexType>*)shared_memory;
+    heapTopK<T, IndexType, StridedData, IsMax>(input_start, cur_size, k, shared_entries, true, thread_index, thread_count, inner_size);
+    __syncthreads();
+
+    // merge
+    if(thread_index == 0) {
+      // TODO(blackhc): Erich says: Performance can likely be improved
+      // significantly by having the merge be done by multiple threads rather than
+      // just one.  ModernGPU has some nice primitives that could help with this.
+      Entry<T, IndexType>* top_k_heap = shared_entries + thread_count * k;
+      mergeShards<T, IndexType, IsMax>(thread_count, k, shared_entries, top_k_heap, output_val_start, ouput_idx_start, inner_size);
+    }
+  }
+
+  template<typename T, typename IndexType>
+  IndexType get_max_num_shards(IndexType k, IndexType length){
+    // This code assumes that k is small enough that the computation
+    // fits inside shared memory (hard coded to 48KB).
+    constexpr IndexType shared_memory_size = 48 << 10;  // 48 KB
+    const IndexType heap_size = k * sizeof(Entry<T, IndexType>);
+    // - shared_memory_size = (num_shards + 1) * heap_size <=>
+    IndexType max_num_shards = shared_memory_size / heap_size - 1;
+    if(max_num_shards <= 0){
+      // too large k for this implementation
+      IndexType maxk = shared_memory_size / (2 * heap_size);
+      std::ostringstream ss;
+      ss << "Too large k: " << k << " for heap-based topk, with 48K shared gpu memory the max-k is " << maxk;
+      std::string err_info = ss.str();
+      throw std::runtime_error(err_info);
+    }
+    //
+    IndexType upper_limit = max_num_shards;                 // memory restriction
+    upper_limit = std::min(upper_limit, IndexType(1024));   // hard restriction
+    upper_limit = std::min(upper_limit, length / k);        // no need to be too large
+    return upper_limit;
+  }
+
+  template<typename T, typename IndexType>
+  IndexType get_auto_num_shards(IndexType k, IndexType length){
+    // TODO: simple & kind-of casual rules by observing some of the results
+    IndexType max_num_shards = get_max_num_shards<T, IndexType>(k, length);
+    if(max_num_shards <= 8)
+      return max_num_shards;
+    else if(max_num_shards <= 64)
+      return std::max((IndexType)8, max_num_shards/2);
+    else{
+      IndexType down = max_num_shards / 2;
+      if(max_num_shards > 256)
+        down = std::max((IndexType)128, down / 2);
+      // the 32-multi that is close to down
+      IndexType left = down / 32 * 32;
+      IndexType right = left + 32;
+      if((down - left) <= (right - down))
+        return left;
+      else
+        return right;
+    }
+  }
+
+  // input(outer_size*cur_size*inner_size) -> output(outer_size*k*inner_size)
+  // num_shards: how many pieces to split
+  template<typename T, typename IndexType, bool IsMax>
+  cudaError topk(T* input, T* ouput_val, IndexType* ouput_idx,
+    IndexType outer_size, IndexType inner_size, IndexType cur_size, IndexType k,
+    IndexType num_shards=0){
+    IndexType grid = outer_size*inner_size;
+    if(num_shards <= 0) // auto setting
+      num_shards = get_auto_num_shards<T, IndexType>(k, cur_size);
+    else{
+      IndexType max_num_shards = get_max_num_shards<T, IndexType>(k, cur_size);
+      num_shards = std::max(max_num_shards, num_shards);
+    }
+    //
+    auto shared_memory_size = (num_shards + 1) * k * sizeof(Entry<T, IndexType>);   //?? possible different sizes of host/device
+    TopKKernel<T, IndexType, IsMax>
+      <<<grid, num_shards, shared_memory_size>>>(input, ouput_val, ouput_idx, outer_size, inner_size, cur_size, k);
+    return cudaGetLastError();
+  }
+};
+
+#endif
+

--- a/third_party/topk_tr.h
+++ b/third_party/topk_tr.h
@@ -1,0 +1,589 @@
+/*
+Copyright (c) 2016-     Facebook, Inc            (Adam Paszke)
+Copyright (c) 2014-     Facebook, Inc            (Soumith Chintala)
+Copyright (c) 2011-2014 Idiap Research Institute (Ronan Collobert)
+Copyright (c) 2012-2014 Deepmind Technologies    (Koray Kavukcuoglu)
+Copyright (c) 2011-2012 NEC Laboratories America (Koray Kavukcuoglu)
+Copyright (c) 2011-2013 NYU                      (Clement Farabet)
+Copyright (c) 2006-2010 NEC Laboratories America (Ronan Collobert, Leon Bottou, Iain Melvin, Jason Weston)
+Copyright (c) 2006      Idiap Research Institute (Samy Bengio)
+Copyright (c) 2001-2004 Idiap Research Institute (Ronan Collobert, Samy Bengio, Johnny Mariethoz)
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the names of Facebook, Deepmind Technologies, NYU, NEC Laboratories America
+and IDIAP Research Institute nor the names of its contributors may be
+used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+// pytroch's implementation using radix-selection
+// - from pytorch/aten/src/THC/THCTensorTopK.cuh
+// https://github.com/pytorch/pytorch/blob/d792c21f72b6bcace80face2a4157528d977bfa9/aten/src/THC/THCTensorTopK.cuh
+// - warning: ignore some types, for eg., does not include THCNumerics for T==half
+
+#ifndef _TOPK_TR
+#define _TOPK_TR
+
+#include <assert.h>
+
+namespace impl_tr{
+  // 
+  template <typename T>
+  struct TopKTypeConfig {};
+
+  template <>
+  struct TopKTypeConfig<float> {
+    typedef uint32_t RadixType;
+    // Converts a float to an integer representation with the same
+    // sorting; i.e., for floats f1, f2:
+    // if f1 < f2 then convert(f1) < convert(f2)
+    // We use this to enable radix selection of floating-point values.
+    // This also gives a relative order for NaNs, but that's ok, as they
+    // will all be adjacent
+    static inline __device__ RadixType convert(float v) {
+      RadixType x = __float_as_int(v);
+      RadixType mask = (x & 0x80000000) ? 0xffffffff : 0x80000000;
+      return (x ^ mask);
+    }
+    static inline __device__ float deconvert(RadixType v) {
+      RadixType mask = (v & 0x80000000) ? 0x80000000 : 0xffffffff;
+      return __int_as_float(v ^ mask);
+    }
+  };
+
+  template <>
+  struct TopKTypeConfig<double> {
+    typedef uint64_t RadixType;
+
+    static inline __device__ RadixType convert(double v) {
+      RadixType x = __double_as_longlong(v);
+      RadixType mask = -((x >> 63)) | 0x8000000000000000;
+      return (x ^ mask);
+    }
+
+    static inline __device__ double deconvert(RadixType v) {
+      RadixType mask = ((v >> 63) - 1) | 0x8000000000000000;
+      return __longlong_as_double(v ^ mask);
+    }
+  };
+
+  // helpers
+
+  // For CC 3.5+, perform a load using __ldg
+  template <typename T>
+  __device__ __forceinline__ T doLdg(const T* p) {
+#if __CUDA_ARCH__ >= 350
+    return __ldg(p);
+#else
+    return *p;
+#endif
+  }
+
+  // Collection of direct PTX functions
+  template <typename T>
+  struct Bitfield {};
+  template <>
+  struct Bitfield<unsigned int> {
+    static __device__ __forceinline__
+      unsigned int getBitfield(unsigned int val, int pos, int len) {
+      unsigned int ret;
+      asm("bfe.u32 %0, %1, %2, %3;" : "=r"(ret) : "r"(val), "r"(pos), "r"(len));
+      return ret;
+    }
+    static __device__ __forceinline__
+      unsigned int setBitfield(unsigned int val, unsigned int toInsert, int pos, int len) {
+      unsigned int ret;
+      asm("bfi.b32 %0, %1, %2, %3, %4;" :
+      "=r"(ret) : "r"(toInsert), "r"(val), "r"(pos), "r"(len));
+      return ret;
+    }
+  };
+
+  template <>
+  struct Bitfield<uint64_t> {
+    static __device__ __forceinline__
+      uint64_t getBitfield(uint64_t val, int pos, int len) {
+      uint64_t ret;
+      asm("bfe.u64 %0, %1, %2, %3;" : "=l"(ret) : "l"(val), "r"(pos), "r"(len));
+      return ret;
+    }
+
+    static __device__ __forceinline__
+      uint64_t setBitfield(uint64_t val, uint64_t toInsert, int pos, int len) {
+      uint64_t ret;
+      asm("bfi.b64 %0, %1, %2, %3, %4;" :
+      "=l"(ret) : "l"(toInsert), "l"(val), "r"(pos), "r"(len));
+      return ret;
+    }
+  };
+
+  // WARP_BALLOT
+  __device__ __forceinline__ int WARP_BALLOT(int predicate, unsigned int mask = 0xffffffff)
+  {
+#if CUDA_VERSION >= 9000
+    return __ballot_sync(mask, predicate);
+#else
+    return __ballot(predicate);
+#endif
+  }
+
+  // ACTIVE_MASK
+  __device__ __forceinline__ unsigned int ACTIVE_MASK()
+  {
+#if CUDA_VERSION >= 9000
+    return __activemask();
+#else
+    // will be ignored anyway
+    return 0xffffffff;
+#endif
+  }
+
+  // getLaneId
+  __device__ __forceinline__ int getLaneId() {
+    int laneId;
+    asm("mov.s32 %0, %laneid;" : "=r"(laneId));
+    return laneId;
+  }
+
+  /**
+  Computes ceil(a / b)
+  */
+  template <typename T>
+  __host__ __device__ __forceinline__ T THCCeilDiv(T a, T b) {
+    return (a + b - 1) / b;
+  }
+
+  /**
+  Computes ceil(a / b) * b; i.e., rounds up `a` to the next highest
+  multiple of b
+  */
+  template <typename T>
+  __host__ __device__ __forceinline__ T THCRoundUp(T a, T b) {
+    return THCCeilDiv(a, b) * b;
+  }
+
+
+  // This function counts the distribution of all input values in a
+  // slice we are selecting by radix digit at `radixDigitPos`, but only
+  // those that pass the filter `((v & desiredMask) == desired)`.
+  // This produces and broadcasts the seen counts for a single block only.
+  // `smem` must have at least `RadixSize` elements.
+  template <typename DataType, typename BitDataType,
+    typename IndexType, typename CountType,
+    int RadixSize, int RadixBits>
+    __device__ void countRadixUsingMask(CountType counts[RadixSize],
+      CountType* smem,
+      BitDataType desired,
+      BitDataType desiredMask,
+      int radixDigitPos,
+      IndexType sliceSize,
+      IndexType withinSliceStride,
+      DataType* data) {
+    // Clear out per-thread counts from a previous round
+#pragma unroll
+    for(int i = 0; i < RadixSize; ++i) {
+      counts[i] = 0;
+    }
+
+    if(threadIdx.x < RadixSize) {
+      smem[threadIdx.x] = 0;
+    }
+    __syncthreads();
+
+    // Scan over all the data. Upon a read, the warp will accumulate
+    // counts per each digit in the radix using warp voting.
+    for(IndexType i = threadIdx.x; i < sliceSize; i += blockDim.x) {
+      BitDataType val = TopKTypeConfig<DataType>::convert(doLdg(&data[i * withinSliceStride]));
+
+      bool hasVal = ((val & desiredMask) == desired);
+      BitDataType digitInRadix = Bitfield<BitDataType>::getBitfield(val, radixDigitPos, RadixBits);
+
+#pragma unroll
+      for(unsigned int j = 0; j < RadixSize; ++j) {
+        bool vote = hasVal && (digitInRadix == j);
+        counts[j] += __popc(WARP_BALLOT(vote, ACTIVE_MASK()));
+      }
+    }
+
+    // Now, for each warp, sum values
+    if(getLaneId() == 0) {
+#pragma unroll
+      for(unsigned int i = 0; i < RadixSize; ++i) {
+        atomicAdd(&smem[i], counts[i]);
+      }
+    }
+
+    __syncthreads();
+
+    // For each thread, read in the total counts
+#pragma unroll
+    for(unsigned int i = 0; i < RadixSize; ++i) {
+      counts[i] = smem[i];
+    }
+
+    __syncthreads();
+  }
+
+  // Over what radix we are selecting values
+#define RADIX_BITS 2 // digits are base-(2 ^ RADIX_BITS)
+#define RADIX_SIZE 4 // 2 ^ RADIX_BITS
+#define RADIX_MASK (RADIX_SIZE - 1)
+
+  // 
+  // This finds the unique value `v` that matches the pattern
+  // ((v & desired) == desiredMask) in our sorted int format
+  template <typename DataType, typename BitDataType, typename IndexType>
+  __device__ DataType findPattern(DataType* smem,
+    DataType* data,
+    IndexType sliceSize,
+    IndexType withinSliceStride,
+    BitDataType desired,
+    BitDataType desiredMask) {
+    if(threadIdx.x < 32) {
+      smem[threadIdx.x] = (DataType)(0);
+    }
+    __syncthreads();
+
+    // All threads participate in the loop, in order to sync on the flag
+    IndexType numIterations = THCRoundUp(sliceSize, (IndexType)blockDim.x);
+    for(IndexType i = threadIdx.x; i < numIterations; i += blockDim.x) {
+      bool inRange = (i < sliceSize);
+      DataType v = inRange ? doLdg(&data[i * withinSliceStride]) : (DataType)(0);
+
+      if(inRange && ((TopKTypeConfig<DataType>::convert(v) & desiredMask) == desired)) {
+        // There should not be conflicts if we are using findPattern,
+        // since the result is unique
+        smem[0] = (DataType)(1);
+        smem[1] = v; // can't use val as the flag, since it could be 0
+      }
+
+      __syncthreads();
+
+      DataType found = smem[0];
+      DataType val = smem[1];
+
+      __syncthreads();
+
+      // Check to see if a thread found the value
+      if(found != (DataType)(0)) {
+        // all threads return this value
+        return val;
+      }
+    }
+
+    // should not get here
+    assert(false);
+    return (DataType)(0);
+  }
+
+  // Returns the top-Kth element found in the data using radix selection
+  // - find k out of sliceSize with stride of withinSliceStride, Descending if Order
+  template <typename DataType, typename BitDataType, typename IndexType, bool Order>
+  __device__ void radixSelect(DataType* data,
+    IndexType k,
+    IndexType sliceSize,
+    IndexType withinSliceStride,
+    int* smem,
+    DataType* topK) {
+    // Per-thread buckets into which we accumulate digit counts in our
+    // radix
+    int counts[RADIX_SIZE];
+    // We only consider elements x such that (x & desiredMask) == desired
+    // Initially, we consider all elements of the array, so the above
+    // statement is true regardless of input.
+    BitDataType desired = 0;
+    BitDataType desiredMask = 0;
+    // We are looking for the top kToFind-th element when iterating over
+    // digits; this count gets reduced by elimination when counting
+    // successive digits
+    int kToFind = k;
+    // We start at the most significant digit in our radix, scanning
+    // through to the least significant digit
+#pragma unroll
+    for(int digitPos = sizeof(DataType) * 8 - RADIX_BITS;
+      digitPos >= 0;
+      digitPos -= RADIX_BITS) {
+      // Count radix distribution for the current position and reduce
+      // across all threads
+      countRadixUsingMask<DataType, BitDataType,
+        IndexType, int,
+        RADIX_SIZE, RADIX_BITS>(
+          counts, smem,
+          desired, desiredMask, digitPos,
+          sliceSize, withinSliceStride, data);
+      // All threads participate in the comparisons below to know the
+      // final result
+#define CHECK_RADIX(i)                                                  \
+    int count = counts[i];                                              \
+                                                                        \
+    /* All threads have the same value in counts here, so all */        \
+    /* threads will return from the function. */                        \
+    if (count == 1 && kToFind == 1) {                                   \
+      /* There is a unique answer. */                                   \
+      desired = Bitfield<BitDataType>::setBitfield(desired, i, digitPos, RADIX_BITS);          \
+      desiredMask =                                                     \
+        Bitfield<BitDataType>::setBitfield(desiredMask, RADIX_MASK, digitPos, RADIX_BITS);     \
+                                                                        \
+      /* The answer is now the unique element v such that: */           \
+      /* (v & desiredMask) == desired */                                \
+      /* However, we do not yet know what the actual element is. We */  \
+      /* need to perform a search through the data to find the */       \
+      /* element that matches this pattern. */                          \
+      *topK = findPattern<DataType, BitDataType, IndexType>(                         \
+        (DataType*) smem, data, sliceSize,                              \
+        withinSliceStride, desired, desiredMask);                       \
+      return;                                                           \
+    }                                                                   \
+                                                                        \
+    if (count >= kToFind) {                                             \
+      desired = Bitfield<BitDataType>::setBitfield(desired, i, digitPos, RADIX_BITS);          \
+      desiredMask =                                                     \
+        Bitfield<BitDataType>::setBitfield(desiredMask, RADIX_MASK, digitPos, RADIX_BITS);     \
+                                                                        \
+      /* The top-Kth element v must now be one such that: */            \
+      /* (v & desiredMask == desired) */                                \
+      /* but we haven't narrowed it down; we must check the next */     \
+      /* least-significant digit */                                     \
+      break;                                                            \
+    }                                                                   \
+                                                                        \
+    kToFind -= count                                                    \
+
+      if(Order) {
+        // Process in descending order
+#pragma unroll
+        for(int i = RADIX_SIZE - 1; i >= 0; --i) {
+          CHECK_RADIX(i);
+        }
+      }
+      else {
+        // Process in ascending order
+#pragma unroll
+        for(int i = 0; i < RADIX_SIZE; ++i) {
+          CHECK_RADIX(i);
+        }
+      }
+#undef CHECK_RADIX
+    } // end digitPos for
+
+      // There is no unique result, but there is a non-unique result
+      // matching `desired` exactly
+    *topK = TopKTypeConfig<DataType>::deconvert(desired);
+  }
+
+  // helpers2
+  template <typename T>
+  struct AddOp {
+    __device__ __forceinline__ T operator()(T const &lhs, T const &rhs) {
+      return lhs + rhs;
+    }
+  };
+
+  __device__ __forceinline__ unsigned getLaneMaskLe() {
+    unsigned mask;
+    asm("mov.u32 %0, %%lanemask_le;" : "=r"(mask));
+    return mask;
+  }
+
+  // Inclusive prefix sum for binary vars using intra-warp voting +
+  // shared memory
+  template <typename T, bool KillWARDependency, class BinaryFunction>
+  __device__ void inclusiveBinaryPrefixScan(T* smem, bool in, T* out, BinaryFunction binop) {
+    // Within-warp, we use warp voting.
+    T vote = WARP_BALLOT(in);
+    T index = __popc(getLaneMaskLe() & vote);
+    T carry = __popc(vote);
+
+    int warp = threadIdx.x / 32;
+
+    // Per each warp, write out a value
+    if(getLaneId() == 0) {
+      smem[warp] = carry;
+    }
+
+    __syncthreads();
+
+    // Sum across warps in one thread. This appears to be faster than a
+    // warp shuffle scan for CC 3.0+
+    if(threadIdx.x == 0) {
+      int current = 0;
+      for(int i = 0; i < blockDim.x / 32; ++i) {
+        T v = smem[i];
+        smem[i] = binop(smem[i], current);
+        current = binop(current, v);
+      }
+    }
+
+    __syncthreads();
+
+    // load the carry from the preceding warp
+    if(warp >= 1) {
+      index = binop(index, smem[warp - 1]);
+    }
+
+    *out = index;
+
+    if(KillWARDependency) {
+      __syncthreads();
+    }
+  }
+
+  // Exclusive prefix sum for binary vars using intra-warp voting +
+  // shared memory
+  template <typename T, bool KillWARDependency, class BinaryFunction>
+  __device__ void exclusiveBinaryPrefixScan(T* smem, bool in, T* out, T* carry, BinaryFunction binop) {
+    inclusiveBinaryPrefixScan<T, false, BinaryFunction>(smem, in, out, binop);
+
+    // Inclusive to exclusive
+    *out -= (T)in;
+
+    // The outgoing carry for all threads is the last warp's sum
+    *carry = smem[(blockDim.x / 32) - 1];
+
+    if(KillWARDependency) {
+      __syncthreads();
+    }
+  }
+
+  // the kernal function
+  template<typename T, typename IndexType, bool Order>
+  __global__ void topk_kernel(T* input, T* out_val, IndexType* out_idx,
+    IndexType cur_size, IndexType k, IndexType outer_size, IndexType inner_size){
+    // Indices are limited to integer fp precision, so counts can fit in
+    // int32, regardless of IndexType
+    __shared__ int smem[32]; // one per each warp, up to warp limit
+                             // in range, kind of like in the batch-size range (if flattened, that will be)
+    IndexType slice = blockIdx.x;
+    if(slice >= outer_size*inner_size) {
+      return;
+    }
+    // prepare data
+    T* inputSliceStart = input + slice/inner_size*inner_size*cur_size + slice%inner_size;
+    T* topKSliceStart = out_val + slice/inner_size*inner_size*k + slice%inner_size;
+    IndexType* indicesSliceStart = out_idx + slice/inner_size*inner_size*k + slice%inner_size;
+    // Find the k-th highest element in our input
+    T topKValue = (T)(0);
+    radixSelect<T, typename TopKTypeConfig<T>::RadixType, IndexType, Order>(
+      inputSliceStart, k, cur_size, inner_size, smem, &topKValue);
+
+    // Every value that is strictly less/greater than `pattern`
+    // (depending on sort dir) in sorted int format is in the top-K.
+    // The top-K value itself might not be unique.
+    //
+    // Since there are a variable number of elements that we see that
+    // are within the top-k, we don't know at what index to write out
+    // the resulting values.
+    // In order to get this, we perform an exclusive prefix sum of
+    // `hasTopK`. This will return the resulting index into which we
+    // need to write the result, if a thread has a result.
+
+    // All threads need to participate in the loop and the prefix sum,
+    // but not necessarily in the load; hence loop bounds being rounded
+    // up to a multiple of the block dim.
+    IndexType numIterations = THCRoundUp(cur_size, (IndexType)blockDim.x);
+    IndexType writeIndexStart = 0;
+    for(IndexType i = threadIdx.x; i < numIterations; i += blockDim.x) {
+      bool inRange = (i < cur_size);
+      T v = inRange ? doLdg(&inputSliceStart[i * inner_size]) : (T)(0);
+      bool hasTopK;
+      if(Order) {   // Process in descending order
+        hasTopK = inRange && (v > topKValue);
+      }
+      else {        // Process in ascending order
+        hasTopK = inRange && (v < topKValue);
+      }
+      int index;
+      int carry;
+      exclusiveBinaryPrefixScan<int, true>(smem, hasTopK, &index, &carry, AddOp<int>());
+      if(hasTopK) {
+        int writeIndex = writeIndexStart + index;
+        assert(writeIndex < k);
+
+        IndexType topKOffset = writeIndex * inner_size;
+        IndexType indexOffset = writeIndex * inner_size;
+
+        topKSliceStart[topKOffset] = v;
+        indicesSliceStart[indexOffset] = i + 0;
+      }
+      writeIndexStart += carry;
+    }
+
+    // We need to fill in the rest with actual == top-K values.
+    // The number that we need is outputSliceSize -
+    // writeIndexStart. There might be more than that number available,
+    // in which case we have to choose the first seen set. We do this
+    // via a prefix sum to calculate indices for writing results.
+    assert(k >= writeIndexStart);
+    IndexType topKRemaining = (k - writeIndexStart);
+    for(IndexType i = threadIdx.x; i < numIterations; i += blockDim.x) {
+      bool inRange = (i < cur_size);
+      T v = inRange ? doLdg(&inputSliceStart[i * inner_size]) : (T)(0);
+      bool hasTopK = inRange && (v == topKValue);
+      int index;
+      int carry;
+      exclusiveBinaryPrefixScan<int, true>(smem, hasTopK, &index, &carry, AddOp<int>());
+      if(hasTopK && index < topKRemaining) {
+        int writeIndex = writeIndexStart + index;
+        assert(writeIndex < k);
+
+        IndexType topKOffset = writeIndex * inner_size;
+        IndexType indexOffset = writeIndex * inner_size;
+
+        topKSliceStart[topKOffset] = v;
+        indicesSliceStart[indexOffset] = i + 0;
+      }
+
+      if(carry >= topKRemaining) {
+        break;
+      }
+      topKRemaining -= carry;
+      writeIndexStart += carry;
+    }
+    return;
+  }
+
+#undef RADIX_BITS
+#undef RADIX_SIZE
+#undef RADIX_MASK
+
+  // final call for the topk (no sorting, only selecting topk)
+  // -- (batch_size,cur_size,inner_size) -> (batch_size,k,inner_size)
+  template<typename T, typename IndexType, bool IsMax>
+  cudaError topk(T* input, T* ouput_val, IndexType* ouput_idx,
+    IndexType outer_size, IndexType inner_size, IndexType cur_size, IndexType k){
+    // todo: check that inputs are valid
+    //
+    IndexType grid = outer_size*inner_size;
+    IndexType block = (std::min(THCRoundUp(cur_size, (IndexType)(32)), (IndexType)(1024)));
+    topk_kernel<T, IndexType, IsMax>
+      <<<grid, block>>>(input, ouput_val, ouput_idx, cur_size, k, outer_size, inner_size);
+    return cudaGetLastError();
+  }
+};
+
+#endif
+


### PR DESCRIPTION
This PR corresponds to Issue #1263 and add CPU/GPU topk function (only topk, no sorting) for Tensor, adopting the underlying implementations from Tensorflow(Heap-based) and PyTorch(Selection-based).

* Evaluations with different settings on these two GPU-strategies and CPU-version can be found at [HERE](https://github.com/zzsfornlp/misc/blob/master/topkv2/run.log).
* Currently, the default strategy is a simple one based on the K-value: using Tensorflow-version when K<=16, otherwise using PyTorch-version.
* The CPU-version simply uses std::nth_element and loops over the batches, which can be extended with multi-thread methods.
* Also, notice that the PyTorch implementation includes several GPU assembly code, and I only test it on K40.
* Finally, about the **license**, I include the licenses of both Tensorflow and PyTorch at the beginning of corresponding files (`third_party/topk_*.h`), wonder whether this is ok?

About the API, it is similar to `TensorTools::argmax`, but returns a pair of (Tensor, IndexTensor) instead.
`std::pair<Tensor, IndexTensor> topk(const Tensor& v, unsigned dim = 0, unsigned num = 1);`

Here is an example using topk:

    # test topk
    import dynet as dy
    import numpy as np
    VOCAB_SIZE = 1000
    BATCH_SIZE = 20
    K = 5
    v = [float(np.random.randint(0, 100000)) for i in range(VOCAB_SIZE*BATCH_SIZE)]
    t = dy.inputVector(v)
    t2 = dy.reshape(t, (VOCAB_SIZE,), BATCH_SIZE)
    t2_t = t2.tensor_value()
    
    # return val/idx
    val, idx = t2_t.topk(0, K)
    
    # testing
    calc = idx.as_numpy().T
    for i in range(BATCH_SIZE):
        gold = np.argsort(v[i*VOCAB_SIZE:(i+1)*VOCAB_SIZE])[-K:]
        if(set(gold) != set(calc[i])):
            print("gold", gold, [v[i*VOCAB_SIZE:(i+1)*VOCAB_SIZE][x] for x in gold])
            print("calc", calc[i], val.as_numpy().T[i])
        assert set(gold) == set(calc[i]), "bad value"

