### PR TITLE
Initial implementation of DropConnect

### DIFF
--- a/dynet/lstm.h
+++ b/dynet/lstm.h
@@ -267,6 +267,23 @@ struct VanillaLSTMBuilder : public RNNBuilder {
    * \param batch_size Batch size
    */
   void set_dropout_masks(unsigned batch_size = 1);
+ 
+ /**
+  * \brief Set DropConnect rate
+  * \details Apply DropConnect [Wan et al., 2013] to hidden to hidden weight matrix. Weights will be masked by random bernoulli matrix.
+  * Each layer of network gets unique mask. 
+  * \param d Weight drop rate
+  */
+  void set_dropconnect(float d);
+  /**
+   * \brief Set DropConnect rate to 0 
+   */
+  void disable_dropconnect();
+  /**
+   * \brief Set mask for recurrent weight matrices at the beginning of new sequence
+   */ 
+  void set_dropconnect_masks();
+
   /**
    * \brief Get parameters in VanillaLSTMBuilder
    * \return list of points to ParameterStorage objects
@@ -294,6 +311,9 @@ public:
   // first index is layer, then ...
   std::vector<std::vector<Expression>> masks;
 
+  // one mask on recurrent weights per layer
+  std::vector<Expression> dropconnect_masks;
+
   // first index is time, second is layer
   std::vector<std::vector<Expression>> h, c;
 
@@ -308,6 +328,9 @@ public:
   bool ln_lstm;
   float forget_bias;
   bool dropout_masks_valid;
+
+  float dropconnect_rate;
+  bool dropconnect_masks_valid;
 
 private:
   ComputationGraph* _cg; // Pointer to current cg

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -502,9 +502,13 @@ cdef extern from "dynet/lstm.h" namespace "dynet":
         CVanillaLSTMBuilder(unsigned layers, unsigned input_dim, unsigned hidden_dim, CModel &model, bool ln_lstm, float forget_bias)
         void set_dropout(float d, float d_r)
         void set_dropout_masks(unsigned batch_size)
+        void set_dropconnect(float d)
+        void disable_dropconnect()
+        void set_dropconnect_masks()
 
         vector[vector[CParameters]] params
         vector[vector[CExpression]] param_vars
+        vector[CExpression] dropconnect_masks
 
     cdef cppclass CCoupledLSTMBuilder "dynet::CoupledLSTMBuilder" (CRNNBuilder):
         CCoupledLSTMBuilder()

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -5288,7 +5288,6 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
             exprs.append(layer_exprs)
         return exprs
 
-
     cpdef void set_dropouts(self, float d, float d_r):
         """Set the dropout rates
         
@@ -5329,6 +5328,15 @@ cdef class VanillaLSTMBuilder(_RNNBuilder): # {{{
         """
         self.thisvanillaptr.set_dropout_masks(batch_size)
 
+    cpdef void set_dropconnect(self, float d):
+        self.thisvanillaptr.set_dropconnect(d)
+    
+    cpdef void disable_dropconnect(self):
+        self.thisvanillaptr.disable_dropconnect()
+    
+    cpdef set_dropconnect_masks(self):
+        self.thisvanillaptr.set_dropconnect_masks()
+        
     def whoami(self): return "VanillaLSTMBuilder"
 # VanillaLSTMBuilder }}}
 


### PR DESCRIPTION
I'm interested in reimplementation of paper "Regularizing and Optimizing LSTM Language Models" but I'm failed to implement DropConnect regularization for LSTM with current Python API. So I made an extension for VanillaLSTMBuilder to support DropConnect regularizer for recurrent  matrix. I used dropout implementation as inspiration, so I not fully confident that my implementation is efficient and truly correct, but testing on lstmlm-auto script indicates that network is able to learn.
p.s. Sorry for English