### PR TITLE
Resetting the random seed after initialization

### DIFF
--- a/doc/source/python_ref.rst
+++ b/doc/source/python_ref.rst
@@ -19,6 +19,8 @@ Initialization functions
 
 .. autofunction:: dynet.init_from_params
 
+.. autofunction:: dynet.reset_random_seed
+
 ParameterCollection and Parameters
 ----------------------------------
 

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -94,13 +94,9 @@ Device_GPU::Device_GPU(int my_id, const DeviceMempoolSizes & mbs,
   CUDA_CHECK(cudaSetDevice(device_id));
   CUBLAS_CHECK(cublasCreate(&cublas_handle));
   CUBLAS_CHECK(cublasSetPointerMode(cublas_handle, CUBLAS_POINTER_MODE_DEVICE));
+  reset_rng(seed);
 #if HAVE_CUDNN
   CUDNN_CHECK(cudnnCreate(&cudnnHandle));
-  CURAND_CHECK(curandCreateGenerator(&curandeng,
-                                     CURAND_RNG_PSEUDO_PHILOX4_32_10));
-  CURAND_CHECK(curandSetPseudoRandomGeneratorSeed(curandeng,
-                                                  seed + 1));
-
 #endif
   kSCALAR_MINUSONE = (float*)gpu_mem.malloc(sizeof(float));
   kSCALAR_ONE = (float*)gpu_mem.malloc(sizeof(float));
@@ -125,6 +121,13 @@ Device_GPU::Device_GPU(int my_id, const DeviceMempoolSizes & mbs,
 }
 
 Device_GPU::~Device_GPU() {}
+
+void Device_GPU::reset_rng(unsigned seed) {
+  CURAND_CHECK(curandCreateGenerator(&curandeng,
+                                     CURAND_RNG_PSEUDO_PHILOX4_32_10));
+  CURAND_CHECK(curandSetPseudoRandomGeneratorSeed(curandeng,
+                                                  seed + 1));
+}
 #endif
 
 Device_CPU::Device_CPU(int my_id, const DeviceMempoolSizes & mbs, bool shared) :

--- a/dynet/devices.h
+++ b/dynet/devices.h
@@ -28,6 +28,7 @@ class Device {
   Device& operator=(const Device&) = delete;
   virtual ~Device();
  public:
+  void reset_rng(unsigned seed) {};
   int device_id;
   DeviceType type;
   MemAllocator* mem;
@@ -47,6 +48,7 @@ class Device_GPU : public Device {
   typedef Eigen::CudaStreamDevice EigenDevice;
   explicit Device_GPU(int my_id, const DeviceMempoolSizes & mb, int device_id, unsigned seed);
   ~Device_GPU();
+  void reset_rng(unsigned seed);
   int cuda_device_id;
   cublasHandle_t cublas_handle;
 #if HAVE_CUDNN

--- a/dynet/init.cc
+++ b/dynet/init.cc
@@ -240,6 +240,7 @@ void initialize(DynetParams& params) {
     params.random_seed = rd();
   }
   cerr << "[dynet] random seed: " << params.random_seed << endl;
+  reset_rng(params.random_seed);
   rndeng = new mt19937(params.random_seed);
 
   // Set weight decay rate
@@ -292,6 +293,20 @@ void cleanup() {
   delete rndeng;
   get_device_manager()->clear();
   default_device = nullptr;
+}
+
+void reset_rng(unsigned seed) {
+  rndeng = new mt19937(seed);
+#if HAVE_CUDA
+  DeviceManager* device_manager = get_device_manager();
+  for (unsigned device_id=0; device_id < device_manager->num_devices(); device_id++){
+      Device* dev = device_manager->get(device_id);
+      if (dev->type == DeviceType::GPU) {
+        Device_GPU* dev_gpu = (Device_GPU*)dev;
+        dev_gpu->reset_rng(seed);
+      }
+  }
+#endif
 }
 
 } // namespace dynet

--- a/dynet/init.h
+++ b/dynet/init.h
@@ -35,6 +35,12 @@ void initialize(DynetParams& params);
 void initialize(int& argc, char**& argv, bool shared_parameters = false);
 void cleanup();
 
+/**
+ * \brief Resets random number generators
+ *
+ */
+void reset_rng(unsigned seed);
+
 } // namespace dynet
 
 #endif

--- a/python/_dynet.pxd
+++ b/python/_dynet.pxd
@@ -21,6 +21,7 @@ cdef extern from "dynet/init.h" namespace "dynet":
     cdef CDynetParams extract_dynet_params(int& argc, char**& argv, bool shared_parameters)
     cdef void initialize(CDynetParams params)
     cdef void initialize(int& argc, char **& argv, bool shared_parameters)
+    void c_reset_rng "dynet::reset_rng" (unsigned seed) except +
 
 cdef extern from "dynet/dim.h" namespace "dynet":
     cdef cppclass CDim "dynet::Dim":

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -246,6 +246,15 @@ def init_from_params(DynetParams params):
         params(DynetParams): dynet parameters
     """
     params.init()
+
+cpdef reset_random_seed(seed):
+    """Resets the random seed and the random number generator
+    
+    Args:
+        seed(int): The new random seed
+    """
+    c_reset_rng(seed)
+
 # }}}
 
 # Dimensions {{{


### PR DESCRIPTION
Introduces `dy.reset_random_seed(seed)` to reset the random seed after initialization #1348 

Coincidentally fixes #1350 