### PR TITLE
Fix appveyor boost version

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -5,8 +5,8 @@ platform: x64
 environment:
   global:
     MSVC_DEFAULT_OPTIONS: ON
-    BOOST_ROOT: C:\Libraries\boost_1_59_0
-    BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
+    BOOST_ROOT: C:\Libraries\boost_1_67_0
+    BOOST_LIBRARYDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14.0
     MSVC: 1
     MINICONDA: "C:\\Miniconda36-x64"
     TWINE_USERNAME: danielh


### PR DESCRIPTION
The boost version seems to no longer be included in the Appveyor build environment:
https://www.appveyor.com/docs/build-environment/#boost

This PR upgrades to the most recent supported version.