### PR TITLE
Fix a bug when calling `.expr(False)` before `renew_cg`

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -898,6 +898,7 @@ cdef class Parameters(Expression): # {{{
     cdef Expression _const_expr
     def __cinit__(self):
         self._version = -1
+        self._const_version = -1
 
     # All creations MUST go through wrap_ptr
     @staticmethod


### PR DESCRIPTION
Fixes #1392