### PR TITLE
Save/load the optimizer state

### DIFF
--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -48,15 +48,13 @@ namespace
 void save_trainer_params(std::ostream& os, const std::vector<ShadowParameters>& vp)
 {
     for (auto sp : vp)
-        for (unsigned i = 0u ; i < sp.h.d.size() ; ++i)
-            os << TensorTools::access_element(sp.h, i) << ' ';
+         os << dynet::as_vector(sp.h);
 }
 
 void save_trainer_params(std::ostream& os, const std::vector<ShadowLookupParameters>& vlp)
 {
     for (auto slp : vlp)
-        for (unsigned i = 0u ; i < slp.all_h.d.size() ; ++i)
-            os << TensorTools::access_element(slp.all_h, i) << ' ';
+	os << dynet::as_vector(slp.all_h);
 }
 
 void load_trainer_params(std::istream& is, std::vector<ShadowParameters>& vp)

--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -41,6 +41,7 @@ bool is_valid(const Eigen::MatrixBase<Derived>& x) {
   return ((x - x).array() == (x - x).array()).all();
 }
 
+#ifndef __CUDACC__
 namespace
 {
 
@@ -85,6 +86,7 @@ void load_trainer_params(std::istream& is, std::vector<ShadowLookupParameters> v
 }
 
 }
+#endif
 
 // --- The actual update code for each operation, implemented on various devices
 
@@ -241,7 +243,6 @@ void CyclicalSGDTrainer::update_lookup_params(real gscale, size_t idx) {
   auto & p = model->lookup_parameters_list()[idx];
   update_rule(gscale, {&p->all_values, &p->all_grads});
 }
-#endif
 
 void CyclicalSGDTrainer::save_state(std::ostream& os)
 {
@@ -269,6 +270,7 @@ void CyclicalSGDTrainer::load_state(std::istream& is, bool restore_hyperparams)
         it = _it;
     }
 }
+#endif
 
 // --- MomentumSGDTrainer
 

--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -54,7 +54,7 @@ void save_trainer_params(std::ostream& os, const std::vector<ShadowParameters>& 
 void save_trainer_params(std::ostream& os, const std::vector<ShadowLookupParameters>& vlp)
 {
     for (auto slp : vlp)
-	os << dynet::as_vector(slp.all_h);
+        os << dynet::as_vector(slp.all_h);
 }
 
 void load_trainer_params(std::istream& is, std::vector<ShadowParameters>& vp)
@@ -186,9 +186,9 @@ void Trainer::load_state(std::istream& is, bool restore_hyperparams)
     is >> _learning_rate >> _clipping_enabled >> _clip_threshold;
     if (restore_hyperparams)
     {
-        _learning_rate = learning_rate;
-        _clipping_enabled = clipping_enabled;
-        _clip_threshold = clip_threshold;
+        learning_rate = _learning_rate;
+        clipping_enabled = _clipping_enabled;
+        clip_threshold = _clip_threshold;
     }
 }
 

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -13,6 +13,7 @@
 #define DYNET_TRAINING_H_
 
 #include <vector>
+#include <iostream>
 
 #include "dynet/model.h"
 #include "dynet/shadow-params.h"
@@ -80,6 +81,23 @@ struct Trainer {
    * \param learning_rate New learning rate
    */
   void restart(real lr);
+
+  /**
+   * @brief Save the optimizer state
+   * @details Write all hyperparameters, momentum values and assimilate (if applicable) to stream;
+   *
+   * \param os Output stream
+   */
+  virtual void save_state(std::ostream& os);
+
+  /**
+   * @brief Load the optimizer state
+   * @details Read all hyperparameters, momentum values and assimilate (if applicable) from stream;
+   *
+   * \param os Input stream
+   * \param restore_hyperparams Wether to load hyperparameters
+   */
+  virtual void load_state(std::istream& is, bool restore_hyperparams=true);
 
   /**
    * \brief Clip gradient
@@ -194,6 +212,7 @@ struct SimpleSGDTrainer : public Trainer {
    */
   explicit SimpleSGDTrainer(ParameterCollection& m, real learning_rate = 0.1) : Trainer(m, learning_rate) {}
   void restart() override {};
+
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
@@ -236,6 +255,9 @@ struct CyclicalSGDTrainer : public Trainer {
    */
   explicit CyclicalSGDTrainer(ParameterCollection& m, float learning_rate_min = 0.01, float learning_rate_max = 0.1, float step_size = 2000, float gamma = 1.0, float edecay = 0.0) : Trainer(m, learning_rate_min), e_min(learning_rate_min), e_max(learning_rate_max), step_size(step_size), gamma(gamma), it(0) {}
   void restart() override {};
+  void save_state(std::ostream& os) override;
+  void load_state(std::istream& is, bool restore_hyperparams=true) override;
+
   using Trainer::restart;
   void update() override {
     Trainer::update();
@@ -281,6 +303,8 @@ struct MomentumSGDTrainer : public Trainer {
     Trainer(m, learning_rate), momentum(mom) {}
 
   void restart() override;
+  void save_state(std::ostream& os) override;
+  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 
   // the following represent the current velocity
@@ -320,6 +344,8 @@ struct AdagradTrainer : public Trainer {
     Trainer(m, learning_rate), epsilon(eps) {}
 
   void restart() override;
+  void save_state(std::ostream& os) override;
+  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
@@ -357,6 +383,8 @@ struct AdadeltaTrainer : public Trainer {
     Trainer(m, 1.0), epsilon(eps), rho(rho) {}
 
   void restart() override;
+  void save_state(std::ostream& os) override;
+  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
@@ -395,6 +423,8 @@ struct RMSPropTrainer : public Trainer {
     Trainer(m, learning_rate), epsilon(eps), rho(rho) {}
 
   void restart() override;
+  void save_state(std::ostream& os) override;
+  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
@@ -433,6 +463,8 @@ struct AdamTrainer : public Trainer {
     Trainer(m, learning_rate), beta_1(beta_1), beta_2(beta_2), epsilon(eps) {}
 
   void restart() override;
+  void save_state(std::ostream& os) override;
+  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 
 protected:
@@ -476,6 +508,8 @@ struct AmsgradTrainer : public Trainer {
     Trainer(m, learning_rate), beta_1(beta_1), beta_2(beta_2), epsilon(eps) {}
 
   void restart() override;
+  void save_state(std::ostream& os) override;
+  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 
 protected:
@@ -525,6 +559,8 @@ struct EGTrainer : public Trainer {
 //-----------------------------------------------------------------------------------------
 
   void restart() override;
+  void save_state(std::ostream& os) override;
+  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -84,20 +84,28 @@ struct Trainer {
 
   /**
    * @brief Save the optimizer state
-   * @details Write all hyperparameters, momentum values and assimilate (if applicable) to stream;
+   * @details Write all hyperparameters, momentum values and assimilate (if applicable) to stream.
    *
    * \param os Output stream
    */
-  virtual void save_state(std::ostream& os);
+  virtual void save(std::ostream& os);
 
   /**
    * @brief Load the optimizer state
-   * @details Read all hyperparameters, momentum values and assimilate (if applicable) from stream;
+   * @details Read all hyperparameters, momentum values and assimilate (if applicable) from stream.
    *
    * \param os Input stream
-   * \param restore_hyperparams Wether to load hyperparameters
    */
-  virtual void load_state(std::istream& is, bool restore_hyperparams=true);
+  virtual void populate(std::istream& is);
+
+  /**
+   * @brief Load the optimizer state
+   * @details Read all hyperparameters, momentum values and assimilate (if applicable) from stream.
+   *
+   * \param os Input stream
+   * \param lr New learning rate
+   */
+  void populate(std::istream& is, real lr);
 
   /**
    * \brief Clip gradient
@@ -255,8 +263,6 @@ struct CyclicalSGDTrainer : public Trainer {
    */
   explicit CyclicalSGDTrainer(ParameterCollection& m, float learning_rate_min = 0.01, float learning_rate_max = 0.1, float step_size = 2000, float gamma = 1.0, float edecay = 0.0) : Trainer(m, learning_rate_min), e_min(learning_rate_min), e_max(learning_rate_max), step_size(step_size), gamma(gamma), it(0) {}
   void restart() override {};
-  void save_state(std::ostream& os) override;
-  void load_state(std::istream& is, bool restore_hyperparams=true) override;
 
   using Trainer::restart;
   void update() override {
@@ -303,9 +309,11 @@ struct MomentumSGDTrainer : public Trainer {
     Trainer(m, learning_rate), momentum(mom) {}
 
   void restart() override;
-  void save_state(std::ostream& os) override;
-  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
+
+  void save(std::ostream& os) override;
+  void populate(std::istream& is) override;
+  using Trainer::populate;
 
   // the following represent the current velocity
   // The shadow parameters are made public for testing, ideally they shouldn't be
@@ -344,9 +352,11 @@ struct AdagradTrainer : public Trainer {
     Trainer(m, learning_rate), epsilon(eps) {}
 
   void restart() override;
-  void save_state(std::ostream& os) override;
-  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
+
+  void save(std::ostream& os) override;
+  void populate(std::istream& is) override;
+  using Trainer::populate;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual unsigned alloc_impl() override;
@@ -383,9 +393,11 @@ struct AdadeltaTrainer : public Trainer {
     Trainer(m, 1.0), epsilon(eps), rho(rho) {}
 
   void restart() override;
-  void save_state(std::ostream& os) override;
-  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
+
+  void save(std::ostream& os) override;
+  void populate(std::istream& is) override;
+  using Trainer::populate;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual unsigned alloc_impl() override;
@@ -423,9 +435,11 @@ struct RMSPropTrainer : public Trainer {
     Trainer(m, learning_rate), epsilon(eps), rho(rho) {}
 
   void restart() override;
-  void save_state(std::ostream& os) override;
-  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
+
+  void save(std::ostream& os) override;
+  void populate(std::istream& is) override;
+  using Trainer::populate;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual unsigned alloc_impl() override;
@@ -463,10 +477,11 @@ struct AdamTrainer : public Trainer {
     Trainer(m, learning_rate), beta_1(beta_1), beta_2(beta_2), epsilon(eps) {}
 
   void restart() override;
-  void save_state(std::ostream& os) override;
-  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 
+  void save(std::ostream& os) override;
+  void populate(std::istream& is) override;
+  using Trainer::populate;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual unsigned alloc_impl() override;
@@ -508,10 +523,11 @@ struct AmsgradTrainer : public Trainer {
     Trainer(m, learning_rate), beta_1(beta_1), beta_2(beta_2), epsilon(eps) {}
 
   void restart() override;
-  void save_state(std::ostream& os) override;
-  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
 
+  void save(std::ostream& os) override;
+  void populate(std::istream& is) override;
+  using Trainer::populate;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual unsigned alloc_impl() override;
@@ -559,9 +575,11 @@ struct EGTrainer : public Trainer {
 //-----------------------------------------------------------------------------------------
 
   void restart() override;
-  void save_state(std::ostream& os) override;
-  void load_state(std::istream& is, bool restore_hyperparams=true) override;
   using Trainer::restart;
+
+  void save(std::ostream& os) override;
+  void populate(std::istream& is) override;
+  using Trainer::populate;
 protected:
   DYNET_TRAINER_DEFINE_DEV_IMPL()
   virtual unsigned alloc_impl() override;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,8 +1,6 @@
 include(CTest)
 enable_testing()
 
-set(CMAKE_CXX_COMPILER "/usr/local/bin/g++-7")
-
 find_package(Boost COMPONENTS system filesystem unit_test_framework REQUIRED)
 include_directories(${TEST_SOURCE_DIR}/src ${Boost_INCLUDE_DIRS})
 add_definitions(-DBOOST_TEST_DYN_LINK)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 include(CTest)
 enable_testing()
 
+set(CMAKE_CXX_COMPILER "/usr/local/bin/g++-7")
+
 find_package(Boost COMPONENTS system filesystem unit_test_framework REQUIRED)
 include_directories(${TEST_SOURCE_DIR}/src ${Boost_INCLUDE_DIRS})
 add_definitions(-DBOOST_TEST_DYN_LINK)
@@ -9,7 +11,7 @@ if (DEFINED ENV{DYNET_TEST_DEVICES})  # use env variable as preprocessor macro
   add_definitions(-DDYNET_TEST_DEVICES=$ENV{DYNET_TEST_DEVICES})
 endif()
 
-foreach(TESTNAME dim dynet exec io mem nodes params tensor trainers rnn softmax)
+foreach(TESTNAME dim dynet exec io mem nodes params tensor trainers trainers-io rnn softmax)
   add_executable(test-${TESTNAME} test-${TESTNAME}.cc)
   if (NOT MSVC)
     target_link_libraries(test-${TESTNAME} ${Boost_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/tests/test-trainers-io.cc
+++ b/tests/test-trainers-io.cc
@@ -47,15 +47,6 @@ struct TrainerIOTest {
     for (auto x : av) free(x);
   }
 
-  template <class T>
-  std::string print_vec(const std::vector<T> vec) {
-    ostringstream oss;
-    if(vec.size()) oss << vec[0];
-    for(size_t i = 1; i < vec.size(); i++)
-      oss << ' ' << vec[i];
-    return oss.str();
-  }
-
     Parameter build_pc(ParameterCollection& pc)
     {
         auto p = pc.add_parameters({3});
@@ -81,7 +72,7 @@ struct TrainerIOTest {
         return loss;
     }
 
-  std::vector<float> ones_vals, param_vals, param2_vals;
+  std::vector<float> ones_vals, param_vals;
   std::vector<char*> av;
 };
 

--- a/tests/test-trainers-io.cc
+++ b/tests/test-trainers-io.cc
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(name) {                                    \
     /* do a second update and check that the loss where different */ \
     /* i.e. that the params of the model are actually different */ \
     auto loss2 = optimize(p, trainer);                          \
-    BOOST_TEST(loss1 != loss2, TOL);                            \
+    BOOST_CHECK(!(abs(loss1 - loss2)/abs(loss1) <= TOL && abs(loss1 - loss2)/abs(loss2) <= TOL)); \
     /*create a new model, load the save state+trainer params, */ \
     /* do one update and check that everything match */         \
     ParameterCollection m2;                                     \

--- a/tests/test-trainers-io.cc
+++ b/tests/test-trainers-io.cc
@@ -1,0 +1,206 @@
+#define BOOST_TEST_MODULE TEST_TRAINER_IO
+/*
+ * There are two different macros to test an optimizer:
+ * - DYNET_TRAINER_IO_TEST_CASE:
+ *   makes two updates of a model. Parameters of the model and the optimizer
+ *   are save after the first update. Then, a new model and a new optimizer
+ *   are created and populated with the saved data.
+ *   The two models must be equal after updating the second one.
+ * - DYNET_TRAINER_IO_PARAM_TEST_CASE:
+ *   this is a save/load test for a given attribute of the optimizer
+ *
+ * TODO: EGTrainer is no fully tested because the update does not change
+ *       the model.
+ */
+
+#include <fstream>
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+
+#include <dynet/dynet.h>
+#include <dynet/expr.h>
+#include <dynet/training.h>
+#include <dynet/io.h>
+
+#include "test.h"
+
+using namespace dynet;
+using namespace std;
+
+struct TrainerIOTest {
+  TrainerIOTest() {
+    // initialize if necessary
+    if(default_device == nullptr) {
+      for (auto x : {"TrainerTest", "--dynet-mem", "10"}) {
+        av.push_back(strdup(x));
+      }
+      ADD_EXTRA_ARGUMENTS(av)
+      char **argv = &av[0];
+      int argc = av.size();
+      dynet::initialize(argc, argv);
+    }
+    ones_vals = {1.f,1.f,1.f};
+    param_vals = {0.5f,0.1f,0.4f};
+  }
+
+  ~TrainerIOTest() {
+    for (auto x : av) free(x);
+  }
+
+  template <class T>
+  std::string print_vec(const std::vector<T> vec) {
+    ostringstream oss;
+    if(vec.size()) oss << vec[0];
+    for(size_t i = 1; i < vec.size(); i++)
+      oss << ' ' << vec[i];
+    return oss.str();
+  }
+
+    Parameter build_pc(ParameterCollection& pc)
+    {
+        auto p = pc.add_parameters({3});
+        TensorTools::set_elements(p.get_storage().values, param_vals);
+        return p;
+    }
+
+    Expression build_loss(ComputationGraph& cg, Parameter& param)
+    {
+        auto x = parameter(cg, param);
+        auto y = input(cg, {3}, ones_vals);
+        return dot_product(x, y);
+    }
+
+    dynet::real optimize(Parameter& param, Trainer& trainer)
+    {
+        dynet::ComputationGraph cg;
+        auto z = build_loss(cg, param);
+        auto loss = as_scalar(cg.forward(z));
+        cg.backward(z);
+        trainer.update();
+
+        return loss;
+    }
+
+  std::vector<float> ones_vals, param_vals, param2_vals;
+  std::vector<char*> av;
+};
+
+BOOST_FIXTURE_TEST_SUITE(trainer_io_test, TrainerIOTest);
+
+#define DYNET_TRAINER_IO_TEST_CASE(name, TRAINER_TYPE)          \
+BOOST_AUTO_TEST_CASE(name) {                                    \
+    /* build model */                                           \
+    ParameterCollection m;                                      \
+    TRAINER_TYPE trainer(m);                                    \
+    auto p = build_pc(m);                                       \
+    /* do one update and save params */                         \
+    float loss1;                                                \
+    loss1 = optimize(p, trainer);                               \
+    {                                                           \
+        dynet::TextFileSaver s("test.model");                   \
+        s.save(m);                                              \
+        std::ofstream f;                                        \
+        f.open("test.optimizer");                               \
+        trainer.save(f);                                        \
+        f.close();                                              \
+    }                                                           \
+    /* do a second update and check that the loss where different */ \
+    /* i.e. that the params of the model are actually different */ \
+    auto loss2 = optimize(p, trainer);                          \
+    BOOST_TEST(loss1 != loss2, TOL);                            \
+    /*create a new model, load the save state+trainer params, */ \
+    /* do one update and check that everything match */         \
+    ParameterCollection m2;                                     \
+    TRAINER_TYPE trainer2(m2);                                  \
+    auto p2 = build_pc(m2);                                     \
+    {                                                           \
+        dynet::TextFileLoader s("test.model");                  \
+        s.populate(m2);                                         \
+        std::ifstream f;                                        \
+        f.open("test.optimizer");                               \
+        trainer2.populate(f);                                   \
+        f.close();                                              \
+    }                                                           \
+    auto loss3 = optimize(p2, trainer2);                        \
+    DYNET_CHECK_EQUAL(loss2, loss3);                            \
+    DYNET_CHECK_EQUAL(m2, m);                                   \
+}                                                               \
+
+#define DYNET_TRAINER_IO_PARAM_TEST_CASE(name, TRAINER_TYPE, SP_NAME) \
+BOOST_AUTO_TEST_CASE(name)                                      \
+{                                                               \
+    class Trainer : public TRAINER_TYPE                         \
+    {                                                           \
+        public:                                                 \
+            using TRAINER_TYPE::SP_NAME;                        \
+            Trainer(ParameterCollection& m) : \
+                TRAINER_TYPE::TRAINER_TYPE(m) \
+                {} \
+    };                                                          \
+    /* build model */                                           \
+    ParameterCollection m;                                      \
+    Trainer trainer(m);                                    \
+    auto p = build_pc(m);                                       \
+    /* do one update and save params */                         \
+    optimize(p, trainer);                                       \
+    {                                                           \
+        std::ofstream f;                                        \
+        f.open("test.optimizer");                               \
+        trainer.save(f);                                        \
+        f.close();                                              \
+    }                                                           \
+    /*create a new model, load the save state params, */        \
+    ParameterCollection m2;                                     \
+    Trainer trainer2(m2);                                  \
+    auto p2 = build_pc(m2);                                     \
+    {                                                           \
+        std::ifstream f;                                        \
+        f.open("test.optimizer");                               \
+        trainer2.populate(f);                                   \
+        f.close();                                              \
+    }                                                           \
+    DYNET_CHECK_EQUAL(trainer2.SP_NAME, trainer.SP_NAME);                 \
+}                                                               \
+
+DYNET_TRAINER_IO_PARAM_TEST_CASE(momentum_sgd_io_param_vp, MomentumSGDTrainer, vp)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(momentum_sgd_io_param_vlp, MomentumSGDTrainer, vlp)
+
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adagrad_io_param_vp, AdagradTrainer, vp)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adagrad_io_param_vlp, AdagradTrainer, vlp)
+
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adadelta_io_param_hg, AdadeltaTrainer, hg)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adadelta_io_param_hlg, AdadeltaTrainer, hlg)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adadelta_io_param_hd, AdadeltaTrainer, hd)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adadelta_io_param_hld, AdadeltaTrainer, hld)
+
+DYNET_TRAINER_IO_PARAM_TEST_CASE(rmsprop_io_param_hmsg, RMSPropTrainer, hmsg)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(rmsprop_io_param_hlmsg, RMSPropTrainer, hlmsg)
+
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adam_io_param_m, AdamTrainer, m)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adam_io_param_lm, AdamTrainer, lm)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adam_io_param_v, AdamTrainer, v)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(adam_io_param_lv, AdamTrainer, lv)
+
+DYNET_TRAINER_IO_PARAM_TEST_CASE(amsgrad_io_param_m, AmsgradTrainer, m)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(amsgrad_io_param_lm, AmsgradTrainer, lm)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(amsgrad_io_param_v, AmsgradTrainer, v)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(amsgrad_io_param_lv, AmsgradTrainer, lv)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(amsgrad_io_param_vhat, AmsgradTrainer, vhat)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(amsgrad_io_param_lvhat, AmsgradTrainer, lvhat)
+
+DYNET_TRAINER_IO_PARAM_TEST_CASE(eg_io_param_hp, EGTrainer, hp)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(eg_io_param_hlp, EGTrainer, hlp)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(eg_io_param_zeg, EGTrainer, zeg)
+DYNET_TRAINER_IO_PARAM_TEST_CASE(eg_io_param_meg, EGTrainer, meg)
+
+DYNET_TRAINER_IO_TEST_CASE(simple_sgd_io, SimpleSGDTrainer)
+DYNET_TRAINER_IO_TEST_CASE(cyclical_sgd_io, CyclicalSGDTrainer)
+DYNET_TRAINER_IO_TEST_CASE(momentum_sgd_io, MomentumSGDTrainer)
+DYNET_TRAINER_IO_TEST_CASE(adagrad_io, AdagradTrainer)
+DYNET_TRAINER_IO_TEST_CASE(adadelta_io, AdadeltaTrainer)
+DYNET_TRAINER_IO_TEST_CASE(rmsprop_io, RMSPropTrainer)
+DYNET_TRAINER_IO_TEST_CASE(adam_io, AdamTrainer)
+DYNET_TRAINER_IO_TEST_CASE(amsgrad_io, AmsgradTrainer)
+//DYNET_TRAINER_IO_TEST_CASE(eg_io, EGTrainer)
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/test-trainers-io.cc
+++ b/tests/test-trainers-io.cc
@@ -133,7 +133,7 @@ BOOST_AUTO_TEST_CASE(name)                                      \
     {                                                           \
         public:                                                 \
             using TRAINER_TYPE::SP_NAME;                        \
-            Trainer(ParameterCollection& m) : \
+            explicit Trainer(ParameterCollection& m) : \
                 TRAINER_TYPE::TRAINER_TYPE(m) \
                 {} \
     };                                                          \

--- a/tests/test.h
+++ b/tests/test.h
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <boost/test/unit_test.hpp>
 #include <dynet/model.h>
+#include <dynet/shadow-params.h>
 
 #define TOL 1e-3
 #define DYNET_CHECK_EQUAL(a, b) equal_check(a, b)

--- a/tests/test.h
+++ b/tests/test.h
@@ -46,6 +46,31 @@ void equal_check(Tensor & v1, Tensor & v2) {
   }
 }
 
+void equal_check(ShadowParameters& sp1, ShadowParameters& sp2)
+{
+    DYNET_CHECK_EQUAL(sp1.h, sp2.h);
+}
+
+void equal_check(std::vector<ShadowParameters>& vsp1, std::vector<ShadowParameters>& vsp2)
+{
+    BOOST_CHECK_EQUAL(vsp1.size(), vsp2.size());
+    for (size_t i = 0 ; i < vsp1.size() ; ++i)
+        DYNET_CHECK_EQUAL(vsp1[i], vsp2[i]);
+}
+
+void equal_check(ShadowLookupParameters& slp1, ShadowLookupParameters& slp2)
+{
+    BOOST_CHECK_EQUAL(slp1.h.size(), slp2.h.size());
+    DYNET_CHECK_EQUAL(slp1.all_h, slp2.all_h);
+}
+
+void equal_check(std::vector<ShadowLookupParameters>& vlsp1, std::vector<ShadowLookupParameters>& vlsp2)
+{
+    BOOST_CHECK_EQUAL(vlsp1.size(), vlsp2.size());
+    for (size_t i = 0 ; i < vlsp1.size() ; ++i)
+        DYNET_CHECK_EQUAL(vlsp1[i], vlsp2[i]);
+}
+
 template <class T>
 void equal_check(std::vector<T> & a,
                  std::vector<T> & b) {


### PR DESCRIPTION
Hi,
I need to adress issue  #785 for my work so I thought I could contribute upstream.

I started to implement methods to save/load the parameters of an optimizer (hyperparameters+momentum etc) in C++. The API is very simple:

```
void Trainer::save_state(std::ostream& os);
void Trainer::load_state(std::istream& is, bool restore_hyperparams);
```

Todo:
- ~~at the moment, when saving params, I use TensorTools::access_element(sp.h, i) to access each element of the tensor individually: this may be really slow, especially on GPU. Is there an alternative?~~ replaced with dynet::as_vector(sp.h)
- try to use templates from dynet/io.h instead of my write/read functions
- .update() should have been called at least once before saving/loading. This is a big issue, I'll try to fix this as soon as possible
- unit testing
- python API: I do not use the python version of dynet so I may struggle to implement this

Please, tell me if you are intersted in this contribution. If yes, I'll try to fix the problems listed above.

Best,
Caio Corro