### PR TITLE
Make capitalization of "DyNet" consistent in documentation.

### DIFF
--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -1,6 +1,6 @@
 .. _contributing:
 
-Contributing to Dynet
+Contributing to DyNet
 ====================
 
 DyNet is an open source project that is only possible because of contributions from users like you!

--- a/doc/source/core.rst
+++ b/doc/source/core.rst
@@ -4,7 +4,7 @@ Core functionalities
 Computation Graph
 ~~~~~~~~~~~~~~~~~
 
-The ComputationGraph is the workhorse of dynet. From the `Dynet technical report <https://arxiv.org/abs/1701.03980>`_ :
+The ComputationGraph is the workhorse of DyNet. From the `DyNet technical report <https://arxiv.org/abs/1701.03980>`_ :
 
     [The] computation graph represents symbolic computation, and the results of the computation are evaluated lazily: the computation is only performed once the user explicitly asks for it (at which point a “forward” computation is triggered).
     Expressions that evaluate to scalars (i.e. loss values) can also be used to trigger a “backward” computation, computing the gradients of the computation with respect to the parameters.
@@ -47,7 +47,7 @@ Tensor objects provide a bridge between C++ data structures and Eigen Tensors fo
 
 Concretely, as an end user you will obtain a tensor object after calling ``.value()`` on an expression. You can then use functions described below to convert these tensors to ``float`` s, arrays of ``float`` s, to save and load the values, etc...
 
-Conversely, when implementing low level nodes (e.g. for new operations), you will need to retrieve Eigen tensors from dynet tensors in order to perform efficient computation.
+Conversely, when implementing low level nodes (e.g. for new operations), you will need to retrieve Eigen tensors from DyNet tensors in order to perform efficient computation.
 
 .. doxygengroup:: tensor
     :members:

--- a/doc/source/debugging.rst
+++ b/doc/source/debugging.rst
@@ -17,7 +17,7 @@ It is possible to create visualizations of the computation graph by calling the 
 Immediate Computation
 ~~~~~~~~~~~~~~~~~~~~~
 
-In general, DyNet performs symbolic execution. This means that you first create the computation graph, then the computation will actually be performed when you request a value using functions such as ``forward()`` or ``value()``. However, if an error occurs during calculation, this can be hard to debug because the error doesn't occur immediately where the offending graph node is created. To make debugging simpler, you can use immediate computing mode in dynet. In this mode, every computation gets executed immediately, just like imperative programming, so that you can find exactly where goes wrong. 
+In general, DyNet performs symbolic execution. This means that you first create the computation graph, then the computation will actually be performed when you request a value using functions such as ``forward()`` or ``value()``. However, if an error occurs during calculation, this can be hard to debug because the error doesn't occur immediately where the offending graph node is created. To make debugging simpler, you can use immediate computing mode in DyNet. In this mode, every computation gets executed immediately, just like imperative programming, so that you can find exactly where goes wrong. 
 
 In C++, you can switch to the immediate computing mode by calling ComputationGraph::set_immediate_compute as follows:
 
@@ -26,7 +26,7 @@ In C++, you can switch to the immediate computing mode by calling ComputationGra
     ComputationGraph cg;
     cg.set_immediate_compute(true);
 
-Further, dynet can automatically check validity of your model, i.e., detecting Inf/NaN, if it is in immediate computing mode. To activate checking validity, you can add the following code after switching to immediate computing mode.
+Further, DyNet can automatically check validity of your model, i.e., detecting Inf/NaN, if it is in immediate computing mode. To activate checking validity, you can add the following code after switching to immediate computing mode.
 
 .. code:: cpp
 

--- a/doc/source/doc_style.rst
+++ b/doc/source/doc_style.rst
@@ -1,7 +1,7 @@
 Documentation
 =============
 
-Dynet uses Doxygen_ for commenting the code and Sphinx_ for the general documentation. 
+DyNet uses Doxygen_ for commenting the code and Sphinx_ for the general documentation. 
 
 If you're only documenting features you don't need to concern yourself with Sphinx, your doxygen comments will be integrated in the documentation automatically.
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -232,7 +232,7 @@ in the generated solution**
 
 The Windows build also supports MKL and CUDA with the latest version of Eigen. If you build with 
 CUDA and/or cuDNN, ensure their respective DLLs are in your PATH environment variable when you use
-dynet (whether in native C++ or Python). For example:
+DyNet (whether in native C++ or Python). For example:
 
 ::
 

--- a/doc/source/python.rst
+++ b/doc/source/python.rst
@@ -322,7 +322,7 @@ to use them.
 Using the GPU from Python
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The preferred way to make dynet use the GPU under Python is to import
+The preferred way to make DyNet use the GPU under Python is to import
 dynet as usual:
 
 ::

--- a/doc/source/python_ref.rst
+++ b/doc/source/python_ref.rst
@@ -2,7 +2,7 @@ Python Reference Manual
 =======================
 
 
-Dynet global parameters
+DyNet global parameters
 -----------------------
 
 DynetParams


### PR DESCRIPTION
I tried to clean up the docs so that "DyNet" was consistently capitalized, unless it was clearly a reference to code.