### PR TITLE
Exponential Moving Average

### DIFF
--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -257,44 +257,6 @@ void Trainer::restart(real lr) {
     this->learning_rate = lr;
     this->restart();
 }
-#endif
-
-// EMA
-
-#ifdef __CUDACC__
-    template void Trainer::update_ema_rule_dev<Device_GPU>(const Device_GPU& dev, Tensor* ema, Tensor* p);
-    template void Trainer::swap_params_to_ema_rule_dev<Device_GPU>(const Device_GPU& dev, bool bias_correction, bool save_weights, Tensor* p, Tensor* mem, Tensor* ema);
-    template void Trainer::swap_params_to_weights_rule_dev<Device_GPU>(const Device_GPU& dev, Tensor* p, Tensor* mem);
-#elif defined(HAVE_CUDA)
-    extern template void Trainer::update_ema_rule_dev<Device_GPU>(const Device_GPU& dev, Tensor* ema, Tensor* p);
-    template void Trainer::update_ema_rule_dev<Device_CPU>(const Device_CPU& dev, Tensor* ema, Tensor* p);
-    void Trainer::update_ema_rule(Tensor* ema, Tensor* p)
-    {
-        if(ema->device->type == DeviceType::CPU)
-            update_ema_rule_dev(*(Device_CPU*)ema->device, ema, p);
-        else if(ema->device->type == DeviceType::GPU)
-        {
-            cudaSetDevice(((Device_GPU*) ema->device)->cuda_device_id);
-            update_rule_rule_dev(*(Device_GPU*) ema->device, ema, p);
-        }
-        else
-            throw std::runtime_error("Bad device in MyTrainer::update_ema_rule");
-    }
-
-    extern template void Trainer::swap_params_to_ema_rule_dev<Device_GPU>(const Device_GPU& dev, bool bias_correction, bool save_weights, Tensor* p, Tensor* mem, Tensor* ema);
-    template void Trainer::swap_params_to_ema_rule_dev<Device_CPU>(const Device_GPU& dev, bool bias_correction, bool save_weights, Tensor* p, Tensor* mem, Tensor* ema);
-    void Trainer::swap_params_to_ema_rule(bool bias_correction, bool save_weights, Tensor* p, Tensor* mem, Tensor* ema)
-    {
-        if(ema->device->type == DeviceType::CPU)
-            swap_params_to_ema_rule_dev(*(Device_CPU*)ema->device, bias_correction, save_weights, p, mem, ema);
-        else if(ema->device->type == DeviceType::GPU)
-        {
-            cudaSetDevice(((Device_GPU*) ema->device)->cuda_device_id);
-            swap_params_to_ema_rule_dev(*(Device_GPU*)ema->device, bias_correction, save_weights, p, mem, ema);
-        }
-        else
-            throw std::runtime_error("Bad device in MyTrainer::swap_params_to_ema_rule");
-    }
 
 void Trainer::save(std::ostream& os)
 {
@@ -338,6 +300,45 @@ void Trainer::populate(std::istream& is, real lr)
     this->populate(is);
     this->learning_rate = lr;
 }
+
+#endif
+
+// EMA
+
+#ifdef __CUDACC__
+    template void Trainer::update_ema_rule_dev<Device_GPU>(const Device_GPU& dev, Tensor* ema, Tensor* p);
+    template void Trainer::swap_params_to_ema_rule_dev<Device_GPU>(const Device_GPU& dev, bool bias_correction, bool save_weights, Tensor* p, Tensor* mem, Tensor* ema);
+    template void Trainer::swap_params_to_weights_rule_dev<Device_GPU>(const Device_GPU& dev, Tensor* p, Tensor* mem);
+#elif defined(HAVE_CUDA)
+    extern template void Trainer::update_ema_rule_dev<Device_GPU>(const Device_GPU& dev, Tensor* ema, Tensor* p);
+    template void Trainer::update_ema_rule_dev<Device_CPU>(const Device_CPU& dev, Tensor* ema, Tensor* p);
+    void Trainer::update_ema_rule(Tensor* ema, Tensor* p)
+    {
+        if(ema->device->type == DeviceType::CPU)
+            update_ema_rule_dev(*(Device_CPU*)ema->device, ema, p);
+        else if(ema->device->type == DeviceType::GPU)
+        {
+            cudaSetDevice(((Device_GPU*) ema->device)->cuda_device_id);
+            update_rule_rule_dev(*(Device_GPU*) ema->device, ema, p);
+        }
+        else
+            throw std::runtime_error("Bad device in MyTrainer::update_ema_rule");
+    }
+
+    extern template void Trainer::swap_params_to_ema_rule_dev<Device_GPU>(const Device_GPU& dev, bool bias_correction, bool save_weights, Tensor* p, Tensor* mem, Tensor* ema);
+    template void Trainer::swap_params_to_ema_rule_dev<Device_CPU>(const Device_GPU& dev, bool bias_correction, bool save_weights, Tensor* p, Tensor* mem, Tensor* ema);
+    void Trainer::swap_params_to_ema_rule(bool bias_correction, bool save_weights, Tensor* p, Tensor* mem, Tensor* ema)
+    {
+        if(ema->device->type == DeviceType::CPU)
+            swap_params_to_ema_rule_dev(*(Device_CPU*)ema->device, bias_correction, save_weights, p, mem, ema);
+        else if(ema->device->type == DeviceType::GPU)
+        {
+            cudaSetDevice(((Device_GPU*) ema->device)->cuda_device_id);
+            swap_params_to_ema_rule_dev(*(Device_GPU*)ema->device, bias_correction, save_weights, p, mem, ema);
+        }
+        else
+            throw std::runtime_error("Bad device in MyTrainer::swap_params_to_ema_rule");
+    }
 
 
     extern template void Trainer::swap_params_to_weights_rule_dev<Device_GPU>(const Device_GPU& dev, Tensor* p, Tensor* mem);

--- a/dynet/training.cc
+++ b/dynet/training.cc
@@ -271,8 +271,6 @@ void Trainer::restart(real lr) {
 
 void Trainer::save(std::ostream& os)
 {
-    if (ma_params_swapped)
-        DYNET_RUNTIME_ERR("Trainer cannot be saved: parameters are swapped with their exponential moving averaged weights");
     os.precision(FLOAT32_PRECISION);
     os << std::scientific << std::showpos;
     write_trainer_header(os, "#Trainer#", aux_allocated, aux_allocated_lookup);
@@ -291,8 +289,8 @@ void Trainer::save(std::ostream& os)
     ;
 
 
-    // save EMA state
-    if (ma_mode != MovingAverage::None)
+    // save EMA/CMA state if parameters are not swapped
+    if (ma_mode != MovingAverage::None && !ma_params_swapped)
     {
         os << "[MA:TRUE]\n";
         write_trainer_header(os, "#MA#", ma_aux_allocated, ma_aux_allocated_lookup);

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -118,6 +118,7 @@ struct Trainer {
   /**
    * @brief Save the optimizer state
    * @details Write all hyperparameters, momentum values and assimilate (if applicable) to stream.
+   *          If the parameters are swapped with their moving averages, only the latters are saved.
    *
    * \param os Output stream
    */

--- a/dynet/training.h
+++ b/dynet/training.h
@@ -58,6 +58,8 @@ struct Trainer {
     ema_params_saved(false),
     ema_update_freq(1u),
     ema_updates(0u),
+    ema_aux_allocated(0),
+    ema_aux_allocated_lookup(0),
     model(&m)
   {}
   virtual ~Trainer();
@@ -175,6 +177,8 @@ struct Trainer {
   bool ema_params_saved; // true if params have been saved when swapping
   unsigned ema_update_freq; // the EMA will be updated each ema_update_frequency updates
   unsigned ema_updates; // number of times the EMA has been updated, used for bias correction
+  unsigned ema_aux_allocated;
+  unsigned ema_aux_allocated_lookup;
   // Shadow parameters used for EMA 
   std::vector<ShadowParameters> ema_p;
   std::vector<ShadowLookupParameters> ema_lp;

--- a/examples/tagger/train_tag-bilstm.cc
+++ b/examples/tagger/train_tag-bilstm.cc
@@ -24,8 +24,8 @@ unsigned TAG_DIM = 32;
 unsigned TAG_SIZE = 0;
 unsigned VOCAB_SIZE = 0;
 
-bool use_momentum = true;
-bool use_ema = false;
+bool use_momentum = false;
+bool use_ema = true;
 
 bool eval = false;
 dynet::Dict d;
@@ -194,7 +194,7 @@ int main(int argc, char** argv) {
   else
     trainer.reset(new SimpleSGDTrainer(model));
   if (use_ema)
-    trainer->ema(0.999);
+    trainer->exponential_moving_average(0.999);
 
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
@@ -241,7 +241,7 @@ int main(int argc, char** argv) {
     report++;
     if (report % dev_every_i_reports == 0) {
       if (use_ema)
-        trainer->swap_params_to_ema(true);
+        trainer->swap_params_to_moving_average(true, true);
       double dloss = 0;
       unsigned dtags = 0;
       double dcorr = 0;

--- a/examples/tagger/train_tag-bilstm.cc
+++ b/examples/tagger/train_tag-bilstm.cc
@@ -25,7 +25,8 @@ unsigned TAG_SIZE = 0;
 unsigned VOCAB_SIZE = 0;
 
 bool use_momentum = false;
-bool use_ema = true;
+bool use_ema = false;
+bool use_cma = false;
 
 bool eval = false;
 dynet::Dict d;
@@ -117,10 +118,69 @@ struct RNNLanguageModel {
 
 int main(int argc, char** argv) {
   dynet::initialize(argc, argv);
-  if (argc != 3 && argc != 4) {
-    cerr << "Usage: " << argv[0] << " corpus.txt dev.txt [model.params]\n";
+
+  std::string path_corpus;
+  std::string path_dev;
+  std::string path_model;
+
+  bool opt_succeed = true;
+  unsigned n_pos_args = 0;
+  std::string* pos_args[]{&path_corpus, &path_dev, &path_model};
+  for (int argi = 1 ; argi < argc ; ++argi)
+  {
+    std::string opt(argv[argi]);
+    if (opt[0] != '-')
+    {
+        if (n_pos_args == 3)
+        {
+           opt_succeed = false;
+           break;
+        }
+        *(pos_args[n_pos_args]) = opt;
+        ++n_pos_args;
+    }
+    else if (opt == "--momentum")
+    {
+        use_momentum = true;
+    }
+    else if (opt == "--ema")
+    {
+        use_ema = true;
+    }
+    else if (opt == "--cma")
+    {
+        use_cma = true;
+    }
+    else
+    {
+        opt_succeed = false;
+        break;
+    }
+  }
+
+  if (use_ema && use_cma)
+  {
+    cerr << "Can not use both Exponential Moving Average and Cumulative Moving Average\n";
+    opt_succeed = false;
+  }
+  if (path_corpus.size() == 0 || path_dev.size() == 0)
+    opt_succeed = false;
+
+  if (!opt_succeed)
+  {
+    cerr << "Usage: " << argv[0] << " corpus.txt dev.txt [model.params] [--momentum] [--ema] [--cma]\n";
     return 1;
   }
+  cerr << "Training data: " << path_corpus << "\n";
+  cerr << "Dev data: " << path_dev << "\n";
+  if (path_model.size() != 0)
+    cerr << "Model params: " << path_corpus << "\n";
+  cerr << "Optimizer: SGD";
+  if (use_momentum) cerr << "+momentum";
+  if (use_ema) cerr << "+ema";
+  if (use_cma) cerr << "+cma";
+  cerr << "\n";
+
   kNONE = td.convert("*");
   kSOS = d.convert("<s>");
   kEOS = d.convert("</s>");
@@ -128,9 +188,9 @@ int main(int argc, char** argv) {
   string line;
   int tlc = 0;
   int ttoks = 0;
-  cerr << "Reading training data from " << argv[1] << "...\n";
+  cerr << "Reading training data from " << path_corpus << "...\n";
   {
-    ifstream in(argv[1]);
+    ifstream in(path_corpus);
     assert(in);
     while(getline(in, line)) {
       ++tlc;
@@ -160,9 +220,9 @@ int main(int argc, char** argv) {
 
   int dlc = 0;
   int dtoks = 0;
-  cerr << "Reading dev data from " << argv[2] << "...\n";
+  cerr << "Reading dev data from " << path_dev<< "...\n";
   {
-    ifstream in(argv[2]);
+    ifstream in(path_dev);
     assert(in);
     while(getline(in, line)) {
       ++dlc;
@@ -195,11 +255,13 @@ int main(int argc, char** argv) {
     trainer.reset(new SimpleSGDTrainer(model));
   if (use_ema)
     trainer->exponential_moving_average(0.999);
+  if (use_cma)
+    trainer->cumulative_moving_average();
 
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);
-  if (argc == 4) {
-    TextFileLoader loader(argv[3]);
+  if (path_model.size() != 0) {
+    TextFileLoader loader(path_model);
     loader.populate(model);
   }
 
@@ -240,7 +302,7 @@ int main(int argc, char** argv) {
     // show score on dev data?
     report++;
     if (report % dev_every_i_reports == 0) {
-      if (use_ema)
+      if (use_ema || use_cma)
         trainer->swap_params_to_moving_average(true, true);
       double dloss = 0;
       unsigned dtags = 0;

--- a/examples/tagger/train_tag-bilstm.cc
+++ b/examples/tagger/train_tag-bilstm.cc
@@ -183,11 +183,14 @@ int main(int argc, char** argv) {
 
   ParameterCollection model;
   bool use_momentum = true;
+  bool use_ema = true;
   std::unique_ptr<Trainer> trainer;
   if (use_momentum)
     trainer.reset(new MomentumSGDTrainer(model));
   else
     trainer.reset(new SimpleSGDTrainer(model));
+  if (use_ema)
+    trainer->ema(0.999);
 
   RNNLanguageModel<LSTMBuilder> lm(model);
   //RNNLanguageModel<SimpleRNNBuilder> lm(model);


### PR DESCRIPTION
Hi,

I am working on an implementation of the Exponential Moving Average of parameters that can be used with any optimizer. It (will) work on CPU&GPU.

A previous pull-request was rejected #385. However, this feature seems to be of interest for users, see #73 and #1465. I implemented everything in the Trainer class, therefore the code is simple and located in a single place. I hope that this can be merged when finished. :-) 

TODO:
- test everything
- as of now, the EMA is computed for every parameters of the model. This introduce extra work for non-learned parameters (for example fixed embeddings). I don't know how to fix that yet, but I will look into that
- An example would be nice, probably a tagger where we can show that the EMA gets (hopefully) better results in the PTB
- update save/populate methods