### PR TITLE
Throws exception when `default_device` is null.

### DIFF
--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -173,8 +173,12 @@ void DeviceManager::add(Device* d) {
 }
 
 Device* DeviceManager::get_global_device(const std::string & name) {
-  if (name == "")
+  if (name == "") {
+    if (!dynet::default_device) {
+      throw std::runtime_error("Default device does not exist");
+    }
     return dynet::default_device;
+  }
   auto it = devices_map.find(name);
   if (it == devices_map.end()) {
     throw std::runtime_error("Invalid device name: " + name);


### PR DESCRIPTION
In the current DyNet, `Device::get_global_device` returns `nullptr` if `dynet::initialize` is never called before.
It would be better if this method throws an exception when `default_device` is null.