### PR TITLE
fixed softmax latex typos

### DIFF
--- a/dynet/expr.h
+++ b/dynet/expr.h
@@ -1330,8 +1330,8 @@ Expression colwise_add(const Expression& x, const Expression& bias);
  * \ingroup lossoperations
  * \brief Softmax
  * \details The softmax function normalizes each column to ensure that all
- *          values are between 0 and 1 and add to one by applying the
- *          e^{x[i]}/{sum_j e^{x[j]}}.
+ *          values are between 0 and 1 and add to one by applying
+ *          \f$\frac{e^{x_i}}{\sum_j e^{x_j}}\f$.
  *
  * \param x A vector or matrix
  * \param d dimension to normalize over (default: 0)
@@ -1344,8 +1344,8 @@ Expression softmax(const Expression& x, unsigned d=0);
  * \ingroup lossoperations
  * \brief Log softmax
  * \details The log softmax function normalizes each column to ensure that all
- *          values are between 0 and 1 and add to one by applying the
- *          e^{x[i]}/{sum_j e^{x[j]}}, then takes the log
+ *          values are between 0 and 1 and add to one by applying
+ *          \f$\frac{e^{x_i}}{\sum_j e^{x_j}}\f$, then taking the log
  *
  * \param x A vector or matrix
  *

--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -3626,7 +3626,7 @@ cpdef Expression log_softmax(Expression x, list restrict=None):
 cpdef Expression softmax(Expression x, unsigned d=0):
     """Softmax
     
-    The softmax function normalizes each column to ensure that all values are between 0 and 1 and add to one by applying the :math:`\\frac{e^{x_i}}{sum_j e^{x_j}}`.
+   The softmax function normalizes each column to ensure that all values are between 0 and 1 and add to one by applying :math:`\\frac{e^{x_i}}{\sum_j e^{x_j}}`.
     
     Args:
         x (dynet.Expression): Input expression


### PR DESCRIPTION
Spotted a few more latex typos in the docs.


**Before:**
![image](https://user-images.githubusercontent.com/10734779/47552777-840ddc00-d8d3-11e8-91db-a4b68598b0c9.png)
![image](https://user-images.githubusercontent.com/10734779/47552898-b8819800-d8d3-11e8-919d-6e6303d722c9.png)


**After** (minus readthedocs styling):
![image](https://user-images.githubusercontent.com/10734779/47552799-96881580-d8d3-11e8-9435-62a768eebf4b.png)
![image](https://user-images.githubusercontent.com/10734779/47552919-c3d4c380-d8d3-11e8-81aa-4da7f7818d30.png)
