### PR TITLE
add a len function to Expressions, returns length of first dim

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -620,6 +620,11 @@ cdef class Expression: #{{{
         return c_dim_as_dim(d)
         # return (d.size(), d.rows(), d.cols(), d.batch_elems())
 
+    def __len__(self):
+        cdef CDim d;
+        d = self.c().dim()
+        return c_dim_as_dim(d)[0][0]
+
     def __repr__(self):
         return str(self)
     def __str__(self):


### PR DESCRIPTION
This PR adds a `__len__` function to the python Expression class.

This allows for an expression that has shape `((T, H), B)` to be passed to functions like `BiRNNBuilder.transduce` and it will work the same as a list of length `T` of expression of shape `((H,), B)`.

`__len__` returns the length of the first dimension which is the same behavior of numpy. It is also matches the behavior of `for x in xs: ...`