### PR TITLE
Disable implicit batching

### DIFF
--- a/dynet/dynet.cc
+++ b/dynet/dynet.cc
@@ -33,25 +33,7 @@ void Node::forward(const std::vector<const Tensor*>& xs,
   if (this->supports_multibatch() || fx.d.batch_elems() == 1) {
     forward_impl(xs, fx);
   } else {
-    size_t i;
-    std::vector<Tensor> xs_elems(xs.size());
-    std::vector<const Tensor*> xs_ptrs(xs.size());
-    std::vector<size_t> xs_sizes(xs.size());
-    for (i = 0; i < xs.size(); ++i) {
-      xs_elems[i] = xs[i]->batch_elem(0);
-      xs_ptrs[i] = &xs_elems[i];
-      xs_sizes[i] = xs_elems[i].d.size();
-    }
-    Tensor fx_elem(fx.batch_elem(0));
-    size_t fx_size = fx_elem.d.size();
-    forward_impl(xs_ptrs, fx_elem);
-    for (unsigned b = 1; b < fx.d.batch_elems(); ++b) {
-      for (i = 0; i < xs.size(); ++i)
-        if (xs[i]->d.bd > 1)
-          xs_elems[i].v += xs_sizes[i];
-      fx_elem.v += fx_size;
-      forward_impl(xs_ptrs, fx_elem);
-    }
+    DYNET_RUNTIME_ERR("Node " << this->as_dummy_string() << " does not support batching but got fed batched tensor");
   }
 }
 
@@ -63,32 +45,7 @@ void Node::backward(const std::vector<const Tensor*>& xs,
   if (this->supports_multibatch() || fx.d.batch_elems() == 1) {
     backward_impl(xs, fx, dEdf, xs_i, dEdxi);
   } else {
-    size_t i;
-    std::vector<Tensor> xs_elems(xs.size());
-    std::vector<const Tensor*> xs_ptrs(xs.size());
-    std::vector<size_t> xs_sizes(xs.size());
-    for (i = 0; i < xs.size(); ++i) {
-      xs_elems[i] = xs[i]->batch_elem(0);
-      xs_ptrs[i] = &xs_elems[i];
-      xs_sizes[i] = xs_elems[i].d.size();
-    }
-    Tensor fx_elem(fx.batch_elem(0));
-    size_t fx_size = fx_elem.d.size();
-    Tensor dEdf_elem(dEdf.batch_elem(0));
-    size_t dEdf_size = dEdf_elem.d.size();
-    Tensor dEdxi_elem(dEdxi.batch_elem(0));
-    size_t dEdxi_size = dEdxi_elem.d.size();
-    backward_impl(xs_ptrs, fx_elem, dEdf_elem, xs_i, dEdxi_elem);
-    for (unsigned b = 1; b < fx.d.batch_elems(); ++b) {
-      for (i = 0; i < xs.size(); ++i)
-        if (xs[i]->d.bd > 1)
-          xs_elems[i].v += xs_sizes[i];
-      fx_elem.v += fx_size;
-      dEdf_elem.v += dEdf_size;
-      if (dEdxi.d.bd > 1)
-        dEdxi_elem.v += dEdxi_size;
-      backward_impl(xs_ptrs, fx_elem, dEdf_elem, xs_i, dEdxi_elem);
-    }
+    DYNET_RUNTIME_ERR("Node " << this->as_dummy_string() << " does not support batching but got fed batched tensor");
   }
 }
 

--- a/dynet/expr.cc
+++ b/dynet/expr.cc
@@ -202,7 +202,7 @@ Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> & v) { 
 Expression pickneglogsoftmax(const Expression& x, const unsigned* pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv)); }
 Expression pickneglogsoftmax(const Expression& x, const vector<unsigned> * pv) { return Expression(x.pg, x.pg->add_function<PickNegLogSoftmax>({x.i}, pv)); }
 
-Expression average_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<AverageColumns>({x.i})); }
+Expression average_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<MomentDimension>({x.i}, vector<unsigned>({1}), 1, false, 0)); }
 Expression sum_dim(const Expression& x, const vector<unsigned>& dims, bool b) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, dims, b)); }
 Expression sum_rows(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, vector<unsigned>({0}), false)); }
 Expression sum_cols(const Expression& x) { return Expression(x.pg, x.pg->add_function<SumDimension>({x.i}, vector<unsigned>({1}), false)); }

--- a/dynet/nodes-arith-cwise.h
+++ b/dynet/nodes-arith-cwise.h
@@ -59,6 +59,7 @@ struct CwiseQuotient : public Node {
 struct Pow : public Node {
   explicit Pow(const std::initializer_list<VariableIndex>& a) : Node(a) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
 };
 
 } // namespace dynet

--- a/dynet/nodes-const.h
+++ b/dynet/nodes-const.h
@@ -10,6 +10,7 @@ namespace dynet {
 struct Constant : public Node {
   explicit Constant(const Dim& d, float val=0.f) : dim(d), value(val) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
   Dim dim;
   float value;
 };

--- a/dynet/nodes-moments.h
+++ b/dynet/nodes-moments.h
@@ -13,13 +13,6 @@ struct Average : public Node {
   virtual bool supports_multibatch() const override { return true; }
 };
 
-// with a single argument x \in R^{n x m}
-// y_i = \sum_j x_i,j / m
-struct AverageColumns : public Node {
-  template <typename T> explicit AverageColumns(const T& a) : Node(a) {}
-  DYNET_NODE_DEFINE_DEV_IMPL()
-};
-
 // y = \sum_i,j,... x[i,j,...]
 struct MomentElements : public Node {
   template <typename T> explicit MomentElements(const T& a, unsigned o) : Node(a), order(o) {}

--- a/dynet/nodes-random.h
+++ b/dynet/nodes-random.h
@@ -19,6 +19,7 @@ struct GaussianNoise : public Node {
 struct RandomNormal : public Node {
   explicit RandomNormal(const Dim& d, float m=0.f, float s=1.f) : dim(d), mean(m), stddev(s) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
   Dim dim;
   float mean, stddev;
 };
@@ -29,6 +30,7 @@ struct RandomBernoulli : public Node {
     DYNET_ASSERT(a.size() == 0, "RandomBernoulli doesn't accept nodes as input");
   }
   DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
   Dim dim;
   real p;
   real scale;
@@ -40,16 +42,18 @@ struct RandomUniform : public Node {
     DYNET_ASSERT(a.size() == 0, "RandomUniform doesn't accept nodes as input");
   }
   DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
   Dim dim;
   real left, right;
 };
 
-// draw a random real from Uniform(left, right)
+// draw a random real from Gubmel(mu, beta)
 struct RandomGumbel : public Node {
   explicit RandomGumbel(const std::initializer_list<VariableIndex>& a, const Dim& d, real mu, real beta) : dim(d), mu(mu), beta(beta) {
     DYNET_ASSERT(a.size() == 0, "RandomGumbel doesn't accept nodes as input");
   }
   DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
   Dim dim;
   real mu, beta;
 };

--- a/dynet/nodes-select.cc
+++ b/dynet/nodes-select.cc
@@ -34,7 +34,7 @@ void SelectRows::forward_dev_impl(const MyDevice & dev, const vector<const Tenso
   for (unsigned i = 0; i < rm.size(); ++i) {
     DYNET_ARG_CHECK(rm[i] < xs[0]->d.rows(),
                             "Out-of-bounds index " << rm[i] << " in SelectRows over expression of dimensions " << xs[0]->d);
-    t<4>(fx).chip<0>(i).device(*dev.edevice) = t<4>(*xs[0]).chip<0>(rm[i]);
+    tb<4>(fx).chip<0>(i).device(*dev.edevice) = tb<4>(*xs[0]).chip<0>(rm[i]);
   }
 }
 
@@ -48,7 +48,7 @@ void SelectRows::backward_dev_impl(const MyDevice & dev,
   DYNET_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectRows::backward");
   auto& rm = *prows;
   for (unsigned i = 0; i < rm.size(); ++i)
-    t<4>(dEdxi).chip<0>(rm[i]).device(*dev.edevice) += t<4>(dEdf).chip<0>(i);
+    tb<4>(dEdxi).chip<0>(rm[i]).device(*dev.edevice) += tb<4>(dEdf).chip<0>(i);
 }
 DYNET_NODE_INST_DEV_IMPL(SelectRows)
 
@@ -79,7 +79,7 @@ void SelectCols::forward_dev_impl(const MyDevice & dev, const vector<const Tenso
   for (unsigned i = 0; i < rm.size(); ++i) {
     DYNET_ARG_CHECK(rm[i] < xs[0]->d.cols(),
                             "Out-of-bounds index " << rm[i] << " in SelectCols over expression of dimensions " << xs[0]->d);
-    t<2>(fx).chip<1>(i).device(*dev.edevice) = t<2>(*xs[0]).chip<1>(rm[i]);
+    tb<2>(fx).chip<1>(i).device(*dev.edevice) = tb<2>(*xs[0]).chip<1>(rm[i]);
   }
 }
 
@@ -93,7 +93,7 @@ void SelectCols::backward_dev_impl(const MyDevice & dev,
   DYNET_ARG_CHECK(xs.size() == 1, "Failed dimension check in SelectCols::backward");
   auto& rm = *pcols;
   for (unsigned i = 0; i < rm.size(); ++i)
-    t<2>(dEdxi).chip<1>(rm[i]).device(*dev.edevice) += t<2>(dEdf).chip<1>(i);
+    tb<2>(dEdxi).chip<1>(rm[i]).device(*dev.edevice) += tb<2>(dEdf).chip<1>(i);
 }
 DYNET_NODE_INST_DEV_IMPL(SelectCols)
 

--- a/dynet/nodes-select.h
+++ b/dynet/nodes-select.h
@@ -12,6 +12,7 @@ struct SelectRows : public Node {
   explicit SelectRows(const std::initializer_list<VariableIndex>& a, const std::vector<unsigned>& r) : Node(a), rows(r), prows(&rows) {}
   explicit SelectRows(const std::initializer_list<VariableIndex>& a, const std::vector<unsigned>* pr) : Node(a), prows(pr) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
   std::vector<unsigned> rows;
   const std::vector<unsigned>* prows;
 };
@@ -22,6 +23,7 @@ struct SelectCols : public Node {
   explicit SelectCols(const std::initializer_list<VariableIndex>& a, const std::vector<unsigned>& c) : Node(a), cols(c), pcols(&cols) {}
   explicit SelectCols(const std::initializer_list<VariableIndex>& a, const std::vector<unsigned>* pc) : Node(a), pcols(pc) {}
   DYNET_NODE_DEFINE_DEV_IMPL()
+  virtual bool supports_multibatch() const override { return true; }
   std::vector<unsigned> cols;
   const std::vector<unsigned>* pcols;
 };


### PR DESCRIPTION
This PR disables implicit batching done by looping through each of the inputs in a tensor, instead throwing an error when nodes that don't support batched inputs are fed a batched input. The reason is twofold:

1. as noted in https://github.com/clab/dynet/issues/1490 this can be a source of hard-to-find bugs
2. this is only used by a small minority of infrequently-used nodes. This PR can be an impetus for us to create batched versions of the remaining nodes.

As a workaround for the remaining nodes, it is possible to do the following, where `my_op()` is the node that doesn't support batching:

    val = dy.concatenate_to_batch([dy.my_op(dy.pick_batch_elem(x,i)) for i in range(x.dim[1])])