### PR TITLE
cmake option for custom optimization level

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,8 +81,14 @@ if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W1 /MP")   # -Wall produces 20k warnings. Enable parallel compilation
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fno-finite-math-only -Wall -Wno-missing-braces -std=c++11 -g")
+
+  if (NOT RELEASE_OPT_LEVEL)
+    set(RELEASE_OPT_LEVEL "fast")
+  endif()
+  message("-- Optimization level: ${RELEASE_OPT_LEVEL}")
+
   set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-omit-frame-pointer")
-  set(CMAKE_CXX_FLAGS_RELEASE "-funroll-loops -Ofast -march=native")
+  set(CMAKE_CXX_FLAGS_RELEASE "-funroll-loops -O${RELEASE_OPT_LEVEL} -march=native")
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -85,6 +85,24 @@ which will train a multilayer perceptron to predict the xor function.
 
 If any process here fails, please see :ref:`debugging-asking` for help.
 
+By default, Dynet will be compiled with the ``-Ofast`` optimization
+level which enables the ``-ffast-math`` option.  In most cases,
+this is be acceptable. However, it may impact mathematical computation outside
+the core of dynet, see `this issue <https://github.com/clab/dynet/issues/1433>`__.
+the ``RELEASE_OPT_LEVEL`` can be used to change the optimization level:
+
+::
+
+     cmake .. -DRELEASE_OPT_LEVEL=3 -DEIGEN3_INCLUDE_DIR=/path/to/eigen
+
+The ``CXXFLAGS`` environment variable can be used for more specific tunning,
+for example
+
+::
+    cmake -E env CXXFLAGS="-fno-math-errno" cmake .. -DRELEASE_OPT_LEVEL=3 -DEIGEN3_INCLUDE_DIR=/path/to/eigen
+
+Note that ``CXXFLAGS`` is only checked during the `first configuration <https://cmake.org/cmake/help/latest/envvar/CXXFLAGS.html>`__.
+
 Compiling/linking external programs
 -----------------------------------
 


### PR DESCRIPTION
Hi,

this pull request addresses issue #1433 .
I also documented this option, which I reproduce here:
```
By default, Dynet will be compiled with the ``-Ofast`` optimization
level which enables the ``-ffast-math`` option.  In most cases,
this is be acceptable. However, it may impact mathematical computation outside
the core of dynet, see `this issue <https://github.com/clab/dynet/issues/1433>`__.
the ``RELEASE_OPT_LEVEL`` can be used to change the optimization level:

::

     cmake .. -DRELEASE_OPT_LEVEL=3 -DEIGEN3_INCLUDE_DIR=/path/to/eigen

The ``CXXFLAGS`` environment variable can be used for more specific tunning,
for example

::
    cmake -E env CXXFLAGS="-fno-math-errno" cmake .. -DRELEASE_OPT_LEVEL=3 -DEIGEN3_INCLUDE_DIR=/path/to/eigen

Note that ``CXXFLAGS`` is only checked during the `first configuration <https://cmake.org/cmake/help/latest/envvar/CXXFLAGS.html>`__.
```