### PR TITLE
add note about dedault gradient clipping behavior

### DIFF
--- a/python/_dynet.pyx
+++ b/python/_dynet.pyx
@@ -6249,6 +6249,7 @@ cdef class Trainer:
     cpdef set_clip_threshold(self,float thr):
         """Set clipping thershold
         
+        Gradients are clipped to 5 by default.
         To deactivate clipping, set the threshold to be <=0
         
         Args:


### PR DESCRIPTION
The default behavior of clipping gradients to 5 (which seems to hold in Python optimizers; I tried a few) [isn't obvious](https://twitter.com/haldaume3/status/925823753405325316); making this documented here may lead to improved reproducibility. 