### PR TITLE
Update install.rst

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -79,7 +79,7 @@ To see that things have built properly, you can run
 
 ::
 
-    ./examples/train_xor
+    ./examples/xor
 
 which will train a multilayer perceptron to predict the xor function.
 


### PR DESCRIPTION
Change ./examples/train_xor to ./examples/xor.
Running ./examples/train_xor produces an error "No such file or directory"