### PR TITLE
Make sure shared library looks like one

### DIFF
--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -11,7 +11,7 @@
 %pragma(java) jniclasscode=%{
     static {
         try {
-            File tempFile = File.createTempFile("dynet", "");
+            File tempFile = File.createTempFile("dynet", ".dll");
             String libname = System.mapLibraryName("dynet_swig");
 
             if (libname.endsWith("dylib")) {


### PR DESCRIPTION
Windows (10) will not do a System.load on a file that is not named like a loadable file.