### PR TITLE
Prediction is added to train_xor.cc

### DIFF
--- a/examples/xor/train_xor.cc
+++ b/examples/xor/train_xor.cc
@@ -65,6 +65,24 @@ int main(int argc, char** argv) {
     cerr << "E = " << loss << endl;
   }
 
+  // Check whether the ComputationGraph learns correctly or not.
+  x_values[0] = -1;
+  x_values[1] = -1;
+  cg.forward(loss_expr);
+  std::cout << "[-1,-1] -1 : " << as_scalar(y_pred.value()) << std::endl;
+  x_values[0] = -1;
+  x_values[1] =  1;
+  cg.forward(loss_expr);
+  std::cout << "[-1, 1]  1 : " << as_scalar(y_pred.value()) << std::endl;
+  x_values[0] =  1;
+  x_values[1] = -1;
+  cg.forward(loss_expr);
+  std::cout << "[ 1,-1]  1 : " << as_scalar(y_pred.value()) << std::endl;
+  x_values[0] =  1;
+  x_values[1] =  1;
+  cg.forward(loss_expr);
+  std::cout << "[ 1, 1] -1 : " << as_scalar(y_pred.value()) << std::endl;
+
   // Output the model and parameter objects to a file.
   TextFileSaver saver("xor.model");
   saver.save(m);

--- a/examples/xor/train_xor.cc
+++ b/examples/xor/train_xor.cc
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
     cerr << "E = " << loss << endl;
   }
 
-  // Check whether the ComputationGraph learns correctly or not.
+  // Check whether our ComputationGraph learns correctly or not.
   x_values[0] = -1;
   x_values[1] = -1;
   cg.forward(loss_expr);


### PR DESCRIPTION
Hello, developer of dynet.
Thanks for great library.

Python XOR example has prediction function.
But C++ one doesn't have that function.

So, I added it in order to show how to predict using learned ComputationGraph.

**Concerns**
A file name is `train_xor` although it will have prediction function.
Should I make `predict_xor.cc` file instead of this pull request?