### PR TITLE
Small fix to the C++ installation instructions on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can install dynet for C++ with the following commands
     # Compile using 2 processes
     make -j 2
     # Test with an example
-    ./examples/train_xor
+    ./examples/xor
 
 For more details refer to the [documentation](http://dynet.readthedocs.io/en/latest/install.html#building)
 


### PR DESCRIPTION
It looks like the name of the executable specified in the `CMakeLists.txt` is `xor`.
https://github.com/clab/dynet/blob/a581587cddd25c295f5b23339bb537d32dca8ee1/examples/CMakeLists.txt#L43

Here is the macro definition.
https://github.com/clab/dynet/blob/a581587cddd25c295f5b23339bb537d32dca8ee1/examples/CMakeLists.txt#L3-L11