### PR TITLE
Make sure ParameterStorageBase also uses shared pointer for Java interface

### DIFF
--- a/contrib/swig/dynet_swig.i
+++ b/contrib/swig/dynet_swig.i
@@ -105,6 +105,7 @@ VECTORCONSTRUCTOR(std::vector<dynet::Parameter>, ParameterVector, ParameterVecto
 %include "cpointer.i"
 %include <std_shared_ptr.i>
 
+%shared_ptr(dynet::ParameterStorageBase)
 %shared_ptr(dynet::ParameterStorage)
 %shared_ptr(dynet::LookupParameterStorage)
 


### PR DESCRIPTION
Its subclasses are marked in dynet_swig.i as using shared pointers:

```
%shared_ptr(dynet::ParameterStorage)
%shared_ptr(dynet::LookupParameterStorage)
```
SWIG warns that the base class "is not similarly marked as a smart pointer".  The line below quiets the warning and also prevents crahes (because of double deletes?).
```
%shared_ptr(dynet::ParameterStorageBase)
```
An issue was filed previously and this will soon link to it.