### PR TITLE
Add PEP 518 build system/requirements spec (pyproject.toml)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython"]
+build-backend = "setuptools.build_meta" 


### PR DESCRIPTION
dynet depends on Cython for its build, consequently, installing dynet with pip from a source dist in an environment without Cython doesn't work (Cython is listed as a dependency but pip tries to build before installing dependencies).
This is not an issue for platforms for which wheels are available, but in the last release they only exist for Python <= 3.7.

[PEP 518](https://www.python.org/dev/peps/pep-0518/) is the solution to this exact problem: it allows specifying build dependencies and a build system (in that case setuptools) and pip is now able to use this information at install time.

This PR adds a `pyproject.toml` file with the correct dependencies and build system informations for dynet, which allows installing from a source dist (including with the `pip install git+https://github.com/clab/dynet#egg=dynet` recommended in README).