### PR TITLE
Fix serious memory leak in code using CUDNN functionality

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,15 +80,16 @@ endif()
 if(MSVC)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -W1 /MP")   # -Wall produces 20k warnings. Enable parallel compilation
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fno-finite-math-only -Wall -Wno-missing-braces -std=c++11 -g")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -fno-finite-math-only -Wall -Wno-missing-braces -std=c++11")
 
   if (NOT RELEASE_OPT_LEVEL)
     set(RELEASE_OPT_LEVEL "fast")
   endif()
   message("-- Optimization level: ${RELEASE_OPT_LEVEL}")
 
-  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -fno-omit-frame-pointer")
-  set(CMAKE_CXX_FLAGS_RELEASE "-funroll-loops -O${RELEASE_OPT_LEVEL} -march=native")
+  set(CMAKE_CXX_FLAGS_DEBUG "-pedantic -O0 -g -fno-omit-frame-pointer")
+  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-Og -g")
+  set(CMAKE_CXX_FLAGS_RELEASE "-funroll-loops -O${RELEASE_OPT_LEVEL} -march=native -DNDEBUG")
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}

--- a/dynet/devices.cc
+++ b/dynet/devices.cc
@@ -120,7 +120,12 @@ Device_GPU::Device_GPU(int my_id, const DeviceMempoolSizes & mbs,
   pools[3] = new AlignedMemoryPool("GPU scratch memory", (mbs.used[3] << 20), &gpu_mem);
 }
 
-Device_GPU::~Device_GPU() {}
+Device_GPU::~Device_GPU()
+{
+#if HAVE_CUDNN
+  CUDNN_CHECK(cudnnDestroy(cudnnHandle));
+#endif
+}
 
 void Device_GPU::reset_rng(unsigned seed) {
   CURAND_CHECK(curandCreateGenerator(&curandeng,

--- a/dynet/nodes-conv2d.cc
+++ b/dynet/nodes-conv2d.cc
@@ -118,8 +118,8 @@ void Conv2D::forward_dev_impl(const MyDevice & dev, const vector<const Tensor*>&
   AlignedMemoryPool* scratch_allocator = default_device->pools[(int)DeviceMempool::SCS];
 #ifdef __CUDACC__
 #if HAVE_CUDNN
-  if (cudnn_conv_op_ == NULL)
-    cudnn_conv_op_ = new CudnnConvOp(stride, is_valid);
+  if (!cudnn_conv_op_)
+    cudnn_conv_op_.reset(new CudnnConvOp(stride, is_valid));
   cudnn_conv_op_->forward_impl(dev, xs, fx);
 #else
   throw std::runtime_error("Conv2D::forward_dev_impl not supported without CUDNN");
@@ -168,8 +168,8 @@ void Conv2D::backward_dev_impl(const MyDevice & dev,
   AlignedMemoryPool* scratch_allocator = default_device->pools[(int)DeviceMempool::SCS];
 #ifdef __CUDACC__
 #if HAVE_CUDNN
-  if (cudnn_conv_op_ == NULL)
-    cudnn_conv_op_ = new CudnnConvOp(stride, is_valid);
+  if (!cudnn_conv_op_)
+    cudnn_conv_op_.reset(new CudnnConvOp(stride, is_valid));
   cudnn_conv_op_->backward_impl(dev, xs, fx, dEdf, i, dEdxi);
 #else
   throw std::runtime_error("Conv2D::backward_dev_impl not supported without CUDNN");

--- a/dynet/nodes-conv2d.h
+++ b/dynet/nodes-conv2d.h
@@ -6,6 +6,7 @@
 
 #if HAVE_CUDNN
 #include "dynet/cudnn-ops.h"
+#include <memory>
 #endif
 
 namespace dynet {
@@ -37,7 +38,7 @@ struct Conv2D: public Node {
 
  private:
 #if HAVE_CUDNN
-  mutable CudnnConvOp* cudnn_conv_op_ = NULL;
+  mutable std::unique_ptr<CudnnConvOp> cudnn_conv_op_;
 #endif
 };
 

--- a/dynet/nodes-maxpooling2d.cc
+++ b/dynet/nodes-maxpooling2d.cc
@@ -69,8 +69,8 @@ void MaxPooling2D::forward_dev_impl(const MyDevice & dev, const vector<const Ten
   AlignedMemoryPool* scratch_allocator = default_device->pools[(int)DeviceMempool::SCS];
 #ifdef __CUDACC__
 #if HAVE_CUDNN
-  if (cudnn_maxpool_op_ == NULL)
-    cudnn_maxpool_op_ = new CudnnMaxPooling2DOp(ksize, stride, is_valid);
+  if (!cudnn_maxpool_op_)
+    cudnn_maxpool_op_.reset(new CudnnMaxPooling2DOp(ksize, stride, is_valid));
   cudnn_maxpool_op_->forward_impl(dev, xs, fx);
 #else
   throw std::runtime_error("MaxPooling2D::forward_dev_impl not supported without CUDNN");
@@ -106,8 +106,8 @@ void MaxPooling2D::backward_dev_impl(const MyDevice & dev,
   DYNET_ASSERT(i == 0, "Failed dimension check in MaxPooling2D::backward: i must be 0");
 #ifdef __CUDACC__
 #if HAVE_CUDNN
-  if (cudnn_maxpool_op_ == NULL)
-    cudnn_maxpool_op_ = new CudnnMaxPooling2DOp(ksize, stride, is_valid);
+  if (!cudnn_maxpool_op_)
+    cudnn_maxpool_op_.reset(new CudnnMaxPooling2DOp(ksize, stride, is_valid));
   cudnn_maxpool_op_->backward_impl(dev, xs, fx, dEdf, i, dEdxi);
 #else
   throw std::runtime_error("MaxPooling2D::backward_dev_impl not supported without CUDNN");

--- a/dynet/nodes-maxpooling2d.h
+++ b/dynet/nodes-maxpooling2d.h
@@ -6,6 +6,7 @@
 
 #if HAVE_CUDNN
 #include "dynet/cudnn-ops.h"
+#include <memory>
 #endif
 
 namespace dynet {
@@ -30,7 +31,7 @@ struct MaxPooling2D: public Node {
 
  private:
 #if HAVE_CUDNN
-  mutable CudnnMaxPooling2DOp* cudnn_maxpool_op_ = NULL;
+  mutable std::unique_ptr<CudnnMaxPooling2DOp> cudnn_maxpool_op_;
 #endif
 };
 


### PR DESCRIPTION
When running convolutions with CUDNN then I lost about 1GB memory per hour.
I did the following to first get dynet to work with CUDA 10.2 and CUDNN 8.0.1 and then fix the main problem:

- CMakeLists.txt: Added RELWITHDEBINFO build target needed to get some performance even when debugging. Better options for RELEASE (-g removed) and DEBUG (-Og -g).
- cudnn-ops.cu: if CUDNN version is >= 8 then replace removed CUDNN API functions by new ones introduced in V7.
- devices.cc, nodes-conv2d.*, nodes-maxpooling2d.*: Ensure allocated memory is freed on destruction of objects.
