### PR TITLE
Free memory for the correct variable

### DIFF
--- a/dynet/model.cc
+++ b/dynet/model.cc
@@ -272,7 +272,7 @@ void ParameterCollectionStorage::project_weights(float radius) {
   auto scratch_size = all_params.size() * sizeof(float);
   if (project_scratch == nullptr || sizeof(project_scratch) < scratch_size) {
     if (project_scratch != nullptr) {
-      default_device->mem->free(gradient_norm_scratch);
+      default_device->mem->free(project_scratch);
     }
     project_scratch = (float *) default_device->mem->malloc(scratch_size);
   }


### PR DESCRIPTION
Otherwise, memory of project_scratch is leaking and gradient_norm_scratch use will cause problems.
