### PR TITLE
Protect Scala Expression from being deleted via its ExpressionVector

### DIFF
--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Vector.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Vector.scala
@@ -93,7 +93,8 @@ class ExpressionVector private[dynet] (
     vector.add(v.expr)
   }
 
-  override def apply(idx: Int): Expression = new Expression(vector.get(idx))
+  // The vector must be kept around in order to index into it.
+  override def apply(idx: Int): Expression = new Expression(vector.get(idx), this)
   override def length: Int = vector.size.toInt
   override def update(idx: Int, elem: Expression): Unit = {
     elem.ensureFresh()


### PR DESCRIPTION
If an ExpressionVector is garbage collected, the C++ memory for the vector and its expressions will be freed in C++.  If any Scala Expressions that were derived from it with apply(n) are still alive, their C++ counterparts will have disappeared out from under them.  The Scala Expression, when used, will try to access its C++ counterpart and cause the C++ code to crash and take down the JVM with it.