### PR TITLE
Fix 'boost::interprocess::interprocess_exception' Permission denied error in multi-user multi-process setting.

### DIFF
--- a/dynet/mp.cc
+++ b/dynet/mp.cc
@@ -1,5 +1,6 @@
 #if !_WINDOWS
 #include "mp.h"
+#include "unistd.h"
 #include "dynet/except.h"
 using namespace std;
 using namespace boost::interprocess;
@@ -15,7 +16,7 @@ namespace dynet {
 
     std::string generate_queue_name() {
       std::ostringstream ss;
-      ss << "dynet_mp_work_queue";
+      ss << "dynet_mp_work_queue_" << getpid() << "_";
       ss << rand();
       return ss.str();
     }


### PR DESCRIPTION
The following error is often thrown out when multiple users run multi-process training on a machine (across the time), which happens a lot in a cluster environment.

    terminate called after throwing an instance of 'boost::interprocess::interprocess_exception'
       what():  Permission denied

What happened is: User A run a multi-process training. A queue file with name "dynet_mp_work_queue" is created with each multi-process training, and is often not deleted properly due to manual termination (like CTRL+C). Now User B tries to run a multi-process training on the same machine, and could not write/delete the queue file. So the above error is thrown.

Fix: Include process id in the queue file name, so different trainings by different users do not step on each other's toes.